### PR TITLE
Fix $All stream implementation in MockStreamStoreConnection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ addons:
 before_script:
   - powershell -executionpolicy unrestricted -File ./tools/CheckAssemblyVersion.ps1
   
-before_script:
-  - powershell -executionpolicy unrestricted -File ./tools/CheckAssemblyVersion.ps1  
-  
 script: 
   - echo $TRAVIS_BRANCH
   - echo $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ addons:
 before_script:
   - powershell -executionpolicy unrestricted -File ./tools/CheckAssemblyVersion.ps1
   
+before_script:
+  - powershell -executionpolicy unrestricted -File ./tools/CheckAssemblyVersion.ps1  
+  
 script: 
   - echo $TRAVIS_BRANCH
   - echo $TRAVIS_BUILD_DIR

--- a/src/ReactiveDomain.Debug.nuspec
+++ b/src/ReactiveDomain.Debug.nuspec
@@ -1,0 +1,112 @@
+﻿<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>ReactiveDomain</id>
+    <version>0.8.21.1</version>
+    <authors>PerkinElmer,Linedata</authors>
+    <owners>PerkinElmer,Linedata</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <description>Package includes all ReactiveDomain Core assemblies</description>
+    <copyright>Copyright © 2014-2019 PerkinElmer, Linedata Inc.</copyright>
+    <dependencies>
+      <group targetFramework=".NETFramework4.5.2">
+        <dependency id="EventStore.Client" version="5.0.1" exclude="Build,Analyzers" />
+        <dependency id="EventStore.Client.Embedded" version="5.0.1" exclude="Build,Analyzers" />	  
+        <dependency id="Microsoft.CSharp" version="4.5.0" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="12.0.2" exclude="Build,Analyzers" />		
+      </group>
+      <group targetFramework=".NETFramework4.7.2">
+        <dependency id="EventStore.Client" version="5.0.1" exclude="Build,Analyzers" />
+        <dependency id="EventStore.Client.Embedded" version="5.0.1" exclude="Build,Analyzers" />	  
+        <dependency id="Microsoft.CSharp" version="4.5.0" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="12.0.2" exclude="Build,Analyzers" />		
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="EventStore.Client" version="5.0.1" exclude="Build,Analyzers" />
+        <dependency id="EventStore.Client.Embedded" version="5.0.1" exclude="Build,Analyzers" />	  
+        <dependency id="Microsoft.CSharp" version="4.5.0" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="12.0.2" exclude="Build,Analyzers" />		
+      </group>
+    </dependencies>
+	<references>
+		<group targetFramework=".NETFramework4.5.2">
+			<reference file="ReactiveDomain.Core.dll" />
+			<reference file="ReactiveDomain.Foundation.dll" />
+			<reference file="ReactiveDomain.Messaging.dll" />
+			<reference file="ReactiveDomain.Persistence.dll" />
+			<reference file="ReactiveDomain.PrivateLedger.dll" />		
+			<reference file="ReactiveDomain.Transport.dll" />
+			<reference file="ReactiveDomain.Core.pdb" />
+			<reference file="ReactiveDomain.Foundation.pdb" />
+			<reference file="ReactiveDomain.Messaging.pdb" />
+			<reference file="ReactiveDomain.Persistence.pdb" />
+			<reference file="ReactiveDomain.PrivateLedger.pdb" />		
+			<reference file="ReactiveDomain.Transport.pdb" />		
+		</group>
+		<group targetFramework=".NETFramework4.7.2">
+			<reference file="ReactiveDomain.Core.dll" />
+			<reference file="ReactiveDomain.Foundation.dll" />
+			<reference file="ReactiveDomain.Messaging.dll" />
+			<reference file="ReactiveDomain.Persistence.dll" />
+			<reference file="ReactiveDomain.PrivateLedger.dll" />		
+			<reference file="ReactiveDomain.Transport.dll" />
+			<reference file="ReactiveDomain.Core.pdb" />
+			<reference file="ReactiveDomain.Foundation.pdb" />
+			<reference file="ReactiveDomain.Messaging.pdb" />
+			<reference file="ReactiveDomain.Persistence.pdb" />
+			<reference file="ReactiveDomain.PrivateLedger.pdb" />		
+			<reference file="ReactiveDomain.Transport.pdb" />				
+		</group>
+		<group targetFramework=".NETStandard2.0">
+			<reference file="ReactiveDomain.Core.dll" />
+			<reference file="ReactiveDomain.Foundation.dll" />
+			<reference file="ReactiveDomain.Messaging.dll" />
+			<reference file="ReactiveDomain.Persistence.dll" />
+			<reference file="ReactiveDomain.PrivateLedger.dll" />		
+			<reference file="ReactiveDomain.Transport.dll" />
+			<reference file="ReactiveDomain.Core.pdb" />
+			<reference file="ReactiveDomain.Foundation.pdb" />
+			<reference file="ReactiveDomain.Messaging.pdb" />
+			<reference file="ReactiveDomain.Persistence.pdb" />
+			<reference file="ReactiveDomain.PrivateLedger.pdb" />		
+			<reference file="ReactiveDomain.Transport.pdb" />			
+		</group>	
+	</references>  	
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="Microsoft.CSharp" targetFramework=".NETFramework4.0" />
+    </frameworkAssemblies>	
+  </metadata>
+  <files>
+    <file src="..\bld\Debug\net452\ReactiveDomain.Core.dll" target="lib\net452" />
+    <file src="..\bld\Debug\net452\ReactiveDomain.Foundation.dll" target="lib\net452" />  
+    <file src="..\bld\Debug\net452\ReactiveDomain.Messaging.dll" target="lib\net452" />
+    <file src="..\bld\Debug\net452\ReactiveDomain.Persistence.dll" target="lib\net452" />	
+    <file src="..\bld\Debug\net452\ReactiveDomain.PrivateLedger.dll" target="lib\net452" />
+    <file src="..\bld\Debug\net452\ReactiveDomain.Transport.dll" target="lib\net452" />		
+    <file src="..\bld\Debug\net472\ReactiveDomain.Core.dll" target="lib\net472" />	
+    <file src="..\bld\Debug\net472\ReactiveDomain.Foundation.dll" target="lib\net472" />  
+    <file src="..\bld\Debug\net472\ReactiveDomain.Messaging.dll" target="lib\net472" />
+    <file src="..\bld\Debug\net472\ReactiveDomain.Persistence.dll" target="lib\net472" />	
+    <file src="..\bld\Debug\net472\ReactiveDomain.PrivateLedger.dll" target="lib\net472" />
+    <file src="..\bld\Debug\net472\ReactiveDomain.Transport.dll" target="lib\net472" />
+    <file src="..\bld\Debug\net452\ReactiveDomain.Core.pdb" target="lib\net452" />
+    <file src="..\bld\Debug\net452\ReactiveDomain.Foundation.pdb" target="lib\net452" />  
+    <file src="..\bld\Debug\net452\ReactiveDomain.Messaging.pdb" target="lib\net452" />
+    <file src="..\bld\Debug\net452\ReactiveDomain.Persistence.pdb" target="lib\net452" />	
+    <file src="..\bld\Debug\net452\ReactiveDomain.PrivateLedger.pdb" target="lib\net452" />
+    <file src="..\bld\Debug\net452\ReactiveDomain.Transport.pdb" target="lib\net452" />		
+    <file src="..\bld\Debug\net472\ReactiveDomain.Core.pdb" target="lib\net472" />	
+    <file src="..\bld\Debug\net472\ReactiveDomain.Foundation.pdb" target="lib\net472" />  
+    <file src="..\bld\Debug\net472\ReactiveDomain.Messaging.pdb" target="lib\net472" />
+    <file src="..\bld\Debug\net472\ReactiveDomain.Persistence.pdb" target="lib\net472" />	
+    <file src="..\bld\Debug\net472\ReactiveDomain.PrivateLedger.pdb" target="lib\net472" />
+    <file src="..\bld\Debug\net472\ReactiveDomain.Transport.pdb" target="lib\net472" />	
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Core.dll" target="lib\netstandard2.0" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Foundation.dll" target="lib\netstandard2.0" />  
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Messaging.dll" target="lib\netstandard2.0" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Persistence.dll" target="lib\netstandard2.0" />	
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.PrivateLedger.dll" target="lib\netstandard2.0" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Transport.dll" target="lib\netstandard2.0" />	
+  </files>  
+</package>

