### PR TITLE
Add IsConnected to TcpBusClientSide

### DIFF
--- a/src/ReactiveDomain.Transport.Tests/ReactiveDomain.Transport.Tests.csproj
+++ b/src/ReactiveDomain.Transport.Tests/ReactiveDomain.Transport.Tests.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
+    <ProjectReference Include="..\ReactiveDomain.Testing\ReactiveDomain.Testing.csproj" />
     <ProjectReference Include="..\ReactiveDomain.Transport\ReactiveDomain.Transport.csproj" />
   </ItemGroup>
 </Project>

--- a/src/ReactiveDomain.Transport.Tests/TcpBusClientSideTests.cs
+++ b/src/ReactiveDomain.Transport.Tests/TcpBusClientSideTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using ReactiveDomain.Messaging;
 using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
 using ReactiveDomain.Transport.Serialization;
 using Xunit;
 
@@ -68,8 +69,8 @@ namespace ReactiveDomain.Transport.Tests
 
             clientInbound.Start();
 
-            // wait for tcp connection to be established (maybe an api to detect this would be nice)
-            Thread.Sleep(TimeSpan.FromMilliseconds(200));
+            // wait for tcp connection to be established
+            AssertEx.IsOrBecomesTrue(() => _tcpBusClientSide.IsConnected, 200);
         }
 
         [Fact]

--- a/src/ReactiveDomain.Transport.Tests/TcpBusServerSideTests.cs
+++ b/src/ReactiveDomain.Transport.Tests/TcpBusServerSideTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ReactiveDomain.Messaging;
 using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
 using Xunit;
 
 namespace ReactiveDomain.Transport.Tests
@@ -43,8 +44,8 @@ namespace ReactiveDomain.Transport.Tests
             // client side
             var tcpBusClientSide = new TcpBusClientSide(_hostAddress, port);
 
-            // wait for tcp connection to be established (maybe an api to detect this would be nice)
-            Thread.Sleep(TimeSpan.FromMilliseconds(200));
+            // wait for tcp connection to be established
+            AssertEx.IsOrBecomesTrue(() => tcpBusClientSide.IsConnected, 200);
 
             // put message into client
             tcpBusClientSide.Handle(new WoftamEvent(prop1, prop2));
@@ -81,8 +82,8 @@ namespace ReactiveDomain.Transport.Tests
             // client side
             var tcpBusClientSide = new TcpBusClientSide(_hostAddress, port);
 
-            // wait for tcp connection to be established (maybe an api to detect this would be nice)
-            Thread.Sleep(TimeSpan.FromMilliseconds(200));
+            // wait for tcp connection to be established
+            AssertEx.IsOrBecomesTrue(() => tcpBusClientSide.IsConnected, 200);
 
             // put disallowed message into client
             tcpBusClientSide.Handle(new WoftamCommand("abc"));

--- a/src/ReactiveDomain.Transport/TcpBusClientSide.cs
+++ b/src/ReactiveDomain.Transport/TcpBusClientSide.cs
@@ -14,6 +14,8 @@ namespace ReactiveDomain.Transport
 {
     public sealed class TcpBusClientSide : TcpBus
     {
+        public bool IsConnected { get; private set; }
+
         public TcpBusClientSide(
             EndPoint endpoint,
             IEnumerable<Type> inboundDiscardingMessageTypes,
@@ -66,11 +68,12 @@ namespace ReactiveDomain.Transport
                     conn =>
                     {
                         Log.Debug($"TcpBusClientSide.CreateTcpConnection({endPoint}) successfully constructed TcpConnection.");
-
+                        IsConnected = true;
                         ConfigureTcpListener(conn);
                     },
                     (conn, err) =>
                     {
+                        IsConnected = false;
                         HandleError(conn, err);
                     },
                     verbose: true);


### PR DESCRIPTION
Adds an `IsConnected` property to the `TcpBusClientSide` so we don't need to put in a delay or otherwise guess when a connection has been established.