### PR TITLE
Add and update Intellisense comments in ReactiveDomain.UI and ReactiveDomain.UI.Testing classes

### DIFF
--- a/src/ReactiveDomain.UI.Testing/Asserts.cs
+++ b/src/ReactiveDomain.UI.Testing/Asserts.cs
@@ -14,7 +14,7 @@ namespace ReactiveDomain.UI.Testing
         /// <param name="cmd">The command whose CanExecute is to be compared</param>
         public static void CanExecute<TIn, TOut>(ReactiveCommand<TIn, TOut> cmd)
         {
-            using (cmd.CanExecute.Replay(1).RefCount().ObserveOn(RxApp.MainThreadScheduler).Subscribe(Xunit.Assert.True)) { }
+            using (cmd.CanExecute.Replay(1).RefCount().ObserveOn(RxApp.MainThreadScheduler).Subscribe(x => Xunit.Assert.True(x))) { }
         }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace ReactiveDomain.UI.Testing
         /// <param name="cmd">The command whose CanExecute is to be compared</param>
         public static void CannotExecute<TIn, TOut>(ReactiveCommand<TIn, TOut> cmd)
         {
-            using (cmd.CanExecute.Replay(1).RefCount().ObserveOn(RxApp.MainThreadScheduler).Subscribe(Xunit.Assert.False)) { }
+            using (cmd.CanExecute.Replay(1).RefCount().ObserveOn(RxApp.MainThreadScheduler).Subscribe(x => Xunit.Assert.False(x))) { }
         }
     }
 }

--- a/src/ReactiveDomain.UI/Bus/ReactiveTransientSubscriber.cs
+++ b/src/ReactiveDomain.UI/Bus/ReactiveTransientSubscriber.cs
@@ -8,35 +8,69 @@ using ReactiveUI;
 
 namespace ReactiveDomain.UI
 {
+    /// <summary>
+    /// A <see cref="ReactiveObject"/> that implements Subscribe on the injected bus and
+    /// that auto-unsubscribes when disposed.
+    /// </summary>
     public abstract class ReactiveTransientSubscriber : ReactiveObject, IDisposable
     {
         private readonly List<IDisposable> _subscriptions = new List<IDisposable>();
         private readonly ISubscriber _eventSubscriber;
         private readonly ICommandSubscriber _commandSubscriber;
 
+        /// <summary>
+        /// Creates a <see cref="ReactiveTransientSubscriber"/> with the injected dispatcher.
+        /// </summary>
+        /// <param name="bus">The dispatcher on which to subscribe to commands.</param>
+        /// <exception cref="ArgumentNullException"><c>bus</c> is <c>null</c></exception>
         protected ReactiveTransientSubscriber(IDispatcher bus) : this((IBus)bus)
         {
             _commandSubscriber = bus ?? throw new ArgumentNullException(nameof(bus));
         }
 
-        protected ReactiveTransientSubscriber(IBus bus) : this((ISubscriber) bus) {}
+        /// <summary>
+        /// Creates a <see cref="ReactiveTransientSubscriber"/> with the injected bus.
+        /// </summary>
+        /// <param name="bus">The bus on which to subscribe to messages.</param>
+        /// <exception cref="ArgumentNullException"><c>bus</c> is <c>null</c></exception>
+        protected ReactiveTransientSubscriber(IBus bus) : this((ISubscriber) bus) { }
 
+        /// <summary>
+        /// Creates a <see cref="ReactiveTransientSubscriber"/> with the injected bus.
+        /// </summary>
+        /// <param name="subscriber">The <see cref="ISubscriber"/> on which to subscribe to messages.</param>
+        /// <exception cref="ArgumentNullException"><c>bus</c> is <c>null</c></exception>
         protected ReactiveTransientSubscriber(ISubscriber subscriber)
         {
             _eventSubscriber = subscriber ?? throw new ArgumentNullException(nameof(subscriber));
         }
 
+        /// <summary>
+        /// Subscribes to messages of type T on the bus. This is typically used when subscribing to events.
+        /// </summary>
+        /// <typeparam name="T">The type of messages to subscribe to.</typeparam>
+        /// <param name="handler">A handler for messages of type T.</param>
         protected void Subscribe<T>(IHandle<T> handler) where T : class, IMessage
         {
             _subscriptions.Add(_eventSubscriber.Subscribe<T>(handler));
         }
 
+        /// <summary>
+        /// Subscribes to commands of type T on the bus.
+        /// </summary>
+        /// <typeparam name="T">The type of commands to subscribe to.</typeparam>
+        /// <param name="handler">A handler for commands of type T.</param>
+        /// <exception cref="ArgumentOutOfRangeException">The class has not been given an
+        /// <see cref="IDispatcher"/> on which to subscribe to commands.</exception>
         protected void Subscribe<T>(IHandleCommand<T> handler) where T : Command
         {
             if (_commandSubscriber == null) throw new ArgumentOutOfRangeException(nameof(handler), @"TransientSubscriber not created with CommandBus to register on.");
             _subscriptions.Add(_commandSubscriber.Subscribe<T>(handler));
         }
 
+        /// <summary>
+        /// Unsubscribes from all subscribed message types on the bus.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
@@ -47,10 +81,10 @@ namespace ReactiveDomain.UI
         {
             if (_disposed)
                 return;
-            if (disposing){
+            if (disposing) {
                 _subscriptions?.ForEach(s => s.Dispose());
             }
-           _disposed = true;
+            _disposed = true;
         }
     }
 }

--- a/src/ReactiveDomain.UI/ReadModel/ReadModelProperty.cs
+++ b/src/ReactiveDomain.UI/ReadModel/ReadModelProperty.cs
@@ -5,11 +5,24 @@ using System.Threading.Tasks;
 
 namespace ReactiveDomain.UI
 {
-
+    /// <summary>
+    /// A wrapper for an observable provider, intended for use in transient read models.
+    /// This provider is a hot observable. Includes simple semantics for appending a new
+    /// item to the provider. Late subscribers are automatically provided with the most
+    /// recent value upon subscription.
+    /// </summary>
+    /// <typeparam name="T">The type of data for the provider.</typeparam>
     public class ReadModelProperty<T> : IObservable<T>
     {
         private readonly List<IObserver<T>> _subscribed = new List<IObserver<T>>();
         private readonly IObservable<T> _observable;
+
+        /// <summary>
+        /// Creates a new <see cref="ReadModelProperty{T}"/>.
+        /// </summary>
+        /// <param name="startValue">The provider's initial value.</param>
+        /// <param name="publishWrapper">An optional wrapper to use when providing
+        /// new values to subscribers.</param>
         public ReadModelProperty(T startValue, Action<Action> publishWrapper = null)
         {
             _lastValue = startValue;
@@ -19,12 +32,19 @@ namespace ReactiveDomain.UI
                 _subscribed.Add(o);
                 return () => _subscribed.Remove(o);
             });
-
         }
 
         private T _lastValue;
         private readonly Action<Action> _publishWrapper;
 
+        /// <summary>
+        /// Append an item to the provider's stream and notifies all subscribers.
+        /// The stream is unchanged and no notifications are made if the provided
+        /// value is the same as the previous value.
+        /// </summary>
+        /// <param name="val">The value to be appended to the stream.</param>
+        /// <param name="force">Forces notifications. If true, notifies subscribers of
+        /// the new value even if that value is the same as the previous value.</param>
         public void Update(T val, bool force = false)
         {
             var noChange = (val != null && val.Equals(_lastValue)) || (val == null && _lastValue == null);
@@ -41,6 +61,14 @@ namespace ReactiveDomain.UI
                     subscriber.OnNext(val);
             }
         }
