### PR TITLE
Expose delete functionality from ES connection to aggregates

### DIFF
--- a/src/ReactiveDomain.Foundation.Tests/when_using_caching_repository.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_caching_repository.cs
@@ -105,6 +105,19 @@ namespace ReactiveDomain.Foundation.Tests
 
         }
 
+        [Fact]
+        public void can_delete_aggregate()
+        {
+            var newAccountId = Guid.NewGuid();
+            ICorrelatedMessage source = MessageBuilder.New(() => new when_using_correlated_repository.CreateAccount(newAccountId));
+            var newAccount = new when_using_correlated_repository.Account(newAccountId, source);
+            _cachingRepo.Save(newAccount);
+
+            var retrievedAccount = _cachingRepo.GetById<when_using_correlated_repository.Account>(newAccountId);
+            _cachingRepo.Delete(retrievedAccount);
+
+            Assert.Throws<AggregateNotFoundException>(() => _cachingRepo.GetById<when_using_correlated_repository.Account>(newAccountId));
+        }
 
         public class Account : EventDrivenStateMachine
         {

--- a/src/ReactiveDomain.Foundation.Tests/when_using_correlated_repository.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_correlated_repository.cs
@@ -165,9 +165,21 @@ namespace ReactiveDomain.Foundation.Tests
 			Assert.NotNull(retrievedAccount2);
 			Assert.Equal(_accountId, retrievedAccount2.Id);
 			Assert.Equal(101, retrievedAccount.Balance);
+        }
 
-		}
-		
+        [Fact]
+        public void can_delete_aggregate()
+        {
+            var newAccountId = Guid.NewGuid();
+            ICorrelatedMessage source = MessageBuilder.New(() => new CreateAccount(newAccountId));
+            var newAccount = new Account(newAccountId, source);
+			_correlatedRepo.Save(newAccount);
+
+            var retrievedAccount = _correlatedRepo.GetById<Account>(newAccountId, source);
+            _correlatedRepo.Delete(retrievedAccount);
+
+            Assert.Throws<AggregateNotFoundException>(() => _correlatedRepo.GetById<Account>(newAccountId, source));
+        }
 
 		public class Account : AggregateRoot
 		{

--- a/src/ReactiveDomain.Foundation/ICorrelatedRepository.cs
+++ b/src/ReactiveDomain.Foundation/ICorrelatedRepository.cs
@@ -9,5 +9,7 @@ namespace ReactiveDomain.Foundation {
         TAggregate GetById<TAggregate>(Guid id, ICorrelatedMessage source) where TAggregate : AggregateRoot, IEventSource;
         TAggregate GetById<TAggregate>(Guid id, int version, ICorrelatedMessage source) where TAggregate : AggregateRoot, IEventSource;
         void Save(IEventSource aggregate);
+        void Delete(IEventSource aggregate);
+        void HardDelete(IEventSource aggregate);
     }
 }

--- a/src/ReactiveDomain.Foundation/IRepository.cs
+++ b/src/ReactiveDomain.Foundation/IRepository.cs
@@ -7,5 +7,7 @@ namespace ReactiveDomain.Foundation
         TAggregate GetById<TAggregate>(Guid id, int version = int.MaxValue) where TAggregate : class, IEventSource;
 		void Update<TAggregate>(ref TAggregate aggregate, int version = int.MaxValue) where TAggregate : class, IEventSource;
         void Save(IEventSource aggregate);
+        void Delete(IEventSource aggregate);
+        void HardDelete(IEventSource aggregate);
     }
 }

--- a/src/ReactiveDomain.Foundation/StreamStore/CachingRepository.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/CachingRepository.cs
@@ -31,6 +31,12 @@ namespace ReactiveDomain.Foundation.StreamStore {
         public void Save(IEventSource aggregate) {
             _cache.Save(aggregate);
         }
+        public void Delete(IEventSource aggregate) {
+            _cache.Delete(aggregate);
+        }
+        public void HardDelete(IEventSource aggregate) {
+            _cache.HardDelete(aggregate);
+        }
         public bool ClearCache(Guid id) {
             return _cache.Remove(id);
         }

--- a/src/ReactiveDomain.Foundation/StreamStore/CorrelatedStreamStoreRepository.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/CorrelatedStreamStoreRepository.cs
@@ -72,6 +72,33 @@ namespace ReactiveDomain.Foundation {
             }
         }
 
