### PR TITLE
ReadModelBase uses an IStreamReader to get old events before going live

### DIFF
--- a/src/ReactiveDomain.Foundation/IListener.cs
+++ b/src/ReactiveDomain.Foundation/IListener.cs
@@ -9,14 +9,16 @@ namespace ReactiveDomain.Foundation
         ISubscriber EventStream { get; }
         long Position { get; }
         string StreamName { get; }
+
         /// <summary>
         /// Starts listening on a named stream
         /// </summary>
         /// <param name="stream">the exact stream name</param>
         /// <param name="checkpoint">start point to listen from</param>
         /// <param name="blockUntilLive">wait for the is live event from the catchup subscription before returning</param>
-        /// <param name="millisecondsTimeout">Timeout to wait before aborting Load defaults to 1000ms</param>
-        void Start(string stream, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken));
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
+        void Start(string stream, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default);
+
         /// <summary>
         /// Starts listening on an aggregate root stream
         /// </summary>
@@ -24,15 +26,16 @@ namespace ReactiveDomain.Foundation
         /// <param name="id">the aggregate id</param>
         /// <param name="checkpoint">start point to listen from</param>
         /// <param name="blockUntilLive">wait for the is live event from the catchup subscription before returning</param>
-        /// <param name="millisecondsTimeout">Timeout to wait before aborting Load defaults to 1000ms</param>
-        void Start<TAggregate>(Guid id, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken)) where TAggregate : class, IEventSource;
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
+        void Start<TAggregate>(Guid id, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default) where TAggregate : class, IEventSource;
+
         /// <summary>
         /// Starts listening on a Aggregate Category Stream
         /// </summary>
         /// <typeparam name="TAggregate">The type of aggregate</typeparam>
         /// <param name="checkpoint">start point to listen from</param>
         /// <param name="blockUntilLive">wait for the is live event from the catchup subscription before returning</param>
-        /// <param name="millisecondsTimeout">Timeout to wait before aborting Load defaults to 1000ms</param>
-        void Start<TAggregate>(long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken)) where TAggregate : class, IEventSource;
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
+        void Start<TAggregate>(long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default) where TAggregate : class, IEventSource;
     }
 }

--- a/src/ReactiveDomain.Foundation/IListener.cs
+++ b/src/ReactiveDomain.Foundation/IListener.cs
@@ -17,7 +17,7 @@ namespace ReactiveDomain.Foundation
         /// <param name="checkpoint">start point to listen from</param>
         /// <param name="blockUntilLive">wait for the is live event from the catchup subscription before returning</param>
         /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
-        void Start(string stream, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default);
+        void Start(string stream, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken));
 
         /// <summary>
         /// Starts listening on an aggregate root stream
@@ -27,7 +27,7 @@ namespace ReactiveDomain.Foundation
         /// <param name="checkpoint">start point to listen from</param>
         /// <param name="blockUntilLive">wait for the is live event from the catchup subscription before returning</param>
         /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
-        void Start<TAggregate>(Guid id, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default) where TAggregate : class, IEventSource;
+        void Start<TAggregate>(Guid id, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken)) where TAggregate : class, IEventSource;
 
         /// <summary>
         /// Starts listening on a Aggregate Category Stream
@@ -36,6 +36,6 @@ namespace ReactiveDomain.Foundation
         /// <param name="checkpoint">start point to listen from</param>
         /// <param name="blockUntilLive">wait for the is live event from the catchup subscription before returning</param>
         /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
-        void Start<TAggregate>(long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default) where TAggregate : class, IEventSource;
+        void Start<TAggregate>(long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken)) where TAggregate : class, IEventSource;
     }
 }

