### PR TITLE
Assembly update build check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ script:
   - dotnet test ./src/ReactiveDomain.PrivateLedger.Tests/ReactiveDomain.PrivateLedger.Tests.csproj
   - dotnet test ./src/ReactiveDomain.Transport.Tests/ReactiveDomain.Transport.Tests.csproj
 
-# after_success:
-#  - powershell -executionpolicy unrestricted -File ./tools/createNuget.ps1
+after_success:
+  - powershell -executionpolicy unrestricted -File ./tools/CreateNuget.ps1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,35 @@
 sudo: required
 language: csharp
-
+os: windows
 mono: none
-dotnet: 2.0.0
 
+branches:
+  only:
+    - master
+    - /.*/
+
+addons:
+  apt:
+    packages:
+      - powershell
+
+before_script:
+  - powershell -executionpolicy unrestricted -File ./tools/CheckAssemblyVersion.ps1
+  
 script: 
+  - echo $TRAVIS_BRANCH
+  - echo $TRAVIS_BUILD_DIR
+  - echo $TRAVIS_PULL_REQUEST
+  - echo $TRAVIS_PULL_REQUEST_BRANCH
+  - echo $TRAVIS_EVENT_TYPE
+  - echo $STABLE
   - dotnet restore ./src/ReactiveDomain.sln
-  - dotnet msbuild ./src/ReactiveDomain.sln
+  - dotnet msbuild ./src/ReactiveDomain.sln -p:Configuration=Debug
+  - dotnet msbuild ./src/ReactiveDomain.sln -p:Configuration=Release
   - dotnet test ./src/ReactiveDomain.Messaging.Tests/ReactiveDomain.Messaging.Tests.csproj
   - dotnet test ./src/ReactiveDomain.Foundation.Tests/ReactiveDomain.Foundation.Tests.csproj  
   - dotnet test ./src/ReactiveDomain.PrivateLedger.Tests/ReactiveDomain.PrivateLedger.Tests.csproj
   - dotnet test ./src/ReactiveDomain.Transport.Tests/ReactiveDomain.Transport.Tests.csproj
+
+# after_success:
+#  - powershell -executionpolicy unrestricted -File ./tools/createNuget.ps1

--- a/src/build.props
+++ b/src/build.props
@@ -22,8 +22,8 @@
         <Company>PerkinElmer,Linedata</Company>
         <Copyright>Copyright © 2014-2019 PerkinElmer, Linedata Inc.</Copyright>
         <Description />
-        <AssemblyVersion>0.8.21.1</AssemblyVersion>
-        <FileVersion>0.8.21.1</FileVersion>
+        <AssemblyVersion>0.8.21.2</AssemblyVersion>
+        <FileVersion>0.8.21.2</FileVersion>
         <NeutralLanguage />
         <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
         <DebugSymbols>true</DebugSymbols>

--- a/src/build.props
+++ b/src/build.props
@@ -22,8 +22,8 @@
         <Company>PerkinElmer,Linedata</Company>
         <Copyright>Copyright © 2014-2019 PerkinElmer, Linedata Inc.</Copyright>
         <Description />
-        <AssemblyVersion>0.7.21.1</AssemblyVersion>
-        <FileVersion>0.7.21.1</FileVersion>
+        <AssemblyVersion>0.8.21.2</AssemblyVersion>
+        <FileVersion>0.8.21.2</FileVersion>
         <NeutralLanguage />
         <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
         <DebugSymbols>true</DebugSymbols>

--- a/src/build.props
+++ b/src/build.props
@@ -22,8 +22,8 @@
         <Company>PerkinElmer,Linedata</Company>
         <Copyright>Copyright © 2014-2019 PerkinElmer, Linedata Inc.</Copyright>
         <Description />
-        <AssemblyVersion>0.8.21.0</AssemblyVersion>
-        <FileVersion>0.8.21.0</FileVersion>
+        <AssemblyVersion>0.8.21.1</AssemblyVersion>
+        <FileVersion>0.8.21.1</FileVersion>
         <NeutralLanguage />
         <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
         <DebugSymbols>true</DebugSymbols>

