### PR TITLE
Add support for Updating aggregates in addition to GetById in repositories

### DIFF
--- a/src/ReactiveDomain.Core/IEventSource.cs
+++ b/src/ReactiveDomain.Core/IEventSource.cs
@@ -27,7 +27,16 @@ namespace ReactiveDomain
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="events"/> is <c>null</c>.</exception>
         /// <exception cref="System.InvalidOperationException">Thrown when this instance has already recorded events.</exception>
         void RestoreFromEvents(IEnumerable<object> events);
-        
+
+        /// <summary>
+        /// Updates this instance with historical events.
+        /// </summary>
+        /// <param name="events">The events to apply.</param>
+        /// <param name="expectedVersion">The expected version prior to applying events</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="events"/> is <c>null</c>.</exception>
+        /// <exception cref="System.InvalidOperationException">Thrown when this instance does not have historical events or expected version mismatch</exception>
+        void UpdateWithEvents(IEnumerable<object> events, long expectedVersion);
+
         /// <summary>
         /// Takes the recorded history of events from this instance (CQS violation, beware).
         /// </summary>

--- a/src/ReactiveDomain.Foundation/Domain/EventDrivenStateMachine.cs
+++ b/src/ReactiveDomain.Foundation/Domain/EventDrivenStateMachine.cs
@@ -44,6 +44,20 @@ namespace ReactiveDomain {
                 _router.Route(@event);
             }
         }
+        public void UpdateWithEvents(IEnumerable<object> events, long expectedVersion) {
+            if (events == null)
+                throw new ArgumentNullException(nameof(events));
+            if (_version < 0)
+                throw new InvalidOperationException("Updating with events is not possible when an instance has no historical events.");
+            if ( _version != expectedVersion) {
+                throw  new InvalidOperationException("Expected version mismatch when updating ");
+            }
+
+            foreach (var @event in events) {
+                _version++;
+                _router.Route(@event);
+            }
+        }
 
         /// <summary>
         /// Returns all events from the EventRecorder since state was loaded or the last time TakeEvents was called

--- a/src/ReactiveDomain.Foundation/IRepository.cs
+++ b/src/ReactiveDomain.Foundation/IRepository.cs
@@ -3,11 +3,9 @@ namespace ReactiveDomain.Foundation
 {
     public interface IRepository
 	{
-        bool TryGetById<TAggregate>(Guid id, out TAggregate aggregate) where TAggregate : class, IEventSource;
-        bool TryGetById<TAggregate>(Guid id, int version, out TAggregate aggregate) where TAggregate : class, IEventSource;
-        TAggregate GetById<TAggregate>(Guid id) where TAggregate : class, IEventSource;
-		TAggregate GetById<TAggregate>(Guid id, int version) where TAggregate : class, IEventSource;
-		void Save(IEventSource aggregate);
-        void UpdateToCurrent(IEventSource aggregate);
+        bool TryGetById<TAggregate>(Guid id,  out TAggregate aggregate, int version = int.MaxValue) where TAggregate : class, IEventSource;
+        TAggregate GetById<TAggregate>(Guid id, int version = int.MaxValue) where TAggregate : class, IEventSource;
+		void Update<TAggregate>(ref TAggregate aggregate, int version = int.MaxValue) where TAggregate : class, IEventSource;
+        void Save(IEventSource aggregate);
     }
 }