--- a/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
@@ -9,48 +9,127 @@ using ReactiveDomain.Util;
 namespace ReactiveDomain.Foundation {
     public abstract class ReadModelBase:IDisposable {
         private readonly Func<IListener> _getListener;
+        private readonly Func<IStreamReader> _getReader;
         private readonly List<IListener> _listeners;
         private readonly InMemoryBus _bus;
         private readonly QueuedHandler _queue;
-        
-        protected ReadModelBase(string name, Func<IListener> getListener) {
-            
+
+        /// <summary>
+        /// Creates a read model with a <see cref="QueuedStreamListener"/> and a <see cref="StreamReader"/> using the provided parameters.
+        /// The stream reader reads existing events before switching to the listener for live events.
+        /// </summary>
+        /// <param name="name">The name of the read model. Also used as the name of the listener and reader.</param>
+        /// <param name="streamStoreConnection">A connection to a StreamStore.</param>
+        /// <param name="streamNameBuilder">How to build stream names for this StreamStore.</param>
+        /// <param name="serializer">A serializer for Events.</param>
+        protected ReadModelBase(string name, IStreamStoreConnection streamStoreConnection, IStreamNameBuilder streamNameBuilder, IEventSerializer serializer)
+            : this(
+                name,
+                () => new QueuedStreamListener(name, streamStoreConnection, streamNameBuilder, serializer),
+                () => new StreamReader(name, streamStoreConnection, streamNameBuilder, serializer)) { }
+
+        /// <summary>
+        /// Creates a read model using the provided Functions to get a listener and reader.
+        /// If provided, the stream reader reads existing events before switching to the listener for live events.
+        /// </summary>
+        /// <param name="name">The name of the read model. Also used as the name of the listener and reader.</param>
+        /// <param name="getListener">A Func to get a new <see cref="IListener"/>.</param>
+        /// <param name="getReader">A Func to get a new <see cref="IStreamReader"/></param>
+        protected ReadModelBase(string name, Func<IListener> getListener, Func<IStreamReader> getReader = null) {
             Ensure.NotNull(getListener, nameof(getListener));
             _getListener = getListener;
+            _getReader = getReader;
             _listeners = new List<IListener>();
             _bus = new InMemoryBus($"{nameof(ReadModelBase)}:{name} bus",false);
             _queue = new QueuedHandler(_bus,$"{nameof(ReadModelBase)}:{name} queue");
             _queue.Start();
         }
-       private IListener AddNewListener() {
-           var l = _getListener();
-           lock (_listeners) {
-               _listeners.Add(l);
-           }
-           l.EventStream.SubscribeToAll(_queue);
-           return l;
-       }
+
+        private IListener AddNewListener() {
+            var l = _getListener();
+            lock (_listeners) {
+                _listeners.Add(l);
+            }
+            l.EventStream.SubscribeToAll(_queue);
+            return l;
+        }
+
+        /// <summary>
+        /// Get the positions of all listeners.
+        /// </summary>
+        /// <returns>A list of Tuples of listener names and checkpoints.</returns>
         public List<Tuple<string, long>> GetCheckpoint() {
             lock (_listeners) {
                 return _listeners.Select(l => new Tuple<string, long>(l.StreamName, l.Position)).ToList();
             }
         }
 
+        /// <summary>
+        /// The stream of events that handlers should subscribe to.
+        /// </summary>
         public ISubscriber EventStream => _bus;
 
-        public void Start(string stream, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken)) {
-           
+        /// <summary>
+        /// Start playback of a named stream.
+        /// </summary>
+        /// <param name="stream">The name of the stream to play back.</param>
+        /// <param name="checkpoint">The event to start with.</param>
+        /// <param name="blockUntilLive">If true, blocks returning from this method until the listener has caught up.</param>
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true.</param>
+        public void Start(string stream, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default) {
+            if (_getReader != null) {
+                using (var reader = _getReader()) {
+                    reader.EventStream.SubscribeToAll(_queue);
+                    if (reader.Read(stream, checkpoint))
+                        checkpoint = reader.Position;
+                    reader.EventStream.Unsubscribe(_queue);
+                }
+            }
             AddNewListener().Start(stream, checkpoint, blockUntilLive, cancelWaitToken);
         }
 
-        public void Start<TAggregate>(Guid id, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken)) where TAggregate : class, IEventSource {
+        /// <summary>
+        /// Start playback of a specific stream of type TAggregate.
+        /// </summary>
+        /// <typeparam name="TAggregate">The type of stream to play back.</typeparam>
+        /// <param name="id">The ID of the stream to play back.</param>
+        /// <param name="checkpoint">The event to start with.</param>
+        /// <param name="blockUntilLive">If true, blocks returning from this method until the listener has caught up.</param>
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true.</param>
+        public void Start<TAggregate>(Guid id, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default) where TAggregate : class, IEventSource {
+            if (_getReader != null) {
+                using (var reader = _getReader()) {
+                    reader.EventStream.SubscribeToAll(_queue);
+                    if (reader.Read<TAggregate>(id, checkpoint))
+                        checkpoint = reader.Position;
+                    reader.EventStream.Unsubscribe(_queue);
+                }
+            }
             AddNewListener().Start<TAggregate>(id, checkpoint, blockUntilLive, cancelWaitToken);
         }
 
-        public void Start<TAggregate>(long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken)) where TAggregate : class, IEventSource {
+        /// <summary>
+        /// Start a category listener for type TAggregate.
+        /// </summary>
+        /// <typeparam name="TAggregate">The type of stream to play back.</typeparam>
+        /// <param name="checkpoint">The event to start with.</param>
+        /// <param name="blockUntilLive">If true, blocks returning from this method until the listener has caught up.</param>
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true.</param>
+        public void Start<TAggregate>(long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default) where TAggregate : class, IEventSource {
+            if (_getReader != null) {
+                using (var reader = _getReader()) {
+                    reader.EventStream.SubscribeToAll(_queue);
+                    if (reader.Read<TAggregate>(checkpoint))
+                        checkpoint = reader.Position;
+                    reader.EventStream.Unsubscribe(_queue);
+                }
+            }
             AddNewListener().Start<TAggregate>(checkpoint, blockUntilLive, cancelWaitToken);
         }
 
+        /// <summary>
+        /// Dispose of resources.
+        /// </summary>
         public void Dispose() {
             Dispose(true);
             GC.SuppressFinalize(this);

--- a/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
@@ -76,7 +76,7 @@ namespace ReactiveDomain.Foundation {
         /// <param name="checkpoint">The event to start with.</param>
         /// <param name="blockUntilLive">If true, blocks returning from this method until the listener has caught up.</param>
         /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true.</param>
-        public void Start(string stream, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default) {
+        public void Start(string stream, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken)) {
             if (_getReader != null) {
                 using (var reader = _getReader()) {
                     reader.EventStream.SubscribeToAll(_queue);
@@ -96,7 +96,7 @@ namespace ReactiveDomain.Foundation {
         /// <param name="checkpoint">The event to start with.</param>
         /// <param name="blockUntilLive">If true, blocks returning from this method until the listener has caught up.</param>
         /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true.</param>
-        public void Start<TAggregate>(Guid id, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default) where TAggregate : class, IEventSource {
+        public void Start<TAggregate>(Guid id, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken)) where TAggregate : class, IEventSource {
             if (_getReader != null) {
                 using (var reader = _getReader()) {
                     reader.EventStream.SubscribeToAll(_queue);
@@ -115,7 +115,7 @@ namespace ReactiveDomain.Foundation {
         /// <param name="checkpoint">The event to start with.</param>
         /// <param name="blockUntilLive">If true, blocks returning from this method until the listener has caught up.</param>
         /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true.</param>
-        public void Start<TAggregate>(long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default) where TAggregate : class, IEventSource {
+        public void Start<TAggregate>(long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken)) where TAggregate : class, IEventSource {
             if (_getReader != null) {
                 using (var reader = _getReader()) {
                     reader.EventStream.SubscribeToAll(_queue);

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamListener.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamListener.cs
@@ -47,6 +47,8 @@ namespace ReactiveDomain.Foundation
         /// <param name="streamNameBuilder">The source for correct stream names based on aggregates and events</param>
         /// <param name="serializer"></param>
         /// <param name="busName">The name to use for the internal bus (helpful in debugging)</param>
+        /// <param name="liveProcessingStarted">An Action to invoke when live processing starts</param>
+        /// <param name="subscriptionDropped">An Action to invoke if a subscription is dropped</param>
         public StreamListener(
                 string listenerName,
                 IStreamStoreConnection streamStoreConnection,
@@ -72,7 +74,7 @@ namespace ReactiveDomain.Foundation
         /// <param name="tMessage"></param>
         /// <param name="checkpoint"></param>
         /// <param name="blockUntilLive"></param>
-        /// <param name="waitToken">Cancelation token to cancel waiting if blockUntilLive is true</param>
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
         public void Start(
             Type tMessage,
             long? checkpoint = null,
@@ -96,7 +98,7 @@ namespace ReactiveDomain.Foundation
         /// <typeparam name="TAggregate">The Aggregate type used to generate the stream name</typeparam>
         /// <param name="checkpoint"></param>
         /// <param name="blockUntilLive"></param>
-        /// <param name="waitToken">Cancelation token to cancel waiting if blockUntilLive is true</param>
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
         public void Start<TAggregate>(
                         long? checkpoint = null,
                         bool blockUntilLive = false,
@@ -118,7 +120,7 @@ namespace ReactiveDomain.Foundation
         /// <param name="id"></param>
         /// <param name="checkpoint"></param>
         /// <param name="blockUntilLive"></param>
-        /// <param name="waitToken">Cancelation token to cancel waiting if blockUntilLive is true</param>
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
         public void Start<TAggregate>(
                         Guid id,
                         long? checkpoint = null,
@@ -139,7 +141,7 @@ namespace ReactiveDomain.Foundation
         /// <param name="streamName"></param>
         /// <param name="checkpoint"></param>
         /// <param name="blockUntilLive"></param>
-        /// <param name="waitToken">Cancelation token to cancel waiting if blockUntilLive is true</param>
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
         public virtual void Start(
                             string streamName,
                             long? checkpoint = null,


### PR DESCRIPTION
- Backward compatible: if no Func to get a stream reader is provided, the listener is used for the whole stream.
- Added a ctor override that specifies the StreamStore properties and builds a QueuedStreamListener and a StreamReader. This will allow for more terse callers in some circumstances, while keeping existing callers fully functional.
- Added XML documentation for all public methods in ReadModelBase and updated XML docs for some related files where the docs were out of date.