--- a/src/build.props
+++ b/src/build.props
@@ -22,8 +22,8 @@
         <Company>PerkinElmer,Linedata</Company>
         <Copyright>Copyright © 2014-2019 PerkinElmer, Linedata Inc.</Copyright>
         <Description />
-        <AssemblyVersion>0.8.21.2</AssemblyVersion>
-        <FileVersion>0.8.21.2</FileVersion>
+        <AssemblyVersion>0.8.21.0</AssemblyVersion>
+        <FileVersion>0.8.21.0</FileVersion>
         <NeutralLanguage />
         <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
         <DebugSymbols>true</DebugSymbols>

--- a/src/build.props
+++ b/src/build.props
@@ -22,8 +22,8 @@
         <Company>PerkinElmer,Linedata</Company>
         <Copyright>Copyright © 2014-2019 PerkinElmer, Linedata Inc.</Copyright>
         <Description />
-        <AssemblyVersion>0.8.21.0</AssemblyVersion>
-        <FileVersion>0.8.21.0</FileVersion>
+        <AssemblyVersion>0.7.21.1</AssemblyVersion>
+        <FileVersion>0.7.21.1</FileVersion>
         <NeutralLanguage />
         <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
         <DebugSymbols>true</DebugSymbols>

--- a/tools/CheckAssemblyVersion.ps1
+++ b/tools/CheckAssemblyVersion.ps1
@@ -10,7 +10,7 @@ $wget = $PSScriptRoot + "\..\tools\wget.exe"
 $tempDir = $env:TEMP
 $masterbuildProps = $tempDir + "\build.props"
 
