### PR TITLE
Update ReactiveUI references to 0.9.22.1

### DIFF
--- a/src/ReactiveDomain.UI.Testing/ReactiveDomain.UI.Testing.csproj
+++ b/src/ReactiveDomain.UI.Testing/ReactiveDomain.UI.Testing.csproj
@@ -16,8 +16,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="reactiveui" Version="7.4.0" Condition="'$(TargetFramework)'=='net452'" />
-    <PackageReference Include="reactiveui" Version="8.7.2" Condition="'$(TargetFramework)'=='net472'" />
-    <PackageReference Include="reactiveui" Version="8.7.2" Condition="'$(TargetFramework)'=='netstandard2.0'" />
+    <PackageReference Include="reactiveui" Version="9.22.1" Condition="'$(TargetFramework)'=='net472'" />
+    <PackageReference Include="reactiveui" Version="9.22.1" Condition="'$(TargetFramework)'=='netstandard2.0'" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/src/ReactiveDomain.UI/ReactiveDomain.UI.csproj
+++ b/src/ReactiveDomain.UI/ReactiveDomain.UI.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="reactiveui" Version="7.4.0" Condition="'$(TargetFramework)'=='net452'" />
-    <PackageReference Include="reactiveui" Version="8.7.2" Condition="'$(TargetFramework)'=='net472'" />
-    <PackageReference Include="reactiveui" Version="8.7.2" Condition="'$(TargetFramework)'=='netstandard2.0'" />
+    <PackageReference Include="reactiveui" Version="9.22.1" Condition="'$(TargetFramework)'=='net472'" />
+    <PackageReference Include="reactiveui" Version="9.22.1" Condition="'$(TargetFramework)'=='netstandard2.0'" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />

--- a/src/build.props
+++ b/src/build.props
@@ -22,8 +22,8 @@
         <Company>PerkinElmer,Linedata</Company>
         <Copyright>Copyright © 2014-2019 PerkinElmer Inc., Linedata Inc.</Copyright>
         <Description />
-        <AssemblyVersion>0.8.21.5</AssemblyVersion>
-        <FileVersion>0.8.21.5</FileVersion>
+        <AssemblyVersion>0.8.21.6</AssemblyVersion>
+        <FileVersion>0.8.21.6</FileVersion>
         <NeutralLanguage />
         <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
         <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Enables the use of DynamicData instead of ReactiveList, while still keeping ReactiveList available as deprecated to avoid breaking client applications that use it.