+
+        /// <summary>
+        /// Subscribes a new observer to this observable and asynchronously notifies
+        /// that observer of the most recent value.
+        /// </summary>
+        /// <param name="observer">The observer to subscribe.</param>
+        /// <returns>A reference to an interface that allows observers to stop receiving
+        /// notifications before the provider has finished sending them.</returns>
         public IDisposable Subscribe(IObserver<T> observer)
         {
             var unsubscribe = _observable.Subscribe(observer);

--- a/src/ReactiveDomain.UI/ViewObjects/CommandBuilder.cs
+++ b/src/ReactiveDomain.UI/ViewObjects/CommandBuilder.cs
@@ -9,38 +9,40 @@ using ReactiveDomain.Messaging.Bus;
 using ReactiveUI;
 using ReactiveCommand = ReactiveUI.ReactiveCommand;
 
+// ReSharper disable UnusedMember.Global
+
 namespace ReactiveDomain.UI
 {
     public static class CommandBuilder
     {
         /// <summary>
-        /// Creates a ReactiveCommand from an Action, with a defined CanExecute.
+        /// Creates a <see cref="ReactiveCommand"/> from an Action, with a defined CanExecute.
         /// </summary>
-        /// <param name="canExecute"></param>
-        /// <param name="action"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <returns></returns>
+        /// <param name="canExecute">The observable that determines if the <see cref="ReactiveCommand"/> can run.</param>
+        /// <param name="action">The action for the command to run.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the command fails.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that executes the provided action.</returns>
         public static ReactiveCommand<Unit, Unit> FromAction(
-                                                IObservable<bool> canExecute,
-                                                Action action,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null)
+            IObservable<bool> canExecute,
+            Action action,
+            IScheduler scheduler = null,
+            string userErrorMsg = null)
         {
             return FromAction(_ => action(), canExecute, scheduler, userErrorMsg);
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand from an Action. The ReactiveCommand's CanExecute will always be true.
+        /// Creates a <see cref="ReactiveCommand"/> from an Action. The ReactiveCommand's CanExecute will always be true.
         /// </summary>
-        /// <param name="action"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <returns></returns>
+        /// <param name="action">The action for the command to run.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the command fails.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that executes the provided action.</returns>
         public static ReactiveCommand<Unit, Unit> FromAction(
-                                                Action action,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null)
+            Action action,
+            IScheduler scheduler = null,
+            string userErrorMsg = null)
         {
             return FromAction(_ => action(), null, scheduler, userErrorMsg);
         }
@@ -66,48 +68,48 @@ namespace ReactiveDomain.UI
                         {
                             // This will return the recovery option returned from the registered user error handler,
                             // e.g. a simple message box in the view code behind
-                            /* n.b. this forces evaluation/execution of the select many  */
+                            /* n.b. this forces evaluation/execution of the select many */
                         });
             return cmd;
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand from an Action&lt;object&gt;, with a defined CanExecute.
+        /// Creates a <see cref="ReactiveCommand"/> from an Action&lt;object&gt;, with a defined CanExecute.
         /// </summary>
-        /// <param name="canExecute"></param>
-        /// <param name="action"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <returns></returns>
+        /// <param name="canExecute">The observable that determines if the <see cref="ReactiveCommand"/> can run.</param>
+        /// <param name="action">The action for the command to run.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the command fails.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that executes the provided action.</returns>
         public static ReactiveCommand<object, Unit> FromActionEx(
-                                               IObservable<bool> canExecute,
-                                               Action<object> action,
-                                               IScheduler scheduler = null,
-                                               string userErrorMsg = null)
+           IObservable<bool> canExecute,
+           Action<object> action,
+           IScheduler scheduler = null,
+           string userErrorMsg = null)
         {
             return FromActionEx(action, canExecute, scheduler, userErrorMsg);
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand from an Action&lt;object&gt;. The ReactiveCommand's CanExecute will always be true.
+        /// Creates a <see cref="ReactiveCommand"/> from an Action&lt;object&gt;. The ReactiveCommand's CanExecute will always be true.
         /// </summary>
-        /// <param name="action"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <returns></returns>
+        /// <param name="action">The action for the command to run.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the command fails.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that executes the provided action.</returns>
         public static ReactiveCommand<object, Unit> FromActionEx(
-                                                Action<object> action,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null)
+            Action<object> action,
+            IScheduler scheduler = null,
+            string userErrorMsg = null)
         {
             return FromActionEx(action, null, scheduler, userErrorMsg);
         }
 
         private static ReactiveCommand<object, Unit> FromActionEx(
-                                                Action<object> action,
-                                                IObservable<bool> canExecute = null,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null)
+            Action<object> action,
+            IObservable<bool> canExecute = null,
+            IScheduler scheduler = null,
+            string userErrorMsg = null)
         {
             if (scheduler == null)
                 scheduler = RxApp.MainThreadScheduler;
@@ -124,195 +126,199 @@ namespace ReactiveDomain.UI
                         {
                             // This will return the recovery option returned from the registered user error handler,
                             // e.g. a simple message box in the view code behind
-                            /* n.b. this forces evaluation/execution of the select many  */
+                            /* n.b. this forces evaluation/execution of the select many */
                         });
             return cmd;
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand that will send the specified Command on the bus when executed.
+        /// Creates a <see cref="ReactiveCommand"/> that will send the specified <see cref="Command"/> on the bus when executed.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="canExecute"></param>
-        /// <param name="commandFunc"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <param name="responseTimeout"></param>
-        /// <param name="ackTimeout"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to send the Command.</param>
+        /// <param name="canExecute">The observable that determines if the <see cref="ReactiveCommand"/> can run.</param>
+        /// <param name="commandFunc">A function that returns the <see cref="Command"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the command fails.</param>
+        /// <param name="responseTimeout">Overrides the bus's default response timeout for this command only.</param>
+        /// <param name="ackTimeout">Overrides the bus's default ack timeout for this command only.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that sends the provided <see cref="Command"/>.</returns>
         public static ReactiveCommand<Unit, Unit> BuildSendCommand(
-                                                this ICommandPublisher bus,
-                                                IObservable<bool> canExecute,
-                                                Func<Command> commandFunc,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null,
-                                                TimeSpan? responseTimeout = null,
-                                                TimeSpan? ackTimeout = null)
+            this ICommandPublisher bus,
+            IObservable<bool> canExecute,
+            Func<Command> commandFunc,
+            IScheduler scheduler = null,
+            string userErrorMsg = null,
+            TimeSpan? responseTimeout = null,
+            TimeSpan? ackTimeout = null)
         {
             return SendCommands(bus, new[] { commandFunc }, canExecute, scheduler, userErrorMsg, responseTimeout, ackTimeout);
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand that will send the specified Command on the bus when executed, with a defined CanExecute.
+        /// Creates a <see cref="ReactiveCommand"/> that will send the specified <see cref="Command"/> on the bus when executed.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="canExecute"></param>
-        /// <param name="commandFunc"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <param name="responseTimeout"></param>
-        /// <param name="ackTimeout"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to send the Command.</param>
+        /// <param name="canExecute">The observable that determines if the <see cref="ReactiveCommand"/> can run.</param>
+        /// <param name="commandFunc">A function that returns the <see cref="Command"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the command fails.</param>
+        /// <param name="responseTimeout">Overrides the bus's default response timeout for this command only.</param>
+        /// <param name="ackTimeout">Overrides the bus's default ack timeout for this command only.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that sends the provided <see cref="Command"/>.</returns>
         public static ReactiveCommand<Unit, Unit> BuildSendCommand(
-                                                this IDispatcher bus,
-                                                IObservable<bool> canExecute,
-                                                Func<Command> commandFunc,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null,
-                                                TimeSpan? responseTimeout = null,
-                                                TimeSpan? ackTimeout = null)
+            this IDispatcher bus,
+            IObservable<bool> canExecute,
+            Func<Command> commandFunc,
+            IScheduler scheduler = null,
+            string userErrorMsg = null,
+            TimeSpan? responseTimeout = null,
+            TimeSpan? ackTimeout = null)
         {
             return SendCommands(bus, new[] { commandFunc }, canExecute, scheduler, userErrorMsg, responseTimeout, ackTimeout);
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand that will send the specified Command on the bus when executed. The ReactiveCommand's CanExecute will always be true.
+        /// Creates a <see cref="ReactiveCommand"/> that will send the specified <see cref="Command"/> on the bus when executed.
+        /// The ReactiveCommand's CanExecute will always be true.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="commandFunc"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <param name="responseTimeout"></param>
-        /// <param name="ackTimeout"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to send the Command.</param>
+        /// <param name="commandFunc">A function that returns the <see cref="Command"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the command fails.</param>
+        /// <param name="responseTimeout">Overrides the bus's default response timeout for this command only.</param>
+        /// <param name="ackTimeout">Overrides the bus's default ack timeout for this command only.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that sends the provided <see cref="Command"/>.</returns>
         public static ReactiveCommand<Unit, Unit> BuildSendCommand(
-                                                this ICommandPublisher bus,
-                                                Func<Command> commandFunc,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null,
-                                                TimeSpan? responseTimeout = null,
-                                                TimeSpan? ackTimeout = null)
+            this ICommandPublisher bus,
+            Func<Command> commandFunc,
+            IScheduler scheduler = null,
+            string userErrorMsg = null,
+            TimeSpan? responseTimeout = null,
+            TimeSpan? ackTimeout = null)
         {
             return SendCommands(bus, new[] { commandFunc }, null, scheduler, userErrorMsg, responseTimeout, ackTimeout);
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand that will send the specified Command on the bus when executed. The ReactiveCommand's CanExecute will always be true.
+        /// Creates a <see cref="ReactiveCommand"/> that will send the specified <see cref="Command"/> on the bus when executed.
+        /// The ReactiveCommand's CanExecute will always be true.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="commandFunc"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <param name="responseTimeout"></param>
-        /// <param name="ackTimeout"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to send the Command.</param>
+        /// <param name="commandFunc">A function that returns the <see cref="Command"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the command fails.</param>
+        /// <param name="responseTimeout">Overrides the bus's default response timeout for this command only.</param>
+        /// <param name="ackTimeout">Overrides the bus's default ack timeout for this command only.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that sends the provided <see cref="Command"/>.</returns>
         public static ReactiveCommand<Unit, Unit> BuildSendCommand(
-                                                this IDispatcher bus,
-                                                Func<Command> commandFunc,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null,
-                                                TimeSpan? responseTimeout = null,
-                                                TimeSpan? ackTimeout = null)
+            this IDispatcher bus,
+            Func<Command> commandFunc,
+            IScheduler scheduler = null,
+            string userErrorMsg = null,
+            TimeSpan? responseTimeout = null,
+            TimeSpan? ackTimeout = null)
         {
             return SendCommands(bus, new[] { commandFunc }, null, scheduler, userErrorMsg, responseTimeout, ackTimeout);
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand that will send the specified Command on the bus when executed, with a defined CanExecute.
+        /// Creates a <see cref="ReactiveCommand"/> that will send all of the specified Commands on the bus when executed.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="canExecute"></param>
-        /// <param name="commands"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <param name="responseTimeout"></param>
-        /// <param name="ackTimeout"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to send the Command.</param>
+        /// <param name="canExecute">The observable that determines if the <see cref="ReactiveCommand"/> can run.</param>
+        /// <param name="commands">A collection of anonymous functions that each return a <see cref="Command"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the command fails.</param>
+        /// <param name="responseTimeout">Overrides the bus's default response timeout for this command only.</param>
+        /// <param name="ackTimeout">Overrides the bus's default ack timeout for this command only.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that sends the provided <see cref="Command"/>.</returns>
         public static ReactiveCommand<Unit, Unit> BuildSendCommand(
-                                                this ICommandPublisher bus,
-                                                IObservable<bool> canExecute,
-                                                IEnumerable<Func<Command>> commands,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null,
-                                                TimeSpan? responseTimeout = null,
-                                                TimeSpan? ackTimeout = null)
+            this ICommandPublisher bus,
+            IObservable<bool> canExecute,
+            IEnumerable<Func<Command>> commands,
+            IScheduler scheduler = null,
+            string userErrorMsg = null,
+            TimeSpan? responseTimeout = null,
+            TimeSpan? ackTimeout = null)
         {
             return SendCommands(bus, commands, canExecute, scheduler, userErrorMsg, responseTimeout, ackTimeout);
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand that will send the specified Command on the bus when executed, with a defined CanExecute.
+        /// Creates a <see cref="ReactiveCommand"/> that will send all of the specified Commands on the bus when executed.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="canExecute"></param>
-        /// <param name="commands"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <param name="responseTimeout"></param>
-        /// <param name="ackTimeout"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to send the Command.</param>
+        /// <param name="canExecute">The observable that determines if the <see cref="ReactiveCommand"/> can run.</param>
+        /// <param name="commands">A collection of anonymous functions that each return a <see cref="Command"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the command fails.</param>
+        /// <param name="responseTimeout">Overrides the bus's default response timeout for this command only.</param>
+        /// <param name="ackTimeout">Overrides the bus's default ack timeout for this command only.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that sends the provided Commands.</returns>
         public static ReactiveCommand<Unit, Unit> BuildSendCommands(
-                                                this IDispatcher bus,
-                                                IObservable<bool> canExecute,
-                                                IEnumerable<Func<Command>> commands,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null,
-                                                TimeSpan? responseTimeout = null,
-                                                TimeSpan? ackTimeout = null)
+            this IDispatcher bus,
+            IObservable<bool> canExecute,
+            IEnumerable<Func<Command>> commands,
+            IScheduler scheduler = null,
+            string userErrorMsg = null,
+            TimeSpan? responseTimeout = null,
+            TimeSpan? ackTimeout = null)
         {
             return SendCommands(bus, commands, canExecute, scheduler, userErrorMsg, responseTimeout, ackTimeout);
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand that will send the specified Command on the bus when executed. The ReactiveCommand's CanExecute will always be true.
+        /// Creates a <see cref="ReactiveCommand"/> that will send all of the specified Commands on the bus when executed.
+        /// The ReactiveCommand's CanExecute will always be true.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="commands"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <param name="responseTimeout"></param>
-        /// <param name="ackTimeout"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to send the Command.</param>
+        /// <param name="commands">A collection of anonymous functions that each return a <see cref="Command"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the command fails.</param>
+        /// <param name="responseTimeout">Overrides the bus's default response timeout for this command only.</param>
+        /// <param name="ackTimeout">Overrides the bus's default ack timeout for this command only.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that sends the provided Commands.</returns>
         public static ReactiveCommand<Unit, Unit> BuildSendCommands(
-                                                this ICommandPublisher bus,
-                                                IEnumerable<Func<Command>> commands,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null,
-                                                TimeSpan? responseTimeout = null,
-                                                TimeSpan? ackTimeout = null)
+            this ICommandPublisher bus,
+            IEnumerable<Func<Command>> commands,
+            IScheduler scheduler = null,
+            string userErrorMsg = null,
+            TimeSpan? responseTimeout = null,
+            TimeSpan? ackTimeout = null)
         {
             return SendCommands(bus, commands, null, scheduler, userErrorMsg, responseTimeout, ackTimeout);
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand that will send the specified Command on the bus when executed.
+        /// Creates a <see cref="ReactiveCommand"/> that will send all of the specified Commands on the bus when executed.
+        /// The ReactiveCommand's CanExecute will always be true.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="commands"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <param name="responseTimeout"></param>
-        /// <param name="ackTimeout"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to send the Command.</param>
+        /// <param name="commands">A collection of anonymous functions that each return a <see cref="Command"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the command fails.</param>
+        /// <param name="responseTimeout">Overrides the bus's default response timeout for this command only.</param>
+        /// <param name="ackTimeout">Overrides the bus's default ack timeout for this command only.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that sends the provided Commands.</returns>
         public static ReactiveCommand<Unit, Unit> BuildSendCommands(
-                                                this IDispatcher bus,
-                                                IEnumerable<Func<Command>> commands,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null,
-                                                TimeSpan? responseTimeout = null,
-                                                TimeSpan? ackTimeout = null)
+            this IDispatcher bus,
+            IEnumerable<Func<Command>> commands,
+            IScheduler scheduler = null,
+            string userErrorMsg = null,
+            TimeSpan? responseTimeout = null,
+            TimeSpan? ackTimeout = null)
         {
             return SendCommands(bus, commands, null, scheduler, userErrorMsg, responseTimeout, ackTimeout);
         }
 
         private static ReactiveCommand<Unit, Unit> SendCommands(
-                    ICommandPublisher bus,
-                    IEnumerable<Func<Command>> commands,
-                    IObservable<bool> canExecute = null,
-                    IScheduler scheduler = null,
-                    string userErrorMsg = null,
-                    TimeSpan? responseTimeout = null,
-                    TimeSpan? ackTimeout = null)
+            ICommandPublisher bus,
+            IEnumerable<Func<Command>> commands,
+            IObservable<bool> canExecute = null,
+            IScheduler scheduler = null,
+            string userErrorMsg = null,
+            TimeSpan? responseTimeout = null,
+            TimeSpan? ackTimeout = null)
         {
             if (scheduler == null)
                 scheduler = RxApp.MainThreadScheduler;
@@ -335,53 +341,53 @@ namespace ReactiveDomain.UI
                         {
                             // This will return the recovery option returned from the registered user error handler,
                             // e.g. a simple message box in the view code behind
-                            /* n.b. this forces evaluation/execution of the select many  */
+                            /* n.b. this forces evaluation/execution of the select many */
                         });
             return cmd;
         }
 
         /// <summary>