--- a/src/ReactiveDomain.Testing.Debug.nuspec
+++ b/src/ReactiveDomain.Testing.Debug.nuspec
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>ReactiveDomain.Testing</id>
+    <version>0.8.21.1</version>
+    <authors>PerkinElmer,Linedata</authors>
+    <owners>PerkinElmer,Linedata</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <description>Package includes ReactiveDomain assemblies needed for unit testing</description>
+    <copyright>Copyright © 2014-2019 PerkinElmer, Linedata Inc.</copyright>
+    <dependencies>
+      <group targetFramework=".NETFramework4.5.2">
+        <dependency id="xunit" version="2.4.1" exclude="Build,Analyzers" />
+        <dependency id="xunit.runner.console" version="2.4.1" exclude="Build,Analyzers" />
+        <dependency id="xunit.runner.visualstudio" version="2.4.1" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.8.21.8" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETFramework4.7.2">
+        <dependency id="Microsoft.NET.Test.Sdk" version="16.2.0" exclude="Build,Analyzers" />
+        <dependency id="xunit" version="2.4.1" exclude="Build,Analyzers" />
+        <dependency id="xunit.runner.console" version="2.4.1" exclude="Build,Analyzers" />
+        <dependency id="xunit.runner.visualstudio" version="2.4.1" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.8.21.8" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.NET.Test.Sdk" version="16.2.0" exclude="Build,Analyzers" />
+        <dependency id="xunit" version="2.4.1" exclude="Build,Analyzers" />
+        <dependency id="xunit.runner.console" version="2.4.1" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.8.21.8" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+    <references>
+      <group targetFramework=".NETFramework4.5.2">
+        <reference file="ReactiveDomain.Testing.dll" />
+        <reference file="ReactiveDomain.Testing.pdb" />
+      </group>
+      <group targetFramework=".NETFramework4.7.2">
+        <reference file="ReactiveDomain.Testing.dll" />
+        <reference file="ReactiveDomain.Testing.pdb" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <reference file="ReactiveDomain.Testing.dll" />
+        <reference file="ReactiveDomain.Testing.pdb" />
+      </group>
+    </references>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="Microsoft.CSharp" targetFramework=".NETFramework4.0" />
+    </frameworkAssemblies>
+  </metadata>
+  <files>
+    <file src="..\bld\Debug\net452\ReactiveDomain.Testing.dll" target="lib\net452" />
+    <file src="..\bld\Debug\net472\ReactiveDomain.Testing.dll" target="lib\net472" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Testing.dll" target="lib\netstandard2.0" />
+    <file src="..\bld\Debug\net452\ReactiveDomain.Testing.pdb" target="lib\net452" />
+    <file src="..\bld\Debug\net472\ReactiveDomain.Testing.pdb" target="lib\net472" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Testing.pdb" target="lib\netstandard2.0" />
+  </files>
+</package>

