### PR TITLE
Add supporting docs for the repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+<!--
+Please note that although we can't commit to any timeline, priority will be given to those who are [Contributors](https://github.com/ReactiveDomain/reactive-domain#contribute ) to the project.
+-->
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**Steps To Reproduce**
+<!--
+Provide the steps to reproduce the behaviour:
+
+​	Either link a Repo showing the error, this gives us most context for your use case scenario.
+
+​	OR Following these steps
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+**Expected behaviour**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Environment**
+<!-- Please complete the following information. -->
+- .NET version:       <!-- [e.g. .NET Core 3.1] -->
+- ReactiveDomain Version:    <!-- [e.g. 0.8.22.1] -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+<!--
+Please note that although we can't commit to any timeline, priority will be given to those who are [Contributors](https://github.com/ReactiveDomain/reactive-domain#contribute ) to the project.
+-->
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. -->
+
+
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+
+
+**Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+
+
+**Describe suggestions on how to achieve the feature**
+<!-- A clear description to how to achieve the feature. -->
+
+
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+**What does this pull request do?**
+<!-- A clear and concise description of the goal of this pull request -->
+
+
+**How does this pull request accomplish that goal?**
+<!-- A clear and concise description of the implementation -->
+
+
+**Why is this pull request important?**
+<!-- What does this do that couldn't be accomplished before? -->
+
+
+**Link to any issues that this resolves**
+<!--
+e.g. "Resolves #60"
+
+    OR
+
+"This does not address any open issues."
+-->
+
+
+**Checklist**
+- [ ] All unit tests in the solution must pass on all versions of .NET that the solution supports
+- [ ] Any new code must be covered by at least one unit test
+- [ ] All public methods must be documented with XML comments

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[the Reactive Domain Slack org](https://reactivedomain.slack.com).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We welcome well-considered feature requests. For **major features**, please enga
 ## <a href="code"></a>Coding
 ### Development Environment
 - Visual Studio 2022 (with latest patches/updates)
-- All versions of .NET currently supported in the solution: Framework 4.5.2, Framework 4.7.2, Core 2.0. Check back here as the supported versions will be updated soon.
+- All versions of .NET currently supported in the solution: .NET Framework 4.8 & .NET 5.0.
 
 ### Coding Guidelines
 When submitting a Pull Request, keep these rules in mind:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to ReactiveDomain
+
+Contributions can take many forms: open an issue, contribute code, enhance the documentation. We welcome contribtutions of any sort to ReactiveDomain. Here are some things to keep in mind when contributing:
+
+- [Code of Conduct](https://github.com/ReactiveDomain/reactive-domain/CODE_OF_CONDUCT.md)
+- [Issues](#issues)
+- [Feature Requests](#requests)
+- [Coding](#coding)
+
+## <a href="issues"></a>Issues and Bugs
+Found a bug in the code or documentation? Submit an issue. Even better, submit a Pull Request to fix it!
+
+## <a href="requests"></a>Feature Requests
+We welcome well-considered feature requests. For **major features**, please engage with us in Slack first to discuss it and work out the details. For **minor features**, feel free to submit a Pull Request right away.
+
+## <a href="code"></a>Coding
+### Development Environment
+- Visual Studio 2022 (with latest patches/updates)
+- All versions of .NET currently supported in the solution: Framework 4.5.2, Framework 4.7.2, Core 2.0. Check back here as the supported versions will be updated soon.
+
+### Coding Guidelines
+When submitting a Pull Request, keep these rules in mind:
+- All unit tests in the solution must pass on all versions of .NET that the solution supports
+- Any new code must be covered by at least one unit test
+- All public methods must be documented with XML comments

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Contributions can take many forms: open an issue, contribute code, enhance the d
 Found a bug in the code or documentation? Submit an issue. Even better, submit a Pull Request to fix it!
 
 ## <a href="requests"></a>Feature Requests
-We welcome well-considered feature requests. For **major features**, please engage with us in Slack first to discuss it and work out the details. For **minor features**, feel free to submit a Pull Request right away.
+We welcome well-considered feature requests. For **major features**, please engage with us in [Slack](https://reactivedomain.slack.com) first to discuss it and work out the details. For **minor features**, feel free to submit a Pull Request right away.
 
 ## <a href="code"></a>Coding
 ### Development Environment

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# reactive-domain
-
 [![Build status](https://ci.appveyor.com/api/projects/status/oir89k5nyyouqtsm?svg=true)](https://ci.appveyor.com/project/jageall/reactive-domain)
 [![Build Status](https://travis-ci.org/linedata/reactive-domain.svg?branch=master)](https://travis-ci.org/linedata/reactive-domain)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
+
+# Reactive Domain
+
+## Overview
+
+Reactive Domain is an open source framework for implementing event sourcing in .NET projects using reactive programming principles. This includes interfaces for using [EventStoreDB](https://eventstore.com). It also provides a messaging framework and other tools for using CQRS.
+
+The framework is highly opinionated. It focuses on using a small number of consistent patterns and design principles in its public interfaces to enable developers to get up to speed quickly. Ease of use and "design for code review" have been the driving forces behind the framework's evolution. Where trade-offs have been necessary, these principles have been emphasized over performance.
+
+## Contributing
+
+Pull requests are welcome! Take a look at the open issues, join our [discussion on Slack](https://reactivedomain.slack.com), or contribute in an area where you see a need. Contributors and participants on our Slack channels are expected to abide by the project's [code of conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ The framework is highly opinionated. It focuses on using a small number of consi
 
 ## Contributing
 
-Pull requests are welcome! Take a look at the open issues, join our [discussion on Slack](https://reactivedomain.slack.com), or contribute in an area where you see a need. Contributors and participants on our Slack channels are expected to abide by the project's [code of conduct](CODE_OF_CONDUCT.md).
+Pull requests are welcome! Take a look at the open issues, join our [discussion on Slack](https://reactivedomain.slack.com), or contribute in an area where you see a need. Contributors and participants on our Slack channels are expected to abide by the project's [code of conduct](CODE_OF_CONDUCT.md). Read the full guidelines on [contributing](CONTRIBUTING.md).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,3 @@
+# Support
+
+For help getting started with ReactiveDomain or to discuss issues you encounter, join the [discussion on Slack](https://reactivedomain.slack.com).


### PR DESCRIPTION
Add a number of docs that are supported automatically by GitHub to make it easier for visitors to use the repo.
- Enhanced README
- Code of conduct
- Templates for bug and feature request Issues
- Template for pull requests
- Guidelines for contributing to the project
- Brief support doc to be shown, e.g., on the New Issue page

This is a draft for now. The code of conduct needs to be updated with better contact info before this will be ready to pull.