-        /// BuildSendCommandEx() does the same thing as BuildSendCommand(), except commandFunc must be defined
-        /// as a function that takes an object as input and returns a Command as result.
+        /// Creates a <see cref="ReactiveCommand"/> that will send the specified <see cref="Command"/> on the bus when executed,
+        /// using the provided object as input.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="canExecute"></param>
-        /// <param name="commandFunc"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <param name="responseTimeout"></param>
-        /// <param name="ackTimeout"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to send the Command.</param>
+        /// <param name="canExecute">The observable that determines if the <see cref="ReactiveCommand"/> can run.</param>
+        /// <param name="commandFunc">A function that returns the <see cref="Command"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the command fails.</param>
+        /// <param name="responseTimeout">Overrides the bus's default response timeout for this command only.</param>
+        /// <param name="ackTimeout">Overrides the bus's default ack timeout for this command only.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that sends the provided <see cref="Command"/>.</returns>
         public static ReactiveCommand<object, Unit> BuildSendCommandEx(
-                                this IDispatcher bus,
-                                IObservable<bool> canExecute,
-                                Func<object, Command> commandFunc,
-                                IScheduler scheduler = null,
-                                string userErrorMsg = null,
-                                TimeSpan? responseTimeout = null,
-                                TimeSpan? ackTimeout = null)
+            this IDispatcher bus,
+            IObservable<bool> canExecute,
+            Func<object, Command> commandFunc,
+            IScheduler scheduler = null,
+            string userErrorMsg = null,
+            TimeSpan? responseTimeout = null,
+            TimeSpan? ackTimeout = null)
         {
             return SendCommandEx(bus, commandFunc, canExecute, scheduler, userErrorMsg, responseTimeout, ackTimeout);
         }
 
         /// <summary>