--- a/src/ReactiveDomain.Testing/Foundation/TestAggregate.cs
+++ b/src/ReactiveDomain.Testing/Foundation/TestAggregate.cs
@@ -37,5 +37,30 @@ namespace ReactiveDomain.Testing
 
         }
     }
+    public class TestAggregate2 : EventDrivenStateMachine
+    {
+
+        public TestAggregate2(Guid id)
+            : this()
+        {
+            if (id == Guid.Empty) throw new ArgumentOutOfRangeException(nameof(id), id, "ID cannot be Guid.Empty");
+            Raise(new TestAggregateMessages.NewAggregate2(id));
+        }
+
+
+        private TestAggregate2()
+        {
+            RegisterEvents();
+        }
+
+        
+
+        
+        private void RegisterEvents()
+        {
+            Register<TestAggregateMessages.NewAggregate2>(e => Id = e.AggregateId);
+            
+        }
+    }
 }
 

--- a/src/ReactiveDomain.Testing/Foundation/TestAggregateMessages.cs
+++ b/src/ReactiveDomain.Testing/Foundation/TestAggregateMessages.cs
@@ -16,6 +16,14 @@ namespace ReactiveDomain.Testing
                 AggregateId = aggregateId;
             }
         }
+        public class NewAggregate2 : Event
+        {
+            public readonly Guid AggregateId;
+            public NewAggregate2(Guid aggregateId)
+            {
+                AggregateId = aggregateId;
+            }
+        }
         public class Increment : Event
         {  
             public readonly Guid AggregateId;

--- a/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
+++ b/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
@@ -23,7 +23,10 @@ namespace ReactiveDomain.Testing
             MockRepository = new StreamStoreRepository(StreamNameBuilder, StreamStoreConnection, EventSerializer);
 
             var connectorBus = new InMemoryBus("connector");
-            StreamStoreConnection.SubscribeToAll(evt => connectorBus.Publish((IMessage)EventSerializer.Deserialize(evt)));
+            StreamStoreConnection.SubscribeToAll(evt => {
+                if(evt is ProjectedEvent) { return;}
+                connectorBus.Publish((IMessage) EventSerializer.Deserialize(evt));
+            });
             RepositoryEvents = new TestQueue(connectorBus, new[] { typeof(Event) });
         }
 

