### PR TITLE
MockRepositorySpecification improvements

### DIFF
--- a/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
+++ b/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
@@ -15,14 +15,13 @@ namespace ReactiveDomain.Testing
         public MockRepositorySpecification()
         {
             var streamNameBuilder = new PrefixedCamelCaseStreamNameBuilder("UnitTest");
-            var mockStreamStore = new MockStreamStoreConnection("Test");
-            StreamStoreConnection = mockStreamStore;
-            mockStreamStore.Connect();
+            StreamStoreConnection = new MockStreamStoreConnection("Test");
+            StreamStoreConnection.Connect();
             var eventSerializer = new JsonMessageSerializer();
-            MockRepository = new StreamStoreRepository(streamNameBuilder, mockStreamStore, eventSerializer);
+            MockRepository = new StreamStoreRepository(streamNameBuilder, StreamStoreConnection, eventSerializer);
 
             var connectorBus = new InMemoryBus("connector");
-            mockStreamStore.SubscribeToAll(evt => connectorBus.Publish((IMessage)eventSerializer.Deserialize(evt)));
+            StreamStoreConnection.SubscribeToAll(evt => connectorBus.Publish((IMessage)eventSerializer.Deserialize(evt)));
             RepositoryEvents = new TestQueue(connectorBus,new []{typeof(Event) });
         }
 

--- a/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
+++ b/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
@@ -10,11 +10,13 @@ namespace ReactiveDomain.Testing
         protected readonly IRepository MockRepository;
         public IRepository Repository => MockRepository;
         public readonly TestQueue RepositoryEvents;
+        public IStreamStoreConnection StreamStoreConnection { get; }
 
         public MockRepositorySpecification()
         {
             var streamNameBuilder = new PrefixedCamelCaseStreamNameBuilder("UnitTest");
             var mockStreamStore = new MockStreamStoreConnection("Test");
+            StreamStoreConnection = mockStreamStore;
             mockStreamStore.Connect();
             var eventSerializer = new JsonMessageSerializer();
             MockRepository = new StreamStoreRepository(streamNameBuilder, mockStreamStore, eventSerializer);

--- a/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
+++ b/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
@@ -10,19 +10,21 @@ namespace ReactiveDomain.Testing
         protected readonly IRepository MockRepository;
         public IRepository Repository => MockRepository;
         public readonly TestQueue RepositoryEvents;
+        public IStreamNameBuilder StreamNameBuilder { get; }
         public IStreamStoreConnection StreamStoreConnection { get; }
+        public IEventSerializer EventSerializer { get; }
 
         public MockRepositorySpecification()
         {
-            var streamNameBuilder = new PrefixedCamelCaseStreamNameBuilder();
+            StreamNameBuilder = new PrefixedCamelCaseStreamNameBuilder();
             StreamStoreConnection = new MockStreamStoreConnection("Test");
             StreamStoreConnection.Connect();
-            var eventSerializer = new JsonMessageSerializer();
-            MockRepository = new StreamStoreRepository(streamNameBuilder, StreamStoreConnection, eventSerializer);
+            EventSerializer = new JsonMessageSerializer();
+            MockRepository = new StreamStoreRepository(StreamNameBuilder, StreamStoreConnection, EventSerializer);
 
             var connectorBus = new InMemoryBus("connector");
-            StreamStoreConnection.SubscribeToAll(evt => connectorBus.Publish((IMessage)eventSerializer.Deserialize(evt)));
-            RepositoryEvents = new TestQueue(connectorBus,new []{typeof(Event) });
+            StreamStoreConnection.SubscribeToAll(evt => connectorBus.Publish((IMessage)EventSerializer.Deserialize(evt)));
+            RepositoryEvents = new TestQueue(connectorBus, new[] { typeof(Event) });
         }
 
         public virtual void ClearQueues()

--- a/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
+++ b/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
@@ -14,7 +14,7 @@ namespace ReactiveDomain.Testing
 
         public MockRepositorySpecification()
         {
-            var streamNameBuilder = new PrefixedCamelCaseStreamNameBuilder("UnitTest");
+            var streamNameBuilder = new PrefixedCamelCaseStreamNameBuilder();
             StreamStoreConnection = new MockStreamStoreConnection("Test");
             StreamStoreConnection.Connect();
             var eventSerializer = new JsonMessageSerializer();

--- a/src/ReactiveDomain.Testing/Specifications/MockRepositoryTests.cs
+++ b/src/ReactiveDomain.Testing/Specifications/MockRepositoryTests.cs
@@ -6,15 +6,14 @@ using Xunit;
 namespace ReactiveDomain.Testing
 {
     public sealed class MockRepositoryTests
-        : IClassFixture<MockRepositorySpecification>,
-          IDisposable,
+        : IDisposable,
           IHandleCommand<TestCommands.Command1>
     {
         private readonly MockRepositorySpecification _fixture;
 
-        public MockRepositoryTests(MockRepositorySpecification fixture)
+        public MockRepositoryTests()
         {
-            _fixture = fixture;
+            _fixture = new MockRepositorySpecification();
             _fixture.Dispatcher.Subscribe<TestCommands.Command1>(this);
         }
 
@@ -22,8 +21,6 @@ namespace ReactiveDomain.Testing
         {
             _fixture.Dispatcher.Unsubscribe<TestCommands.Command1>(this);
         }
-
-
 
         [Fact]
         public void can_get_repository_events()


### PR DESCRIPTION
- Expose an `IStreamStoreConnection`, an `IStreamNameBuilder`, and an `IEventSerializer` from `MockRepositorySpecification` to allow read models and other clients to connect to the mock StreamStore when using this test fixture and interact with it seamlessly.
- Fix a bug (unnecessary prefix in the stream name builder) that interfered with GetById.
- Use a new instance of the MockRepositorySpecification for each test in `MockRepositoryTests`.