-        /// BuildSendCommandEx() does the same thing as BuildSendCommand(), except commandFunc must be defined
-        /// as a function that takes an object as input and returns a Command as result.
+        /// Creates a <see cref="ReactiveCommand"/> that will send the specified <see cref="Command"/> on the bus when executed,
+        /// using the provided object as input. The ReactiveCommand's CanExecute will always be true.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="commandFunc"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <param name="responseTimeout"></param>
-        /// <param name="ackTimeout"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to send the Command.</param>
+        /// <param name="commandFunc">A function that returns the <see cref="Command"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the command fails.</param>
+        /// <param name="responseTimeout">Overrides the bus's default response timeout for this command only.</param>
+        /// <param name="ackTimeout">Overrides the bus's default ack timeout for this command only.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that sends the provided <see cref="Command"/>.</returns>
         public static ReactiveCommand<object, Unit> BuildSendCommandEx(
-                                                       this IDispatcher bus,
-                                                       Func<object, Command> commandFunc,
-                                                       IScheduler scheduler = null,
-                                                       string userErrorMsg = null,
-                                                       TimeSpan? responseTimeout = null,
-                                                       TimeSpan? ackTimeout = null)
+            this IDispatcher bus,
+            Func<object, Command> commandFunc,
+            IScheduler scheduler = null,
+            string userErrorMsg = null,
+            TimeSpan? responseTimeout = null,
+            TimeSpan? ackTimeout = null)
         {
             return SendCommandEx(bus, commandFunc, null, scheduler, userErrorMsg, responseTimeout, ackTimeout);
         }