--- a/src/ReactiveDomain.Foundation/StreamStore/CachingRepository.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/CachingRepository.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace ReactiveDomain.Foundation.StreamStore {
     /// <summary>
@@ -21,24 +20,15 @@ namespace ReactiveDomain.Foundation.StreamStore {
             if (cacheFactory == null) {
                 cacheFactory = repo => new ReadThroughAggregateCache(repo);
             }
-
             _cache = cacheFactory(baseRepository);
         }
-
-
-        public bool TryGetById<TAggregate>(Guid id, out TAggregate aggregate) where TAggregate : class, IEventSource
-        {
-            return _cache.GetById(id, out aggregate);
+        public bool TryGetById<TAggregate>(Guid id, out TAggregate aggregate) where TAggregate : class, IEventSource {
+            return _cache.TryGetById(id, out aggregate);
         }
-        public TAggregate GetById<TAggregate>(Guid id) where TAggregate : class, IEventSource
-        {
-            if (!_cache.GetById(id, out TAggregate aggregate)) {
-                throw new AggregateNotFoundException(id,typeof(TAggregate));
-            }
-            return aggregate;
+        public TAggregate GetById<TAggregate>(Guid id) where TAggregate : class, IEventSource {
+            return _cache.GetById<TAggregate>(id);
         }
-        public void Save(IEventSource aggregate)
-        {
+        public void Save(IEventSource aggregate) {
             _cache.Save(aggregate);
         }
         public bool ClearCache(Guid id) {

--- a/src/ReactiveDomain.Foundation/StreamStore/CorrelatedStreamStoreRepository.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/CorrelatedStreamStoreRepository.cs
@@ -3,33 +3,39 @@ using ReactiveDomain.Foundation.StreamStore;
 using ReactiveDomain.Messaging;
 
 // ReSharper disable once CheckNamespace
-namespace ReactiveDomain.Foundation{
-    public class CorrelatedStreamStoreRepository:ICorrelatedRepository, IDisposable
+namespace ReactiveDomain.Foundation {
+    public class CorrelatedStreamStoreRepository : ICorrelatedRepository, IDisposable
     {
         private readonly IRepository _repository;
         private readonly IAggregateCache _cache = null;
-        public CorrelatedStreamStoreRepository(IRepository repository) {
-            _repository = repository;
-        }
         public CorrelatedStreamStoreRepository(
-            IStreamNameBuilder streamNameBuilder,
-            IStreamStoreConnection streamStoreConnection,
-            IEventSerializer eventSerializer,
-            Func<IRepository,IAggregateCache> cacheFactory = null) {
-            _repository = new StreamStoreRepository(streamNameBuilder,streamStoreConnection,eventSerializer);
+            IRepository repository,
+            Func<IRepository, IAggregateCache> cacheFactory = null) {
+            _repository = repository;
             if (cacheFactory != null) {
                 _cache = cacheFactory(_repository);
             }
         }
-        
+
+        public CorrelatedStreamStoreRepository(
+            IStreamNameBuilder streamNameBuilder,
+            IStreamStoreConnection streamStoreConnection,
+            IEventSerializer eventSerializer,
+            Func<IRepository, IAggregateCache> cacheFactory = null) {
+            _repository = new StreamStoreRepository(streamNameBuilder, streamStoreConnection, eventSerializer);
+            if (cacheFactory != null) {
+                _cache = cacheFactory(_repository);
+            }
+        }
+
         public bool TryGetById<TAggregate>(Guid id, out TAggregate aggregate, ICorrelatedMessage source) where TAggregate : AggregateRoot, IEventSource {
             return TryGetById(id, int.MaxValue, out aggregate, source);
         }
 
         public TAggregate GetById<TAggregate>(Guid id, ICorrelatedMessage source) where TAggregate : AggregateRoot, IEventSource {
-           return GetById<TAggregate>(id, int.MaxValue, source);
+            return GetById<TAggregate>(id, int.MaxValue, source);
         }
-        
+
         public bool TryGetById<TAggregate>(Guid id, int version, out TAggregate aggregate, ICorrelatedMessage source) where TAggregate : AggregateRoot, IEventSource {
             try {
                 aggregate = GetById<TAggregate>(id, version, source);
@@ -40,33 +46,34 @@ namespace ReactiveDomain.Foundation{
                 return false;
             }
         }
-       
-        public TAggregate GetById<TAggregate>(Guid id, int version, ICorrelatedMessage source) where TAggregate : AggregateRoot, IEventSource
-        {
+
+        public TAggregate GetById<TAggregate>(Guid id, int version, ICorrelatedMessage source) where TAggregate : AggregateRoot, IEventSource {
             TAggregate agg = null;
             _cache?.GetById(id, out agg);
 
-            if(agg == null || agg.Version > version) {
+            if (agg == null || agg.Version > version) {
                 agg = _repository.GetById<TAggregate>(id, version);
             }
-            
+
             ((ICorrelatedEventSource)agg).Source = source;
             return agg;
         }
 
         public void Save(IEventSource aggregate) {
             if (_cache != null) {
-                _cache.Save( aggregate);
+                _cache.Save(aggregate);
             }
             else {
                 _repository.Save(aggregate);
             }
         }
+
         protected virtual void Dispose(bool disposing) {
             if (disposing) {
-                _cache.Dispose();
+                _cache?.Dispose();
             }
         }
+
         public void Dispose() {
             Dispose(true);
             GC.SuppressFinalize(this);

--- a/src/ReactiveDomain.Foundation/StreamStore/IAggregateCache.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/IAggregateCache.cs
@@ -5,10 +5,8 @@ namespace ReactiveDomain.Foundation.StreamStore {
     /// While it might seem more natural to save and restore the event set behind the aggregate,
     /// this cache stores only the collapsed state in the aggregate  
     /// </summary>
-    public interface IAggregateCache: IDisposable
+    public interface IAggregateCache:IRepository, IDisposable
     {
-        bool GetById<TAggregate>(Guid id, out TAggregate aggregate) where TAggregate : class, IEventSource;
-        bool Save(IEventSource aggregate);
         bool Remove(Guid id);
         void Clear();
     }

--- a/src/ReactiveDomain.Testing/EventStore/MockStreamStoreConnectionTests.cs
+++ b/src/ReactiveDomain.Testing/EventStore/MockStreamStoreConnectionTests.cs
@@ -1,7 +1,6 @@
 ﻿using ReactiveDomain.Foundation;
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using ReactiveDomain.Messaging;
 using ReactiveDomain.Testing.EventStore;
 using Xunit;
@@ -13,11 +12,13 @@ namespace ReactiveDomain.Testing
     // ReSharper disable InconsistentNaming
     public class MockStreamStoreConnectionTests : IClassFixture<StreamStoreConnectionFixture>
     {
+        // ReSharper disable once CollectionNeverQueried.Local
         private readonly List<IStreamStoreConnection> _streamStoreConnections = new List<IStreamStoreConnection>();
 
         private readonly List<IRepository> _repos = new List<IRepository>();
         private readonly IStreamNameBuilder _streamNameBuilder;
         private readonly Tuple<IStreamStoreConnection, StreamStoreRepository> _mockPair;
+        // ReSharper disable once NotAccessedField.Local
         private readonly Tuple<IStreamStoreConnection, StreamStoreRepository> _fixturePair;
 
 
@@ -78,12 +79,12 @@ namespace ReactiveDomain.Testing
 
             foreach (var repo in _repos) {
                 var id = Guid.NewGuid();
-                Assert.False(repo.TryGetById(id, 1, out TestAggregate tAgg));
+                Assert.False(repo.TryGetById(id,  out TestAggregate tAgg,1));
                 Assert.Null(tAgg);
                 tAgg = new TestAggregate(id);
                 repo.Save(tAgg);
 
-                Assert.True(repo.TryGetById(id, 1, out TestAggregate rAgg));
+                Assert.True(repo.TryGetById(id,  out TestAggregate rAgg, 1));
                 Assert.NotNull(rAgg);
                 Assert.Equal(tAgg.Id, rAgg.Id);
             }


### PR DESCRIPTION
- Add Update methods to IRepository
- Update Repository and Aggregate caches classes to use Update when possible
- Add a ctor overload to CorrelatedStreamStoreRepository allowing injecting both an IRepository and an optional cache factory. This will make the class easier to use in scenarios where the CorrelatedStreamStoreRepository is being defined in a place where an IRepository has already been created or injected.
- Fix a bug in the Dispose(bool) method that would cause an exception to be thrown if no cache has been defined.