--- a/src/ReactiveDomain.UI.Debug.nuspec
+++ b/src/ReactiveDomain.UI.Debug.nuspec
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>ReactiveDomain.UI</id>
+    <version>0.8.21.1</version>
+    <authors>PerkinElmer,Linedata</authors>
+    <owners>PerkinElmer,Linedata</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <description>Package includes all ReactiveDomain UI assembly</description>
+    <copyright>Copyright © 2014-2019 PerkinElmer, Linedata Inc.</copyright>
+    <dependencies>
+      <group targetFramework=".NETFramework4.5.2">
+        <dependency id="ReactiveDomain" version="0.8.21.8" exclude="Build,Analyzers" />
+        <dependency id="ReactiveUI" version="7.4.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETFramework4.7.2">
+        <dependency id="ReactiveDomain" version="0.8.21.8" exclude="Build,Analyzers" />
+        <dependency id="ReactiveUI" version="8.7.2" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="ReactiveDomain" version="0.8.21.8" exclude="Build,Analyzers" />
+        <dependency id="ReactiveUI" version="8.7.2" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+    <references>
+      <group targetFramework=".NETFramework4.5.2">
+        <reference file="ReactiveDomain.UI.dll" />
+        <reference file="ReactiveDomain.UI.pdb" />
+      </group>
+      <group targetFramework=".NETFramework4.7.2">
+        <reference file="ReactiveDomain.UI.dll" />
+        <reference file="ReactiveDomain.UI.pdb" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <reference file="ReactiveDomain.UI.dll" />
+        <reference file="ReactiveDomain.UI.pdb" />
+      </group>
+    </references>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="Microsoft.CSharp" targetFramework=".NETFramework4.0" />
+    </frameworkAssemblies>
+  </metadata>
+  <files>
+    <file src="..\bld\Debug\net452\ReactiveDomain.UI.dll" target="lib\net452" />
+    <file src="..\bld\Debug\net472\ReactiveDomain.UI.dll" target="lib\net472" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.UI.dll" target="lib\netstandard2.0" />
+    <file src="..\bld\Debug\net452\ReactiveDomain.UI.pdb" target="lib\net452" />
+    <file src="..\bld\Debug\net472\ReactiveDomain.UI.pdb" target="lib\net472" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.UI.pdb" target="lib\netstandard2.0" />
+  </files>
+</package>

--- a/src/ReactiveDomain.UI.Testing.Debug.nuspec
+++ b/src/ReactiveDomain.UI.Testing.Debug.nuspec
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>ReactiveDomain.UI.Testing</id>
+    <version>0.8.21.1</version>
+    <authors>PerkinElmer,Linedata</authors>
+    <owners>PerkinElmer,Linedata</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <description>Package includes all ReactiveDomain UI assemblies for unit testing</description>
+    <copyright>Copyright © 2014-2019 PerkinElmer, Linedata Inc.</copyright>
+    <dependencies>
+      <group targetFramework=".NETFramework4.5.2">
+        <dependency id="Microsoft.NET.Test.Sdk" version="16.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.Testing" version="0.8.21.8" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.UI" version="0.8.21.8" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETFramework4.7.2">
+        <dependency id="Microsoft.NET.Test.Sdk" version="16.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.Testing" version="0.8.21.8" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.UI" version="0.8.21.8" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.NET.Test.Sdk" version="16.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.Testing" version="0.8.21.8" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.UI" version="0.8.21.8" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+    <references>
+      <group targetFramework=".NETFramework4.5.2">
+        <reference file="ReactiveDomain.UI.Testing.dll" />
+        <reference file="ReactiveDomain.UI.Testing.pdb" />
+      </group>
+      <group targetFramework=".NETFramework4.7.2">
+        <reference file="ReactiveDomain.UI.Testing.dll" />
+        <reference file="ReactiveDomain.UI.Testing.pdb" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <reference file="ReactiveDomain.UI.Testing.dll" />
+        <reference file="ReactiveDomain.UI.Testing.pdb" />
+      </group>
+    </references>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="Microsoft.CSharp" targetFramework=".NETFramework4.0" />
+    </frameworkAssemblies>
+  </metadata>
+  <files>
+    <file src="..\bld\Debug\net452\ReactiveDomain.UI.Testing.dll" target="lib\net452" />
+    <file src="..\bld\Debug\net472\ReactiveDomain.UI.Testing.dll" target="lib\net472" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.UI.Testing.dll" target="lib\netstandard2.0" />
+    <file src="..\bld\Debug\net452\ReactiveDomain.UI.Testing.pdb" target="lib\net452" />
+    <file src="..\bld\Debug\net472\ReactiveDomain.UI.Testing.pdb" target="lib\net472" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.UI.Testing.pdb" target="lib\netstandard2.0" />
+  </files>
+</package>

