### PR TITLE
Work around issue with ToArray during SpinUntil

### DIFF
--- a/src/ReactiveDomain.Testing/Specifications/TestQueue.cs
+++ b/src/ReactiveDomain.Testing/Specifications/TestQueue.cs
@@ -114,7 +114,7 @@ namespace ReactiveDomain.Testing
             var msgType = typeof(T);
             do
             {
-                if (SpinWait.SpinUntil(() => HandledTypes.Any(t => msgType.IsAssignableFrom(t)), 50))
+                if (SpinWait.SpinUntil(() => _handledTypes.Any(t => msgType.IsAssignableFrom(t)), 50))
                 {
                     return;
                 }


### PR DESCRIPTION
In `TestQueue.WaitFor()`, the use of the `HandledTypes` property was causing problems. That property converts from `HashSet<Type>` to `Array<Type>` using `ToArray()`. The conversion occasionally throws an ArgumentException, saying "Destination array is not long enough to copy all the items in the collection. Check array index and length." This error in turn causes unit tests that use `WaitFor` to occasionally fail. Because the exception is thrown from a core .NET library, we need to work around it, which we do by using the `_handledTypes` `HashSet` directly in `WaitFor()`.

Attempts to fix #101 