-# Master version is always used no need to check on master branch builds
+# Master branch's assembly version is always used no need to check on master branch builds
 if ($branch -eq "master")  
 {
   Write-Host ("Master branch. Skipping assembly check")   

--- a/tools/CheckAssemblyVersion.ps1
+++ b/tools/CheckAssemblyVersion.ps1
@@ -1,0 +1,74 @@
+# CheckAssemblyVersion.ps1
+#
+# This script will check the build.props file to get current assembly version on master branch
+# It will then compare to the assembly version of the local branch
+# If they are the same this script will exit with exitcode 2 therefore failing the travis build
+#
+
+$branch = $env:TRAVIS_BRANCH
+$wget = $PSScriptRoot + "\..\tools\wget.exe"
+$tempDir = $env:TEMP
+$masterbuildProps = $tempDir + "\build.props"
+
+# Master version is always used no need to check on master branch builds
+if ($branch -eq "master")  
+{
+  Write-Host ("Master branch. Skipping assembly check")   
+  Exit
+}
+
+# Echo the location of script for debug purposes
+Write-Host ("Powershell script location is " + $PSScriptRoot)
+
+if (Test-Path $masterbuildProps) 
+{
+  Remove-Item $masterbuildProps
+}
+
+# Clone just the build.props from master and get the current assembly version
+& $wget https://raw.githubusercontent.com/ReactiveDomain/reactive-domain/master/src/build.props -P $tempDir
+
+# Get the assembly and file version from build.props on the master branch
+$masterProps = [xml] (get-content $masterbuildProps -Encoding UTF8)
+$masterAssemblyVersionNode = $masterProps.SelectSingleNode("//Project/PropertyGroup/AssemblyVersion")
+
+Write-Host ("Master branch Assembly Version is " + $masterAssemblyVersionNode.InnerText )
+
+$masterMajor = $masterAssemblyVersionNode.InnerText.Split('.')[0]
+$masterMinor = $masterAssemblyVersionNode.InnerText.Split('.')[1]
+$masterBuild = $masterAssemblyVersionNode.InnerText.Split('.')[2]
+$masterRevision = $masterAssemblyVersionNode.InnerText.Split('.')[3]
+
+
+# Get the assemnbly and file version from build.props on current branch
+$buildProps = $PSScriptRoot + "\..\src\build.props"
+$props = [xml] (get-content $buildProps -Encoding UTF8)
+$assemblyVersionNode = $props.SelectSingleNode("//Project/PropertyGroup/AssemblyVersion")
+$fileVersionNode = $props.SelectSingleNode("//Project/PropertyGroup/FileVersion")
+
+Write-Host ("Local Assembly Version node is " + $assemblyVersionNode.InnerText )
+
+$major = $assemblyVersionNode.InnerText.Split('.')[0]
+$minor = $assemblyVersionNode.InnerText.Split('.')[1]
+$build = $assemblyVersionNode.InnerText.Split('.')[2]
+$revision = $assemblyVersionNode.InnerText.Split('.')[3]
+
+
+# If any of the version numbers are different from the master version then we are good and can exit successfully
+if (($masterMajor -ne $major) -or ($masterMinor -ne $minor) -or ($masterBuild -ne $build) -or ($masterRevision -ne $revision))  
+{
+  Write-Host ("Assembly version already updated. Exiting script...")   
+  Exit
+}
+
+
+# If version has not been updated log it and exit with resturn code 2. This will cause build to fail in Travis
+# The write host stuff below will appear in the Travis console output
+Write-Host ("*******************************************************************************************************************") 
+Write-Host ("")
+Write-Host ("")
+Write-Host ("Assembly version not updated! Assembly number in build.props must be incremented before merging into master!!!!") 
+Write-Host ("")
+Write-Host ("")
+Write-Host ("*******************************************************************************************************************") 
+Exit 2

--- a/tools/CheckAssemblyVersion.ps1
+++ b/tools/CheckAssemblyVersion.ps1
@@ -61,13 +61,12 @@ if (($masterMajor -ne $major) -or ($masterMinor -ne $minor) -or ($masterBuild -n
   Exit
 }
 
-
 # If version has not been updated log it and exit with resturn code 2. This will cause build to fail in Travis
 # The write host stuff below will appear in the Travis console output
 Write-Host ("*******************************************************************************************************************") 
 Write-Host ("")
 Write-Host ("")
-Write-Host ("Assembly version not updated! Assembly number in build.props must be incremented before merging into master!!!!") 
+Write-Host ("		Assembly version not updated! Assembly number in build.props must be incremented before merging into master!!!!") 
 Write-Host ("")
 Write-Host ("")
 Write-Host ("*******************************************************************************************************************") 

--- a/tools/CheckAssemblyVersion.ps1
+++ b/tools/CheckAssemblyVersion.ps1
@@ -115,6 +115,6 @@ if (($masterMajor -eq $major) -and ($masterMinor -eq $minor) -and ($masterBuild 
     Exit 2 
 }  
 
-Write-Host ("Assembly version updated correctly. Exiting script...")   
+Write-Host ("Assembly version updated correctly. Build will proceed")   
 Exit
 

--- a/tools/CheckAssemblyVersion.ps1
+++ b/tools/CheckAssemblyVersion.ps1
@@ -40,7 +40,7 @@ $masterBuild = $masterAssemblyVersionNode.InnerText.Split('.')[2]
 $masterRevision = $masterAssemblyVersionNode.InnerText.Split('.')[3]
 
 
-# Get the assemnbly and file version from build.props on current branch
+# Get the assembly and file version from build.props on current branch
 $buildProps = $PSScriptRoot + "\..\src\build.props"
 $props = [xml] (get-content $buildProps -Encoding UTF8)
 $assemblyVersionNode = $props.SelectSingleNode("//Project/PropertyGroup/AssemblyVersion")
@@ -54,20 +54,67 @@ $build = $assemblyVersionNode.InnerText.Split('.')[2]
 $revision = $assemblyVersionNode.InnerText.Split('.')[3]
 
 
-# If any of the version numbers are different from the master version then we are good and can exit successfully
-if (($masterMajor -ne $major) -or ($masterMinor -ne $minor) -or ($masterBuild -ne $build) -or ($masterRevision -ne $revision))  
+# Verify the assembly has been incremented from the assembly version on master branch
+if ($masterMajor -gt $major)
 {
-  Write-Host ("Assembly version already updated. Exiting script...")   
-  Exit
+    Write-Host ("*******************************************************************************************************************") 
+    Write-Host ("")
+    Write-Host ("")
+    Write-Host ("		Invalid Assembly Version!!! Master version of assembly is less than version on master branch!!!") 
+    Write-Host ("")
+    Write-Host ("")
+    Write-Host ("*******************************************************************************************************************")
+    Exit 2
 }
 
-# If version has not been updated log it and exit with resturn code 2. This will cause build to fail in Travis
-# The write host stuff below will appear in the Travis console output
-Write-Host ("*******************************************************************************************************************") 
-Write-Host ("")
-Write-Host ("")
-Write-Host ("		Assembly version not updated! Assembly number in build.props must be incremented before merging into master!!!!") 
-Write-Host ("")
-Write-Host ("")
-Write-Host ("*******************************************************************************************************************") 
-Exit 2
+if (($masterMajor -eq $major) -and ($masterMinor -gt $minor))
+{
+    Write-Host ("*******************************************************************************************************************") 
+    Write-Host ("")
+    Write-Host ("")
+    Write-Host ("		Invalid Assembly Version!!! Minor version of assembly is less than version on master branch!!!") 
+    Write-Host ("")
+    Write-Host ("")
+    Write-Host ("*******************************************************************************************************************")
+    Exit 2 
+}
+
+if (($masterMajor -eq $major) -and ($masterMinor -eq $minor) -and ($masterBuild -gt $build))
+{
+    Write-Host ("*******************************************************************************************************************") 
+    Write-Host ("")
+    Write-Host ("")
+    Write-Host ("		Invalid Assembly Version!!! Build version of assembly is less than version on master branch!!!") 
+    Write-Host ("")
+    Write-Host ("")
+    Write-Host ("*******************************************************************************************************************")
+    Exit 2 
+}  
+    
+if (($masterMajor -eq $major) -and ($masterMinor -eq $minor) -and ($masterBuild -eq $build) -and ($masterRevision -gt $revision))
+{
+    Write-Host ("*******************************************************************************************************************") 
+    Write-Host ("")
+    Write-Host ("")
+    Write-Host ("		Invalid Assembly Version!!! Revision version of assembly is less than version on master branch!!!") 
+    Write-Host ("")
+    Write-Host ("")
+    Write-Host ("*******************************************************************************************************************")
+    Exit 2 
+}    
+    
+if (($masterMajor -eq $major) -and ($masterMinor -eq $minor) -and ($masterBuild -eq $build) -and ($masterRevision -eq $revision))
+{
+    Write-Host ("*******************************************************************************************************************") 
+    Write-Host ("")
+    Write-Host ("")
+    Write-Host ("		Assembly version not updated! Assembly number in build.props must be incremented before merging into master!!!!") 
+    Write-Host ("")
+    Write-Host ("")
+    Write-Host ("*******************************************************************************************************************")
+    Exit 2 
+}  
+
+Write-Host ("Assembly version updated correctly. Exiting script...")   
+Exit
+

--- a/tools/CreateNuget.ps1
+++ b/tools/CreateNuget.ps1
@@ -1,8 +1,8 @@
 # CreateNuget.ps1
 #
 # This script will get the fileversion of ReactiveDomain.Core.dll. 
-# This version number will be used to create the corresponding nuget package 
-# The nuget is then pushed to nuget.org
+# This version number will be used to create the corresponding ReactiveDomain nuget packages 
+# The ReactiveDomain nugets are then pushed to nuget.org
 # 
 # Note: If build is unstable, a beta (pre release) version of the nuget will be pushed
 #       If build is stable, a stable (release) version will be pushed

--- a/tools/CreateNuget.ps1
+++ b/tools/CreateNuget.ps1
@@ -1,0 +1,82 @@
+# CreateNuget.ps1
+#
+# This script will get the fileversion of ReactiveDomain.Core.dll. 
+# This version number will be used to create the corresponding nuget package 
+# The nuget is then pushed to nuget.org
+# 
+# Note: If build is unstable, a beta (pre release) version of the nuget will be pushed
+#       If build is stable, a stable (release) version will be pushed
+
+# branch must be master to create a nuget
+$masterString = "update-nuspec-for-builds"
+$branch = $env:TRAVIS_BRANCH
+$apikey = $env:NugetOrgApiKey
+$githubToken = $env:GithubApiToken
+
+# create and push nuget off of master branch ONLY
+if ($branch -ne $masterString)  
+{
+  Write-Host ("Not a master branch. Will not create nuget")   
+  Exit
+}
+
+# This changes when its a CI build or a manually triggered via the web UI
+# api --> means manual/stable build ;  push --> means CI/unstable build
+$buildType = $env:TRAVIS_EVENT_TYPE    
+
+
+Write-Host ("Powershell script location is " + $PSScriptRoot)
+
+$ReactiveDomainDll = $PSScriptRoot + "\..\bld\Release\net472\ReactiveDomain.Core.dll"
+$RDVersion = (Get-Item $ReactiveDomainDll).VersionInfo.FileVersion
+$ReactiveDomainNuspec = $PSScriptRoot + "\..\src\ReactiveDomain.nuspec"
+$ReactiveDomainTestingNuspec = $PSScriptRoot + "\..\src\ReactiveDomain.Testing.nuspec"
+$ReactiveDomainUINuspec = $PSScriptRoot + "\..\src\ReactiveDomain.UI.nuspec"
+$ReactiveDomainUITestingNuspec = $PSScriptRoot + "\..\src\ReactiveDomain.UI.Testing.nuspec"
+$nuget = $PSScriptRoot + "\..\src\.nuget\nuget.exe"
+
+Write-Host ("Reactive Domain version is " + $RDVersion)
+Write-Host ("Build type is " + $buildType)
+Write-Host ("ReactiveDomain nuspec file is " + $ReactiveDomainNuspec)
+Write-Host ("ReactiveDomain.Testing nuspec file is " + $ReactiveDomainTestingNuspec)
+Write-Host ("ReactiveDomain.UI nuspec file is " + $ReactiveDomainUINuspec)
+Write-Host ("ReactiveDomain.UI.Testing nuspec file is " + $ReactiveDomainUITestingNuspec)
+Write-Host ("Branch is file is " + $branch)
+
+& $nuget update -self
+
+# Set the version string:
+#     If the Travis Build type is a push then that means its a build from a push from a feature branch (nuget should be beta)
+#     If Travis Build type is api then that means the build was manually triggered and string should be stable
+$versionString = ""
+
+if ($buildType -eq "push" )
+{
+  $versionString = $RDVersion + "-beta"
+  Write-Host ("This is an unstable master build. pushing unstable nuget version: " + $versionString)
+}
+
+if ($buildType -eq "api" )
+{
+  $versionString = $RDVersion
+  Write-Host ("This is a stable master build. pushing stable nuget version: " + $versionString)
+}
+
+# Pack the nuspec files to create the .nupkg files using the set versionString
+& $nuget pack $ReactiveDomainNuspec -Version $versionString
+& $nuget pack $ReactiveDomainTestingNuspec -Version $versionString
+& $nuget pack $ReactiveDomainUINuspec -Version $versionString
+& $nuget pack $ReactiveDomainUITestingNuspec -Version $versionString
+
+
+# Push the nuget packages to nuget.org
+$ReactiveDomainNupkg = $PSScriptRoot + "\..\ReactiveDomain." + $versionString + ".nupkg"
+$ReactiveDomainTestingNupkg = $PSScriptRoot + "\..\ReactiveDomain.Testing." + $versionString + ".nupkg"
+$ReactiveDomainUINupkg = $PSScriptRoot + "\..\ReactiveDomain.UI." + $versionString + ".nupkg"
+$ReactiveDomainUITestingNupkg = $PSScriptRoot + "\..\ReactiveDomain.UI.Testing." + $versionString + ".nupkg"
+
+& $nuget push $ReactiveDomainNupkg -Source "https://api.nuget.org/v3/index.json" -ApiKey $apikey 
+& $nuget push $ReactiveDomainTestingNupkg -Source "https://api.nuget.org/v3/index.json" -ApiKey $apikey 
+& $nuget push $ReactiveDomainUINupkg -Source "https://api.nuget.org/v3/index.json" -ApiKey $apikey 
+& $nuget push $ReactiveDomainUITestingNupkg -Source "https://api.nuget.org/v3/index.json" -ApiKey $apikey 
+

--- a/tools/CreateNuget.ps1
+++ b/tools/CreateNuget.ps1
@@ -8,10 +8,9 @@
 #       If build is stable, a stable (release) version will be pushed
 
 # branch must be master to create a nuget
-$masterString = "update-nuspec-for-builds"
+$masterString = "master"
 $branch = $env:TRAVIS_BRANCH
 $apikey = $env:NugetOrgApiKey
-$githubToken = $env:GithubApiToken
 
 # create and push nuget off of master branch ONLY
 if ($branch -ne $masterString)  
@@ -45,9 +44,10 @@ Write-Host ("Branch is file is " + $branch)
 
 & $nuget update -self
 
+# *******************************************************************************************************************************
 # Set the version string:
 #     If the Travis Build type is a push then that means its a build from a push from a feature branch (nuget should be beta)
-#     If Travis Build type is api then that means the build was manually triggered and string should be stable
+#     If Travis Build type is api then that means the build was manually triggered and string should be stable (no "-beta" suffix)
 $versionString = ""
 
 if ($buildType -eq "push" )
@@ -61,15 +61,17 @@ if ($buildType -eq "api" )
   $versionString = $RDVersion
   Write-Host ("This is a stable master build. pushing stable nuget version: " + $versionString)
 }
+# *******************************************************************************************************************************
 
-# Pack the nuspec files to create the .nupkg files using the set versionString
+# Pack the nuspec files to create the .nupkg files using the set versionString  *************************************************
 & $nuget pack $ReactiveDomainNuspec -Version $versionString
 & $nuget pack $ReactiveDomainTestingNuspec -Version $versionString
 & $nuget pack $ReactiveDomainUINuspec -Version $versionString
 & $nuget pack $ReactiveDomainUITestingNuspec -Version $versionString
 
+# *******************************************************************************************************************************
 
-# Push the nuget packages to nuget.org
+# Push the nuget packages to nuget.org ******************************************************************************************
 $ReactiveDomainNupkg = $PSScriptRoot + "\..\ReactiveDomain." + $versionString + ".nupkg"
 $ReactiveDomainTestingNupkg = $PSScriptRoot + "\..\ReactiveDomain.Testing." + $versionString + ".nupkg"
 $ReactiveDomainUINupkg = $PSScriptRoot + "\..\ReactiveDomain.UI." + $versionString + ".nupkg"
@@ -80,3 +82,4 @@ $ReactiveDomainUITestingNupkg = $PSScriptRoot + "\..\ReactiveDomain.UI.Testing."
 & $nuget push $ReactiveDomainUINupkg -Source "https://api.nuget.org/v3/index.json" -ApiKey $apikey 
 & $nuget push $ReactiveDomainUITestingNupkg -Source "https://api.nuget.org/v3/index.json" -ApiKey $apikey 
 
+# *******************************************************************************************************************************

--- a/tools/CreateNuget.ps1
+++ b/tools/CreateNuget.ps1
@@ -21,8 +21,14 @@ if ($branch -ne $masterString)
 
 # This changes when its a CI build or a manually triggered via the web UI
 # api --> means manual/stable build ;  push --> means CI/unstable build
-$buildType = $env:TRAVIS_EVENT_TYPE    
+# pull_request --> CI build triggered when opening a PR (do nothing here)
+$buildType = $env:TRAVIS_EVENT_TYPE 
 
+if ($buildType -eq "pull_request")  
+{
+  Write-Host ("Pull request build. Will not create nuget")   
+  Exit
+}   
 
 Write-Host ("Powershell script location is " + $PSScriptRoot)
 


### PR DESCRIPTION
Updates for travis builds

Update yml file to:
1. call CheckAssembly powershell script
2. Restore nugets
3. Build solution (Debug and Release)
4. Run unit tests
5. call CreateNuget powershell script

Add CheckAssembly.ps1 - Checks to make sure build.props is updated from version on master branch

Add CreateNuget.ps1 - Creates beta/release nuget depending on the type of Travis build (push vs api)

Add wget.exe - Used by CheckAssembly.ps1 to clone only the build.props from master branch ( https://www.gnu.org/software/wget/ )

Note:
CheckAssembly.ps1 only runs when branch IS NOT master
CreateNuget.ps1 only runs when branch IS master