@@ -415,79 +421,84 @@ namespace ReactiveDomain.UI
                         {
                             // This will return the recovery option returned from the registered user error handler,
                             // e.g. a simple message box in the view code behind
-                            /* n.b. this forces evaluation/execution of the select many  */
+                            /* n.b. this forces evaluation/execution of the select many */
                         });
             return cmd;
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand that will publish the specified Event on the bus when executed.
+        /// Creates a <see cref="ReactiveCommand"/> that will publish the specified <see cref="Event"/> on the bus when executed.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="canExecute"></param>
-        /// <param name="eventFunc"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to publish the Event.</param>
+        /// <param name="canExecute">The observable that determines if the <see cref="ReactiveCommand"/> can run.</param>
+        /// <param name="eventFunc">A function that returns the <see cref="Event"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the Event handler throws. Event handlers should never throw,
+        /// so this would indicate a programming error.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that publishes the provided <see cref="Event"/>.</returns>
         public static ReactiveCommand<Unit, Unit> BuildPublishEvent(
-                                                    this IPublisher bus,
-                                                    IObservable<bool> canExecute,
-                                                    Func<Event> eventFunc,
-                                                    IScheduler scheduler = null,
-                                                    string userErrorMsg = null)
+            this IPublisher bus,
+            IObservable<bool> canExecute,
+            Func<Event> eventFunc,
+            IScheduler scheduler = null,
+            string userErrorMsg = null)
         {
             return PublishEvents(bus, new[] { eventFunc }, canExecute, scheduler, userErrorMsg);
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand that will publish the specified Event on the bus when executed.
+        /// Creates a <see cref="ReactiveCommand"/> that will publish the specified <see cref="Event"/> on the bus when executed.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="eventFunc"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to publish the Event.</param>
+        /// <param name="eventFunc">A function that returns the <see cref="Event"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the Event handler throws. Event handlers should never throw,
+        /// so this would indicate a programming error.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that publishes the provided <see cref="Event"/>.</returns>
         public static ReactiveCommand<Unit, Unit> BuildPublishEvent(
-                                                   this IPublisher bus,
-                                                   Func<Event> eventFunc,
-                                                   IScheduler scheduler = null,
-                                                   string userErrorMsg = null)
+            this IPublisher bus,
+            Func<Event> eventFunc,
+            IScheduler scheduler = null,
+            string userErrorMsg = null)
         {
             return PublishEvents(bus, new[] { eventFunc }, null, scheduler, userErrorMsg);
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand that will publish the specified Event on the bus when executed.
+        /// Creates a <see cref="ReactiveCommand"/> that will publish all of the specified Events on the bus when executed.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="canExecute"></param>
-        /// <param name="events"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <returns></returns>
-        public static ReactiveCommand<Unit, Unit> BuildPublishEvent(
-                                                this IPublisher bus,
-                                                IObservable<bool> canExecute,
-                                                IEnumerable<Func<Event>> events,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null)
+        /// <param name="bus">The bus on which to publish the Event.</param>
+        /// <param name="canExecute">The observable that determines if the <see cref="ReactiveCommand"/> can run.</param>
+        /// <param name="events">A collection of anonymous functions that each return a <see cref="Command"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the Event handler throws. Event handlers should never throw,
+        /// so this would indicate a programming error.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that publishes the provided Events.</returns>
+        public static ReactiveCommand<Unit, Unit> BuildPublishEvents(
+            this IPublisher bus,
+            IObservable<bool> canExecute,
+            IEnumerable<Func<Event>> events,
+            IScheduler scheduler = null,
+            string userErrorMsg = null)
         {
             return PublishEvents(bus, events, canExecute, scheduler, userErrorMsg);
         }
 
         /// <summary>
-        /// Creates a ReactiveCommand that will publish the specified Event on the bus when executed.
+        /// Creates a <see cref="ReactiveCommand"/> that will publish all of the specified Events on the bus when executed.
+        /// The ReactiveCommand's CanExecute will always be true.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="events"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <returns></returns>
-        public static ReactiveCommand<Unit, Unit> BuildPublishEvent(
-                                                this IPublisher bus,
-                                                IEnumerable<Func<Event>> events,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null)
+        /// <param name="bus">The bus on which to publish the Event.</param>
+        /// <param name="events">A collection of anonymous functions that each return an <see cref="Event"/> to publish.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the Event handler throws. Event handlers should never throw,
+        /// so this would indicate a programming error.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that publishes the provided Events.</returns>
+        public static ReactiveCommand<Unit, Unit> BuildPublishEvents(
+            this IPublisher bus,
+            IEnumerable<Func<Event>> events,
+            IScheduler scheduler = null,
+            string userErrorMsg = null)
         {
             return PublishEvents(bus, events, null, scheduler, userErrorMsg);
         }
@@ -521,65 +532,68 @@ namespace ReactiveDomain.UI
                         {
                             // This will return the recovery option returned from the registered user error handler,
                             // e.g. a simple message box in the view code behind
-                            /* n.b. this forces evaluation/execution of the select many  */
+                            /* n.b. this forces evaluation/execution of the select many */
                         });
             return cmd;
         }
 
         /// <summary>
