### PR TITLE
Enhance IsOrBecomes functions for use with reactive view models

### DIFF
--- a/src/ReactiveDomain.Testing/Assert.cs
+++ b/src/ReactiveDomain.Testing/Assert.cs
@@ -43,7 +43,7 @@ namespace ReactiveDomain.Testing
         /// Repeatedly evaluates the function until false is returned or the timeout expires.
         /// Will return immediatly when the condition is false.
         /// Evaluates the timeout every 10 msec until expired.
-        /// Will not yield the thread by default, if yeilding is required to resolve deadlocks set yeildThread to true.
+        /// Will not yield the thread by default, if yielding is required to resolve deadlocks set yieldThread to true.
         /// </summary>
         /// <param name="func">The function to evaluate.</param>
         /// <param name="timeout">A timeout in milliseconds. If not specified, defaults to 1000.</param>
@@ -60,7 +60,7 @@ namespace ReactiveDomain.Testing
         /// Repeatedly evaluates the function until true is returned or the timeout expires.
         /// Will return immediatly when the condition is true.
         /// Evaluates the timeout every 10 msec until expired.
-        /// Will not yield the thread by default, if yeilding is required to resolve deadlocks set yeildThread to true.
+        /// Will not yield the thread by default, if yielding is required to resolve deadlocks set yieldThread to true.
         /// </summary>
         /// <param name="func">The function to evaluate.</param>
         /// <param name="timeout">A timeout in milliseconds. If not specified, defaults to 1000.</param>

--- a/src/ReactiveDomain.Testing/Assert.cs
+++ b/src/ReactiveDomain.Testing/Assert.cs
@@ -8,12 +8,24 @@ namespace ReactiveDomain.Testing
 {
     public class AssertEx
     {
-        public static void CommandThrows<T>(Action fireAction) where T : Exception
+        /// <summary>
+        /// Verifies that an action that sends a command causes an exception of the specified type to be thrown.
+        /// </summary>
+        /// <typeparam name="T">The expected type of exception</typeparam>
+        /// <param name="sendAction">An <see cref="Action"/> that sends a <see cref="Messaging.Command"/>.</param>
+        public static void CommandThrows<T>(Action sendAction) where T : Exception
         {
-            var exp = Assert.Throws<CommandException>(fireAction);
+            var exp = Assert.Throws<CommandException>(sendAction);
             Assert.IsType<T>(exp.InnerException);
         }
 
+        /// <summary>
+        /// Evaluates whether two array segments are equal.
+        /// </summary>
+        /// <typeparam name="T">The type of items in the sequence.</typeparam>
+        /// <param name="expectedSequence">The expected values in the sequence.</param>
+        /// <param name="buffer">The actual sequence whose values are to be checked.</param>
+        /// <param name="offset">An index offset within <paramref name="buffer"/> where the sequence is expected to begin.</param>
         public static void ArraySegmentEqual<T>(
             T[] expectedSequence, T[] buffer, int offset = 0)
         {
@@ -26,18 +38,37 @@ namespace ReactiveDomain.Testing
             }
         }
 
-        public static void IsOrBecomesFalse(Func<bool> func, int? timeout = null, string msg = null)
+        /// <summary>
+        /// Checks whether a function returns false when evaluated.
+        /// Evaluates the function every 10 msec until it returns false or the timeout is reached.
+        /// </summary>
+        /// <param name="func">The function to evaluate.</param>
+        /// <param name="timeout">A timeout in milliseconds. If not specified, defaults to 1000.</param>
+        /// <param name="msg">A message to display if the condition is not satisfied.</param>
+        /// <param name="yieldThread">If true, the thread relinquishes the remainder of its time
+        /// slice to any thread of equal priority that is ready to run.</param>
+        public static void IsOrBecomesFalse(Func<bool> func, int? timeout = null, string msg = null, bool yieldThread = false)
         {
-            IsOrBecomesTrue(() => !func(), timeout, msg);
+            IsOrBecomesTrue(() => !func(), timeout, msg, yieldThread);
         }
 
-        public static void IsOrBecomesTrue(Func<bool> func, int? timeout = null, string msg = null)
+        /// <summary>
+        /// Checks whether a function returns true when evaluated.
+        /// Evaluates the function every 10 msec until it returns true or the timeout is reached.
+        /// </summary>
+        /// <param name="func">The function to evaluate.</param>
+        /// <param name="timeout">A timeout in milliseconds. If not specified, defaults to 1000.</param>
+        /// <param name="msg">A message to display if the condition is not satisfied.</param>
+        /// <param name="yieldThread">If true, the thread relinquishes the remainder of its time
+        /// slice to any thread of equal priority that is ready to run.</param>
+        public static void IsOrBecomesTrue(Func<bool> func, int? timeout = null, string msg = null, bool yieldThread = false)
         {
+            if (yieldThread) Thread.Sleep(0);
             if (!timeout.HasValue) timeout = 1000;
-            var waitLoops = timeout/10;
+            var waitLoops = timeout / 10;
             for (int i = 0; i < waitLoops; i++) {
                 SpinWait.SpinUntil(func, 10);
-                if(func()) break;
+                if (func()) break;
                 //DispatchOtherThings();
             }
             Assert.True(func(), msg ?? "");

--- a/src/build.props
+++ b/src/build.props
@@ -22,8 +22,8 @@
         <Company>PerkinElmer,Linedata</Company>
         <Copyright>Copyright © 2014-2019 PerkinElmer Inc., Linedata Inc.</Copyright>
         <Description />
-        <AssemblyVersion>0.8.21.2</AssemblyVersion>
-        <FileVersion>0.8.21.2</FileVersion>
+        <AssemblyVersion>0.8.21.3</AssemblyVersion>
+        <FileVersion>0.8.21.3</FileVersion>
         <NeutralLanguage />
         <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
         <DebugSymbols>true</DebugSymbols>

--- a/src/build.props
+++ b/src/build.props
@@ -20,10 +20,10 @@
         <Platforms>AnyCPU</Platforms>
         <Authors>PerkinElmer,Linedata</Authors>
         <Company>PerkinElmer,Linedata</Company>
-        <Copyright>Copyright © 2014-2019 PerkinElmer, Linedata Inc.</Copyright>
+        <Copyright>Copyright © 2014-2019 PerkinElmer Inc., Linedata Inc.</Copyright>
         <Description />
-        <AssemblyVersion>0.8.21.1</AssemblyVersion>
-        <FileVersion>0.8.21.1</FileVersion>
+        <AssemblyVersion>0.8.21.2</AssemblyVersion>
+        <FileVersion>0.8.21.2</FileVersion>
         <NeutralLanguage />
         <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
         <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
The IsOrBecomes methods can now optionally yield at the beginning of execution. This allows them to work with tests of view models that include code that need to run on the "UI thread" or on the Immediate thread when running in unit tests. This option is disabled by default.