--- a/tools/CreateNuget.ps1
+++ b/tools/CreateNuget.ps1
@@ -8,49 +8,55 @@
 #       If build is stable, a stable (release) version will be pushed
 
 # branch must be master to create a nuget
+$configuration = "Release"
+$nuspecExtension = ".nuspec"
 $masterString = "master"
 $branch = $env:TRAVIS_BRANCH
 $apikey = $env:NugetOrgApiKey
-
-# create and push nuget off of master branch ONLY
-if ($branch -ne $masterString)  
-{
-  Write-Host ("Not a master branch. Will not create nuget")   
-  Exit
-}
 
 # This changes when its a CI build or a manually triggered via the web UI
 # api --> means manual/stable build ;  push --> means CI/unstable build
 # pull_request --> CI build triggered when opening a PR (do nothing here)
 $buildType = $env:TRAVIS_EVENT_TYPE 
 
+# create and push nuget off of master branch ONLY
+if (($branch -ne $masterString) -and ($buildType -ne "debug"))  
+{
+  Write-Host ("Not a master branch. Will not create nuget")   
+  Exit
+}
+
 if ($buildType -eq "pull_request")  
 {
   Write-Host ("Pull request build. Will not create nuget")   
   Exit
-}   
+}  
 
+if ($buildType -eq "debug")  
+{
+  Write-Host ("Debug build. Will create debug nuget") 
+  $configuration = "Debug" 
+  $nuspecExtension = ".Debug.nuspec" 
+}   
+ 
 Write-Host ("Powershell script location is " + $PSScriptRoot)
 
-$ReactiveDomainDll = $PSScriptRoot + "\..\bld\Release\net472\ReactiveDomain.Core.dll"
+$ReactiveDomainDll = $PSScriptRoot + "\..\bld\$configuration\net472\ReactiveDomain.Core.dll"
 $RDVersion = (Get-Item $ReactiveDomainDll).VersionInfo.FileVersion
+$ReactiveDomainNuspec = $PSScriptRoot + "\..\src\ReactiveDomain" + $nuspecExtension
+$ReactiveDomainTestingNuspec = $PSScriptRoot + "\..\src\ReactiveDomain.Testing" + $nuspecExtension
+$ReactiveDomainUINuspec = $PSScriptRoot + "\..\src\ReactiveDomain.UI" + $nuspecExtension
+$ReactiveDomainUITestingNuspec = $PSScriptRoot + "\..\src\ReactiveDomain.UI.Testing" + $nuspecExtension
 
-$ReactiveDomainNuspec = $PSScriptRoot + "\..\src\ReactiveDomain.nuspec"
 $RDFoundationProject = $PSScriptRoot + "\..\src\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj"
 $RDMessagingProject = $PSScriptRoot + "\..\src\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj"
 $RDPersistenceProject = $PSScriptRoot + "\..\src\ReactiveDomain.Persistence\ReactiveDomain.Persistence.csproj"
 $RDPrivateLedgerProject = $PSScriptRoot + "\..\src\ReactiveDomain.PrivateLedger\ReactiveDomain.PrivateLedger.csproj"
 $RDTransportProject = $PSScriptRoot + "\..\src\ReactiveDomain.Transport\ReactiveDomain.Transport.csproj"
 
-$ReactiveDomainTestingNuspec = $PSScriptRoot + "\..\src\ReactiveDomain.Testing.nuspec"
 $ReactiveDomainTestingProject = $PSScriptRoot + "\..\src\ReactiveDomain.Testing\ReactiveDomain.Testing.csproj"
-
-$ReactiveDomainUINuspec = $PSScriptRoot + "\..\src\ReactiveDomain.UI.nuspec"
 $RDUIProject = $PSScriptRoot + "\..\src\ReactiveDomain.UI\ReactiveDomain.UI.csproj"
-
-$ReactiveDomainUITestingNuspec = $PSScriptRoot + "\..\src\ReactiveDomain.UI.Testing.nuspec"
 $RDUITestingProject = $PSScriptRoot + "\..\src\ReactiveDomain.UI.Testing\ReactiveDomain.UI.Testing.csproj"
-
 $nuget = $PSScriptRoot + "\..\src\.nuget\nuget.exe"
 
 Write-Host ("Reactive Domain version is " + $RDVersion)


### PR DESCRIPTION
fixes #42 
Fixes to Mock store
- Add explict All Stream
- Ensure all events are posted to AllStream first
- Post all Projection eventst to AllStream
- Add new AllStreamProjection that correctly handles From and CatchUp scenarios

Fixes to MockSpecification
 - Exclude Projection Events inTestQueue to match current behavior 