-        /// BuildPublishEventEx() does the same thing as BuildPublishEvent(), except eventFunc must be defined
-        /// as a function that takes an object as input and returns a Command as result.
+        /// Creates a <see cref="ReactiveCommand"/> that will publish the specified <see cref="Event"/> on the bus when executed,
+        /// using the provided object as input.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="canExecute"></param>
-        /// <param name="eventFunc"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to publish the Event.</param>
+        /// <param name="canExecute">The observable that determines if the <see cref="ReactiveCommand"/> can run.</param>
+        /// <param name="eventFunc">A function that returns the <see cref="Event"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the Event handler throws. Event handlers should never throw,
+        /// so this would indicate a programming error.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that publishes the provided <see cref="Event"/>.</returns>
         public static ReactiveCommand<object, Unit> BuildPublishEventEx(
-                                                    this IPublisher bus,
-                                                    IObservable<bool> canExecute,
-                                                    Func<object, Event> eventFunc,
-                                                    IScheduler scheduler = null,
-                                                    string userErrorMsg = null)
+            this IPublisher bus,
+            IObservable<bool> canExecute,
+            Func<object, Event> eventFunc,
+            IScheduler scheduler = null,
+            string userErrorMsg = null)
         {
             return PublishEventsEx(bus, new[] { eventFunc }, canExecute, scheduler, userErrorMsg);
         }
 
         /// <summary>
