### PR TITLE
set the args in the overloaded SetupEventstore method

### DIFF
--- a/src/ReactiveDomain.Persistence/EventStore/EventStoreLoader.cs
+++ b/src/ReactiveDomain.Persistence/EventStore/EventStoreLoader.cs
@@ -42,7 +42,7 @@ namespace ReactiveDomain.EventStore {
                 tcpPort: 1113,
                 windowStyle: ProcessWindowStyle.Hidden,
                 opt: StartConflictOption.Connect,
-                additionalArgs);
+                additionalArgs:additionalArgs);
         }
         public void SetupEventStore(
                                 DirectoryInfo installPath,

--- a/src/ReactiveDomain.Persistence/EventStore/EventStoreLoader.cs
+++ b/src/ReactiveDomain.Persistence/EventStore/EventStoreLoader.cs
@@ -33,26 +33,30 @@ namespace ReactiveDomain.EventStore {
         public IStreamStoreConnection Connection { get; private set; }
 
         public void SetupEventStore(DirectoryInfo installPath, string additionalArgs = null) {
-            var args = $" --config=\"./config.yaml\" {additionalArgs ?? ""}";
+            var config = "config.yaml";
 
             SetupEventStore(installPath,
-                args,
+                config,
                 new UserCredentials("admin", "changeit"),
                 IPAddress.Parse("127.0.0.1"),
                 tcpPort: 1113,
                 windowStyle: ProcessWindowStyle.Hidden,
-                opt: StartConflictOption.Connect);
+                opt: StartConflictOption.Connect,
+                additionalArgs);
         }
         public void SetupEventStore(
                                 DirectoryInfo installPath,
-                                string args,
+                                string config,
                                 UserCredentials credentials,
                                 IPAddress server,
                                 int tcpPort,
                                 ProcessWindowStyle windowStyle,
-                                StartConflictOption opt) {
-            Ensure.NotNullOrEmpty(args, "args");
+                                StartConflictOption opt,
+                                string additionalArgs = null) {
+            Ensure.NotNullOrEmpty(config, "config");
             Ensure.NotNull(credentials, "credentials");
+
+            var args = $" --config=\"./{config}\" {additionalArgs ?? ""}";
 
             var fullPath = Path.Combine(installPath.FullName, "EventStore.ClusterNode.exe");
 


### PR DESCRIPTION
the args format `$" --config=\"./config.yaml\" {additionalArgs ?? ""}"` is not set in the overloaded method `SetupEventStore` when its called externally.