### PR TITLE
Add convenience method for getting a listener on the mock repo

### DIFF
--- a/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
+++ b/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
@@ -35,5 +35,12 @@ namespace ReactiveDomain.Testing
             RepositoryEvents.Clear();
             TestQueue.Clear();
         }
+
+        public IListener GetListener(string name) =>
+                            new QueuedStreamListener(
+                                name,
+                                StreamStoreConnection,
+                                StreamNameBuilder,
+                                EventSerializer);
     }
 }


### PR DESCRIPTION
Simple convenience method for getting a listener using the default stream store connection, stream name builder, and event serializer from the `MockRepositorySpecification`.