+        /// <summary>
+        /// Soft delete the aggregate. Its stream can be re-created by appending new events.
+        /// </summary>
+        /// <param name="aggregate">The aggregate to be deleted.</param>
+        public void Delete(IEventSource aggregate) {
+            if (_cache != null) {
+                _cache.Delete(aggregate);
+            }
+            else {
+                _repository.Delete(aggregate);
+            }
+        }
+
+        /// <summary>
+        /// Hard delete the aggregate. This permanently deletes the aggregate's stream.
+        /// </summary>
+        /// <param name="aggregate">The aggregate to be deleted.</param>
+        public void HardDelete(IEventSource aggregate)
+        {
+            if (_cache != null) {
+                _cache.HardDelete(aggregate);
+            }
+            else {
+                _repository.HardDelete(aggregate);
+            }
+        }
+
         protected virtual void Dispose(bool disposing) {
             if (disposing) {
                 _cache?.Dispose();

--- a/src/ReactiveDomain.Foundation/StreamStore/ReadThroughAggregateCache.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/ReadThroughAggregateCache.cs
@@ -106,6 +106,25 @@ namespace ReactiveDomain.Foundation.StreamStore
 
 
         }
+
+        /// <summary>
+        /// Soft delete the aggregate. Its stream can be re-created by appending new events.
+        /// </summary>
+        /// <param name="aggregate">The aggregate to be deleted.</param>
+        public void Delete(IEventSource aggregate) {
+            _baseRepository.Delete(aggregate);
+            _knownAggregates.Remove(aggregate.Id);
+        }
+
+        /// <summary>
+        /// Hard delete the aggregate. This permanently deletes the aggregate's stream.
+        /// </summary>
+        /// <param name="aggregate">The aggregate to be deleted.</param>
+        public void HardDelete(IEventSource aggregate) {
+            _baseRepository.HardDelete(aggregate);
+            _knownAggregates.Remove(aggregate.Id);
+        }
+
         public bool Remove(Guid id) {
             return _knownAggregates.Remove(id);
         }

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamStoreRepository.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamStoreRepository.cs
@@ -136,6 +136,25 @@ namespace ReactiveDomain.Foundation {
             _streamStoreConnection.AppendToStream(streamName, expectedVersion, null, eventsToSave);
         }
 
+        /// <summary>
+        /// Soft delete the aggregate. Its stream can be re-created by appending new events.
+        /// </summary>
+        /// <param name="aggregate">The aggregate to be deleted.</param>
+        public void Delete(IEventSource aggregate) {
+            var streamName = _streamNameBuilder.GenerateForAggregate(aggregate.GetType(), aggregate.Id);
+            var expectedVersion = aggregate.ExpectedVersion;
+            _streamStoreConnection.DeleteStream(streamName, expectedVersion);
+        }
 
+        /// <summary>
+        /// Hard delete the aggregate. This permanently deletes the aggregate's stream.
+        /// </summary>
+        /// <param name="aggregate">The aggregate to be deleted.</param>
+        public void HardDelete(IEventSource aggregate)
+        {
+            var streamName = _streamNameBuilder.GenerateForAggregate(aggregate.GetType(), aggregate.Id);
+            var expectedVersion = aggregate.ExpectedVersion;
+            _streamStoreConnection.HardDeleteStream(streamName, expectedVersion);
+        }
     }
 }

--- a/src/ReactiveDomain.Persistence/IStreamStoreConnection.cs
+++ b/src/ReactiveDomain.Persistence/IStreamStoreConnection.cs
@@ -133,6 +133,7 @@ namespace ReactiveDomain
         /// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
         /// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
         /// <param name="userCredentials">User credentials to use for the operation.</param>
+        /// <param name="resolveLinkTos">If true, resolve link events.</param>
         /// <returns>An IDisposable that can be used to close the subscription.</returns>
         IDisposable SubscribeToAll(
             Action<RecordedEvent> eventAppeared,
@@ -149,6 +150,8 @@ namespace ReactiveDomain
             UserCredentials userCredentials = null,
             bool resolveLinkTos = true);
 
-        void DeleteStream(string stream, int expectedVersion, UserCredentials credentials = null);
+        void DeleteStream(string stream, long expectedVersion, UserCredentials credentials = null);
+
+        void HardDeleteStream(string stream, long expectedVersion, UserCredentials credentials = null);
     }
 }


### PR DESCRIPTION
Add `Delete` and `HardDelete` methods to the different repository and cache implementations to allow for simple deletion of a stream using the aggregate that's associated with that stream.