-        /// BuildPublishEventEx() does the same thing as BuildPublishEvent(), except eventFunc must be defined
-        /// as a function that takes an object as input and returns a Command as result.
+        /// Creates a <see cref="ReactiveCommand"/> that will publish the specified <see cref="Event"/> on the bus when executed,
+        /// using the provided object as input. The ReactiveCommand's CanExecute will always be true.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="eventFunc"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to publish the Event.</param>
+        /// <param name="eventFunc">A function that returns the <see cref="Event"/> to send.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the Event handler throws. Event handlers should never throw,
+        /// so this would indicate a programming error.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that publishes the provided <see cref="Event"/>.</returns>
         public static ReactiveCommand<object, Unit> BuildPublishEventEx(
-                                                   this IPublisher bus,
-                                                   Func<object, Event> eventFunc,
-                                                   IScheduler scheduler = null,
-                                                   string userErrorMsg = null)
+            this IPublisher bus,
+            Func<object, Event> eventFunc,
+            IScheduler scheduler = null,
+            string userErrorMsg = null)
         {
             return PublishEventsEx(bus, new[] { eventFunc }, null, scheduler, userErrorMsg);
         }
 
         /// <summary>
-        /// BuildPublishEventEx() does the same thing as BuildPublishEvent(), except eventFuncs must be defined
-        /// as a function that takes an object as input and returns a Command as result.
+        /// Creates a <see cref="ReactiveCommand"/> that will publish all of the specified Events on the bus when executed,
+        /// using the provided object as input.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="canExecute"></param>
-        /// <param name="eventFuncs"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to publish the Event.</param>
+        /// <param name="canExecute">The observable that determines if the <see cref="ReactiveCommand"/> can run.</param>
+        /// <param name="eventFuncs">A collection of anonymous functions that each return an <see cref="Event"/> to publish.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the Event handler throws. Event handlers should never throw,
+        /// so this would indicate a programming error.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that publishes the provided <see cref="Event"/>.</returns>
         public static ReactiveCommand<object, Unit> BuildPublishEventsEx(
-                                                this IPublisher bus,
-                                                IObservable<bool> canExecute,
-                                                IEnumerable<Func<object, Event>> eventFuncs,
-                                                IScheduler scheduler = null,
-                                                string userErrorMsg = null)
+            this IPublisher bus,
+            IObservable<bool> canExecute,
+            IEnumerable<Func<object, Event>> eventFuncs,
+            IScheduler scheduler = null,
+            string userErrorMsg = null)
         {
             return PublishEventsEx(bus, eventFuncs, canExecute, scheduler, userErrorMsg);
         }
@@ -588,11 +602,12 @@ namespace ReactiveDomain.UI
         /// BuildPublishEventEx() does the same thing as BuildPublishEvent(), except eventFuncs must be defined
         /// as a function that takes an object as input and returns a Command as result.
         /// </summary>
-        /// <param name="bus"></param>
-        /// <param name="eventFuncs"></param>
-        /// <param name="scheduler"></param>
-        /// <param name="userErrorMsg"></param>
-        /// <returns></returns>
+        /// <param name="bus">The bus on which to publish the Event.</param>
+        /// <param name="eventFuncs">A collection of anonymous functions that each return an <see cref="Event"/> to publish.</param>
+        /// <param name="scheduler">The scheduler on which to run the <see cref="ReactiveCommand"/>.</param>
+        /// <param name="userErrorMsg">An error message to present if the Event handler throws. Event handlers should never throw,
+        /// so this would indicate a programming error.</param>
+        /// <returns>A <see cref="ReactiveCommand"/> that publishes the provided <see cref="Event"/>.</returns>
         public static ReactiveCommand<object, Unit> BuildPublishEventsEx(
                                                 this IPublisher bus,
                                                 IEnumerable<Func<object, Event>> eventFuncs,
@@ -631,7 +646,7 @@ namespace ReactiveDomain.UI
                         {
                             // This will return the recovery option returned from the registered user error handler,
                             // e.g. a simple message box in the view code behind
-                            /* n.b. this forces evaluation/execution of the select many  */
+                            /* n.b. this forces evaluation/execution of the select many */
                         });
             return cmd;
         }

--- a/src/ReactiveDomain.UI/ViewObjects/Interactions.cs
+++ b/src/ReactiveDomain.UI/ViewObjects/Interactions.cs
@@ -2,13 +2,18 @@
 
 namespace ReactiveDomain.UI
 {
+    /// <summary>
+    /// A wrapper for ReactiveUI Interactions that re-implements the legacy recovery options.
+    /// </summary>
     public static class Interactions
     {
+        /// <summary>
+        /// A wrapper for a <see cref="UserError"/> with custom recovery options to cancel, retry, or fail.
+        /// </summary>
         public static readonly Interaction<UserError, RecoveryOptionResult> Errors = new Interaction<UserError, RecoveryOptionResult>();
 
         /// <summary>
-        /// RecoveryOptionResult describes to the code throwing the error what to do
-        /// once the error is resolved. This is adapted from legacy UserError code.
+        /// Describes to the code throwing the error what to do once the error is resolved.
         /// </summary>
         public enum RecoveryOptionResult
         {

--- a/src/ReactiveDomain.UI/ViewObjects/Threading.cs
+++ b/src/ReactiveDomain.UI/ViewObjects/Threading.cs
@@ -4,8 +4,14 @@ using System.Threading.Tasks;
 
 namespace ReactiveDomain.UI
 {
+    /// <summary>
+    /// Static methods for running actions on different threads.
+    /// </summary>
     public static class Threading
     {
+        /// <summary>
+        /// The current <see cref="DispatcherScheduler"/> if available, otherwise the <see cref="ThreadPoolScheduler"/>
+        /// </summary>
         public static IScheduler MainThreadScheduler
         {
             get
@@ -21,6 +27,10 @@ namespace ReactiveDomain.UI
             }
         }
 
+        /// <summary>
+        /// Runs the specified action on the Dispatcher once the Dispatcher is not busy.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
         public static void RunOnUiThreadAsync(Action action)
         {
             if (System.Windows.Application.Current?.Dispatcher.CheckAccess() ?? false)
@@ -31,24 +41,36 @@ namespace ReactiveDomain.UI
             Task.Run(() => RunOnUiThread(_ => action()));
         }
 
+        /// <summary>
+        /// Runs the specified action on the Dispatcher immediately.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
         public static void RunOnUiThread(Action action)
         {
             RunOnUiThread(_ => action());
         }
 
-        public static void RunOnUiThread(Action<object> action, object parm = null, bool fallback = true)
+        /// <summary>
+        /// Runs the specified action on the Dispatcher immediately, using the specified object as input to the action.
+        /// </summary>
+        /// <param name="action">The action to run.</param>
+        /// <param name="param">The input to the action.</param>
+        /// <param name="fallback">If <c>true</c> and the Dispatcher does not exist, e.g., when calling from a unit test,
+        /// run the action on the calling thread.</param>
+        /// <exception cref="InvalidOperationException">The Dispatcher does not exist and <paramref name="fallback"/> is <c>false</c>.</exception>
+        public static void RunOnUiThread(Action<object> action, object param = null, bool fallback = true)
         {
             if (System.Windows.Application.Current?.Dispatcher.CheckAccess() ?? false)
             {
-                action(parm); // we're on the ui thread, just go for it
+                action(param); // we're on the ui thread, just go for it
                 return;
             }
             // Execute the action on the UI thread.  Note that we sometimes call this
             // function from a unit-test, in which case there IS no UI thread.
             if (System.Windows.Application.Current != null)
-                System.Windows.Application.Current.Dispatcher.Invoke(action, parm);
+                System.Windows.Application.Current.Dispatcher.Invoke(action, param);
             else if (fallback)
-                action(parm);
+                action(param);
             else
                 throw new InvalidOperationException("Unable to run on UI thread!");
         }

--- a/src/ReactiveDomain.UI/ViewObjects/UserError.cs
+++ b/src/ReactiveDomain.UI/ViewObjects/UserError.cs
@@ -7,14 +7,20 @@ namespace ReactiveDomain.UI
     /// </summary>
     public class UserError
     {
+        /// <summary>
+        /// The user-facing message to present.
+        /// </summary>
         public readonly string ErrorMessage;
+        /// <summary>
+        /// The <see cref="Exception"/> associated with this error.
+        /// </summary>
         public readonly Exception Ex;
 
         /// <summary>
         /// Create a new immutable UserError.
         /// </summary>
-        /// <param name="errorMessage"></param>
-        /// <param name="ex"></param>
+        /// <param name="errorMessage">The user-facing message to present.</param>
+        /// <param name="ex">The <see cref="Exception"/> associated with this error.</param>
         public UserError(
             string errorMessage,
             Exception ex)


### PR DESCRIPTION
All `public` methods, properties, fields, enums, etc. in the ReactiveDomain.UI and ReactiveDomain.UI.Testing projects now have complete and up-to-date XML comments for Intellisense.

Also implemented a minor performance improvement in ReactiveDomain.UI.Testing.Asserts. The new code uses an expression lambda instead of a method group since the latter creates an anonymous delegate at runtime, which is slower.