### PR TITLE
`ReadModelBase` can use a `StreamReader` for performance

### DIFF
--- a/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base_with_reader.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base_with_reader.cs
@@ -1,0 +1,237 @@
+﻿using System;
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests
+{
+    // ReSharper disable once InconsistentNaming
+    public class when_using_read_model_base_with_reader :
+                    ReadModelBase,
+                    IHandle<when_using_read_model_base_with_reader.ReadModelTestEvent>,
+                    IClassFixture<StreamStoreConnectionFixture>
+    {
+        private static IStreamStoreConnection _conn;
+        private static readonly IEventSerializer Serializer =
+            new JsonMessageSerializer();
+        private static readonly IStreamNameBuilder Namer =
+            new PrefixedCamelCaseStreamNameBuilder(nameof(when_using_read_model_base));
+
+        private readonly string _stream1;
+        private readonly string _stream2;
+
+
+        public when_using_read_model_base_with_reader(StreamStoreConnectionFixture fixture)
+                    : base(nameof(when_using_read_model_base),
+                           new ConfiguredConnection(fixture.Connection, Namer, Serializer))
+        {
+            _conn = fixture.Connection;
+            _conn.Connect();
+
+            // ReSharper disable once RedundantTypeArgumentsOfMethod
+            EventStream.Subscribe<ReadModelTestEvent>(this);
+
+            _stream1 = Namer.GenerateForAggregate(typeof(TestAggregate), Guid.NewGuid());
+            _stream2 = Namer.GenerateForAggregate(typeof(TestAggregate), Guid.NewGuid());
+
+            AppendEvents(10, _conn, _stream1, 2);
+            AppendEvents(10, _conn, _stream2, 3);
+            _conn.TryConfirmStream(_stream1, 10);
+            _conn.TryConfirmStream(_stream2, 10);
+            _conn.TryConfirmStream(Namer.GenerateForCategory(typeof(TestAggregate)), 20);
+        }
+
+        private void AppendEvents(
+                        int numEventsToBeSent,
+                        IStreamStoreConnection conn,
+                        string streamName,
+                        int value)
+        {
+            for (int evtNumber = 0; evtNumber < numEventsToBeSent; evtNumber++)
+            {
+                var evt = new ReadModelTestEvent(evtNumber, value);
+                conn.AppendToStream(streamName, ExpectedVersion.Any, null, Serializer.Serialize(evt));
+            }
+        }
+        [Fact]
+        public void can_start_streams_by_aggregate()
+        {
+            var aggId = Guid.NewGuid();
+            var s1 = Namer.GenerateForAggregate(typeof(TestAggregate), aggId);
+            AppendEvents(1, _conn, s1, 7);
+            Start<TestAggregate>(aggId);
+            AssertEx.IsOrBecomesTrue(() => Count == 1, 1000, msg: $"Expected 1 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 7);
+        }
+        [Fact]
+        public void can_start_streams_by_aggregate_category()
+        {
+
+            var s1 = Namer.GenerateForAggregate(typeof(ReadModelTestCategoryAggregate), Guid.NewGuid());
+            AppendEvents(1, _conn, s1, 7);
+            var s2 = Namer.GenerateForAggregate(typeof(ReadModelTestCategoryAggregate), Guid.NewGuid());
+            AppendEvents(1, _conn, s2, 5);
+            Start<ReadModelTestCategoryAggregate>(null, true);
+
+            AssertEx.IsOrBecomesTrue(() => Count == 2, 1000, msg: $"Expected 2 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 12);
+        }
+        [Fact]
+        public void can_read_one_stream()
+        {
+            Start(_stream1);
+            AssertEx.IsOrBecomesTrue(() => Count == 10, 1000, msg: $"Expected 10 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 20);
+            //confirm checkpoints
+            Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
+            Assert.Equal(9, GetCheckpoint()[0].Item2);
+        }
+        [Fact]
+        public void can_read_two_streams()
+        {
+            Start(_stream1);
+            Start(_stream2);
+            AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 50);
+            //confirm checkpoints
+            Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
+            Assert.Equal(9, GetCheckpoint()[0].Item2);
+            Assert.Equal(_stream2, GetCheckpoint()[1].Item1);
+            Assert.Equal(9, GetCheckpoint()[1].Item2);
+        }
+        [Fact]
+        public void can_wait_for_one_stream_to_go_live()
+        {
+            Start(_stream1, null, true);
+            AssertEx.IsOrBecomesTrue(() => Count == 10, 100, msg: $"Expected 10 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 20, 100);
+        }
+        [Fact]
+        public void can_wait_for_two_streams_to_go_live()
+        {
+            Start(_stream1, null, true);
+            AssertEx.IsOrBecomesTrue(() => Count == 10, 100, msg: $"Expected 10 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 20, 100);
+
+            Start(_stream2, null, true);
+            AssertEx.IsOrBecomesTrue(() => Count == 20, 10, msg: $"Expected 20 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 50, 100);
+        }
+        [Fact]
+        public void can_listen_to_one_stream()
+        {
+            Start(_stream1);
+            AssertEx.IsOrBecomesTrue(() => Count == 10, 1000, msg: $"Expected 10 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 20);
+            //add more messages
+            AppendEvents(10, _conn, _stream1, 5);
+            AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 70);
+            //confirm checkpoints
+            Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
+            Assert.Equal(19, GetCheckpoint()[0].Item2); Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
+            Assert.Equal(19, GetCheckpoint()[0].Item2);
+        }
+        [Fact]
+        public void can_listen_to_two_streams()
+        {
+            Start(_stream1);
+            Start(_stream2);
+            AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 50);
+            //add more messages
+            AppendEvents(10, _conn, _stream1, 5);
+            AppendEvents(10, _conn, _stream2, 7);
+            AssertEx.IsOrBecomesTrue(() => Count == 40, 1000, msg: $"Expected 20 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 170);
+            //confirm checkpoints
+            Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
+            Assert.Equal(19, GetCheckpoint()[0].Item2);
+            Assert.Equal(_stream2, GetCheckpoint()[1].Item1);
+            Assert.Equal(19, GetCheckpoint()[1].Item2);
+        }
+        [Fact]
+        public void can_use_checkpoint_on_one_stream()
+        {
+            //restore state
+            var checkPoint = 8L;//Zero based, ignore the first 9 events
+            Count = 9;
+            Sum = 18;
+            //start at the checkpoint
+            Start(_stream1, checkPoint);
+            //add the one recorded event
+            AssertEx.IsOrBecomesTrue(() => Count == 10, 100, msg: $"Expected 10 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 20);
+            //add more messages
+            AppendEvents(10, _conn, _stream1, 5);
+            AssertEx.IsOrBecomesTrue(() => Count == 20, 100, msg: $"Expected 20 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 70);
+            //confirm checkpoints
+            Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
+            Assert.Equal(19, GetCheckpoint()[0].Item2);
+        }
+        [Fact]
+        public void can_use_checkpoint_on_two_streams()
+        {
+            //restore state
+            var checkPoint1 = 8L;//Zero based, ignore the first 9 events
+            var checkPoint2 = 5L;//Zero based, ignore the first 6 events
+            Count = (9) + (6);
+            Sum = (9 * 2) + (6 * 3);
+            Start(_stream1, checkPoint1);
+            Start(_stream2, checkPoint2);
+            //add the recorded events 2 on stream 1 & 5 on stream 2
+            AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 50, msg: $"Expected 50 got {Sum}");
+            //add more messages
+            AppendEvents(10, _conn, _stream1, 5);
+            AppendEvents(10, _conn, _stream2, 7);
+            AssertEx.IsOrBecomesTrue(() => Count == 40, 1000, msg: $"Expected 20 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 170);
+            //confirm checkpoints
+            Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
+            Assert.Equal(19, GetCheckpoint()[0].Item2);
+            Assert.Equal(_stream2, GetCheckpoint()[1].Item1);
+            Assert.Equal(19, GetCheckpoint()[1].Item2);
+        }
+        [Fact]
+        public void can_listen_to_the_same_stream_twice()
+        {
+            Assert.Equal(0, Count);
+            //weird but true
+            //n.b. Don't do this on purpose
+            Start(_stream1);
+            Start(_stream1);
+            //double events
+            AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 40);
+            //even more doubled events
+            AppendEvents(10, _conn, _stream1, 5);
+            AssertEx.IsOrBecomesTrue(() => Count == 40, 2000, msg: $"Expected 40 got {Count}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 140);
+        }
+
+        public long Sum { get; private set; }
+        public long Count { get; private set; }
+        void IHandle<ReadModelTestEvent>.Handle(ReadModelTestEvent @event)
+        {
+            Sum += @event.Value;
+            Count++;
+        }
+        public class ReadModelTestEvent : Event
+        {
+            public readonly int Number;
+            public readonly int Value;
+
+            public ReadModelTestEvent(
+                int number,
+                int value)
+            {
+                Number = number;
+                Value = value;
+            }
+        }
+        public class ReadModelTestCategoryAggregate : EventDrivenStateMachine { }
+    }
+}

--- a/src/ReactiveDomain.Foundation/IListener.cs
+++ b/src/ReactiveDomain.Foundation/IListener.cs
@@ -9,14 +9,15 @@ namespace ReactiveDomain.Foundation
         ISubscriber EventStream { get; }
         long Position { get; }
         string StreamName { get; }
+
         /// <summary>
         /// Starts listening on a named stream
         /// </summary>
         /// <param name="stream">the exact stream name</param>
         /// <param name="checkpoint">start point to listen from</param>
         /// <param name="blockUntilLive">wait for the is live event from the catchup subscription before returning</param>
-        /// <param name="millisecondsTimeout">Timeout to wait before aborting Load defaults to 1000ms</param>
-        void Start(string stream, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken));
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
+        void Start(string stream, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default);
         /// <summary>
         /// Starts listening on an aggregate root stream
         /// </summary>
@@ -24,15 +25,15 @@ namespace ReactiveDomain.Foundation
         /// <param name="id">the aggregate id</param>
         /// <param name="checkpoint">start point to listen from</param>
         /// <param name="blockUntilLive">wait for the is live event from the catchup subscription before returning</param>
-        /// <param name="millisecondsTimeout">Timeout to wait before aborting Load defaults to 1000ms</param>
-        void Start<TAggregate>(Guid id, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken)) where TAggregate : class, IEventSource;
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
+        void Start<TAggregate>(Guid id, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default) where TAggregate : class, IEventSource;
         /// <summary>
         /// Starts listening on a Aggregate Category Stream
         /// </summary>
         /// <typeparam name="TAggregate">The type of aggregate</typeparam>
         /// <param name="checkpoint">start point to listen from</param>
         /// <param name="blockUntilLive">wait for the is live event from the catchup subscription before returning</param>
-        /// <param name="millisecondsTimeout">Timeout to wait before aborting Load defaults to 1000ms</param>
-        void Start<TAggregate>(long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken)) where TAggregate : class, IEventSource;
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
+        void Start<TAggregate>(long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default) where TAggregate : class, IEventSource;
     }
 }

--- a/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
@@ -17,15 +17,39 @@ namespace ReactiveDomain.Foundation
     {
         private readonly Func<IListener> _getListener;
         private readonly List<IListener> _listeners;
+        private readonly Func<IStreamReader> _getReader;
         private readonly InMemoryBus _bus;
         private readonly QueuedHandler _queue;
         public int MessageCount => _queue.MessageCount;
         public bool Idle => _queue.Idle;
+
+        /// <summary>
+        /// Creates a read model using the provided Function to get a listener.
+        /// This is deprecated and will be removed in a future version of ReactiveDomain.
+        /// </summary>
+        /// <param name="name">The name of the read model. Also used as the name of the listener.</param>
+        /// <param name="getListener">A Func to get a new <see cref="IListener"/>.</param>
         protected ReadModelBase(string name, Func<IListener> getListener)
         {
-
             Ensure.NotNull(getListener, nameof(getListener));
             _getListener = getListener;
+            _listeners = new List<IListener>();
+            _bus = new InMemoryBus($"{nameof(ReadModelBase)}:{name} bus", false);
+            _queue = new QueuedHandler(_bus, $"{nameof(ReadModelBase)}:{name} queue");
+            _queue.Start();
+        }
+
+        /// <summary>
+        /// Creates a read model using the provided stream store connection. Reads existing events using a
+        /// reader, then transitions to a listener for live events.
+        /// </summary>
+        /// <param name="name">The name of the read model. Also used as the name of the listener and reader.</param>
+        /// <param name="connection">A connection to a stream store.</param>
+        protected ReadModelBase(string name, IConfiguredConnection connection)
+        {
+            Ensure.NotNull(connection, nameof(connection));
+            _getListener = () => connection.GetListener(name);
+            _getReader = () => connection.GetReader(name, Handle);
             _listeners = new List<IListener>();
             _bus = new InMemoryBus($"{nameof(ReadModelBase)}:{name} bus", false);
             _queue = new QueuedHandler(_bus, $"{nameof(ReadModelBase)}:{name} queue");
@@ -42,6 +66,11 @@ namespace ReactiveDomain.Foundation
             l.EventStream.SubscribeToAll(_queue);
             return l;
         }
+
+        /// <summary>
+        /// Get the positions of all listeners.
+        /// </summary>
+        /// <returns>A list of Tuples of listener names and checkpoints.</returns>
         public List<Tuple<string, long>> GetCheckpoint()
         {
             lock (_listeners)
@@ -50,24 +79,75 @@ namespace ReactiveDomain.Foundation
             }
         }
 
+        /// <summary>
+        /// The stream of events that handlers should subscribe to.
+        /// </summary>
         public ISubscriber EventStream => _bus;
 
-        public void Start(string stream, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken))
+        /// <summary>
+        /// Start playback of a named stream.
+        /// </summary>
+        /// <param name="stream">The name of the stream to play back.</param>
+        /// <param name="checkpoint">The event to start with.</param>
+        /// <param name="blockUntilLive">If true, blocks returning from this method until the listener has caught up.</param>
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true.</param>
+        public void Start(string stream, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default)
         {
-
+            if (_getReader != null)
+            {
+                using (var reader = _getReader())
+                {
+                    reader.Read(stream, () => Idle, checkpoint);
+                    checkpoint = reader.Position;
+                }
+            }
             AddNewListener().Start(stream, checkpoint, blockUntilLive, cancelWaitToken);
         }
 
-        public void Start<TAggregate>(Guid id, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken)) where TAggregate : class, IEventSource
+        /// <summary>
+        /// Start playback of a specific stream of type TAggregate.
+        /// </summary>
+        /// <typeparam name="TAggregate">The type of stream to play back.</typeparam>
+        /// <param name="id">The ID of the stream to play back.</param>
+        /// <param name="checkpoint">The event to start with.</param>
+        /// <param name="blockUntilLive">If true, blocks returning from this method until the listener has caught up.</param>
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true.</param>
+        public void Start<TAggregate>(Guid id, long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default) where TAggregate : class, IEventSource
         {
+            if (_getReader != null)
+            {
+                using (var reader = _getReader())
+                {
+                    reader.Read<TAggregate>(id, () => Idle, checkpoint);
+                    checkpoint = reader.Position;
+                }
+            }
             AddNewListener().Start<TAggregate>(id, checkpoint, blockUntilLive, cancelWaitToken);
         }
 
-        public void Start<TAggregate>(long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default(CancellationToken)) where TAggregate : class, IEventSource
+        /// <summary>
+        /// Start a category listener for type TAggregate.
+        /// </summary>
+        /// <typeparam name="TAggregate">The type of stream to play back.</typeparam>
+        /// <param name="checkpoint">The event to start with.</param>
+        /// <param name="blockUntilLive">If true, blocks returning from this method until the listener has caught up.</param>
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true.</param>
+        public void Start<TAggregate>(long? checkpoint = null, bool blockUntilLive = false, CancellationToken cancelWaitToken = default) where TAggregate : class, IEventSource
         {
+            if (_getReader != null)
+            {
+                using (var reader = _getReader())
+                {
+                    reader.Read<TAggregate>(() => Idle, checkpoint);
+                    checkpoint = reader.Position;
+                }
+            }
             AddNewListener().Start<TAggregate>(checkpoint, blockUntilLive, cancelWaitToken);
         }
 
+        /// <summary>
+        /// Dispose of resources.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamListener.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamListener.cs
@@ -47,6 +47,8 @@ namespace ReactiveDomain.Foundation
         /// <param name="streamNameBuilder">The source for correct stream names based on aggregates and events</param>
         /// <param name="serializer"></param>
         /// <param name="busName">The name to use for the internal bus (helpful in debugging)</param>
+        /// <param name="liveProcessingStarted"></param>
+        /// <param name="subscriptionDropped"></param>
         public StreamListener(
                 string listenerName,
                 IStreamStoreConnection streamStoreConnection,
@@ -72,7 +74,7 @@ namespace ReactiveDomain.Foundation
         /// <param name="tMessage"></param>
         /// <param name="checkpoint"></param>
         /// <param name="blockUntilLive"></param>
-        /// <param name="waitToken">Cancelation token to cancel waiting if blockUntilLive is true</param>
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
         public void Start(
             Type tMessage,
             long? checkpoint = null,
@@ -96,7 +98,7 @@ namespace ReactiveDomain.Foundation
         /// <typeparam name="TAggregate">The Aggregate type used to generate the stream name</typeparam>
         /// <param name="checkpoint"></param>
         /// <param name="blockUntilLive"></param>
-        /// <param name="waitToken">Cancelation token to cancel waiting if blockUntilLive is true</param>
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
         public void Start<TAggregate>(
                         long? checkpoint = null,
                         bool blockUntilLive = false,
@@ -118,7 +120,7 @@ namespace ReactiveDomain.Foundation
         /// <param name="id"></param>
         /// <param name="checkpoint"></param>
         /// <param name="blockUntilLive"></param>
-        /// <param name="waitToken">Cancelation token to cancel waiting if blockUntilLive is true</param>
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
         public void Start<TAggregate>(
                         Guid id,
                         long? checkpoint = null,
@@ -139,7 +141,7 @@ namespace ReactiveDomain.Foundation
         /// <param name="streamName"></param>
         /// <param name="checkpoint"></param>
         /// <param name="blockUntilLive"></param>
-        /// <param name="waitToken">Cancelation token to cancel waiting if blockUntilLive is true</param>
+        /// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true</param>
         public virtual void Start(
                             string streamName,
                             long? checkpoint = null,
@@ -187,6 +189,7 @@ namespace ReactiveDomain.Foundation
                 (subscriptionDropped ?? _subscriptionDropped)?.Invoke(r, e);
             };
 
+            Interlocked.Exchange(ref StreamPosition, lastCheckpoint ?? 0);
             var sub = _streamStoreConnection.SubscribeToStreamFrom(
                 stream,
                 lastCheckpoint,

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
@@ -1,5 +1,4 @@
 ﻿using ReactiveDomain.Messaging;
-using ReactiveDomain.Messaging.Bus;
 using ReactiveDomain.Util;
 using System;
 using System.Threading;
@@ -8,12 +7,10 @@ using System.Threading;
 namespace ReactiveDomain.Foundation
 {
     /// <summary>
-    /// StreamReader
-    /// This class reads streams on a Subscribable bus and is primarily used in the building of read models. 
+    /// This class reads streams and is primarily used in the building of read models. 
     /// The Raw events returned from the Stream will be unwrapped using the provided serializer and
-    /// consumers can subscribe to event notifications by subscribing to the exposed EventStream.
+    /// handed to the injected handler.
     ///</summary>
-
     public class StreamReader : IStreamReader
     {
         protected readonly string ReaderName;
@@ -35,8 +32,8 @@ namespace ReactiveDomain.Foundation
         /// <param name="name">Name of the reader</param>
         /// <param name="streamStoreConnection">The stream store to subscribe to</param>
         /// <param name="streamNameBuilder">The source for correct stream names based on aggregates and events</param>
-        /// <param name="serializer">the serializer to apply to the evenets in the stream</param>
-        /// <param name="handle">The target handle read events are passed to</param>
+        /// <param name="serializer">the serializer to apply to the events in the stream</param>
+        /// <param name="handle">The target handle that read events are passed to</param>
         public StreamReader(
                 string name,
                 IStreamStoreConnection streamStoreConnection,
@@ -56,8 +53,8 @@ namespace ReactiveDomain.Foundation
         /// i.e. $et-[MessageType]
         /// </summary>
         /// <param name="tMessage">The message type used to generate the stream (projection) name</param>
-        /// <param name="completionCheck">Read will block until true to ensure processing has completed, use '()=> true' to continue without blocking. If cancelation or timeout is required it should be implemented in the completion method</param>
-        /// <param name="checkpoint">The starting point to read from.</param>
+        /// <param name="completionCheck">Read will block until true to ensure processing has completed, use '()=> true' to continue without blocking. If cancellation or timeout is required it should be implemented in the completion method</param>
+        /// <param name="checkpoint">The event number of the last received event. Reading will start with the next event.</param>
         /// <param name="count">The count of items to read</param>
         /// <param name="readBackwards">Read the stream backwards</param>
         /// <returns>Returns true if any events were read from the stream</returns>
@@ -77,9 +74,9 @@ namespace ReactiveDomain.Foundation
             return Read(
                 _streamNameBuilder.GenerateForEventType(tMessage.Name),
                 completionCheck,
-               checkpoint,
-               count,
-               readBackwards);
+                checkpoint,
+                count,
+                readBackwards);
         }
 
         /// <summary>
@@ -87,8 +84,8 @@ namespace ReactiveDomain.Foundation
         /// i.e. $ce-[AggregateType]
         /// </summary>
         /// <typeparam name="TAggregate">The Aggregate type used to generate the stream name</typeparam>
-        /// <param name="completionCheck">Read will block until true to ensure processing has completed, use '()=> true' to continue without blocking. If cancelation or timeout is required it should be implemented in the completion method</param>
-        /// <param name="checkpoint">The starting point to read from.</param>
+        /// <param name="completionCheck">Read will block until true to ensure processing has completed, use '()=> true' to continue without blocking. If cancellation or timeout is required it should be implemented in the completion method</param>
+        /// <param name="checkpoint">The event number of the last received event. Reading will start with the next event.</param>
         /// <param name="count">The count of items to read</param>
         /// <param name="readBackwards">Read the stream backwards</param>
         /// <returns>Returns true if any events were read from the stream</returns>
@@ -113,8 +110,8 @@ namespace ReactiveDomain.Foundation
         /// </summary>
         /// <typeparam name="TAggregate">The Aggregate type used to generate the stream name</typeparam>
         /// <param name="id">Aggregate id to generate stream name.</param>
-        /// <param name="completionCheck">Read will block until true to ensure processing has completed, use '()=> true' to continue without blocking. If cancelation or timeout is required it should be implemented in the completion method</param>
-        /// <param name="checkpoint">The starting point to read from.</param>
+        /// <param name="completionCheck">Read will block until true to ensure processing has completed, use '()=> true' to continue without blocking. If cancellation or timeout is required it should be implemented in the completion method</param>
+        /// <param name="checkpoint">The event number of the last received event. Reading will start with the next event.</param>
         /// <param name="count">The count of items to read</param>
         /// <param name="readBackwards">Read the stream backwards</param>
         /// <returns>Returns true if any events were read from the stream</returns>
@@ -138,8 +135,8 @@ namespace ReactiveDomain.Foundation
         /// i.e. [StreamName]
         /// </summary>
         /// <param name="streamName">An exact stream name.</param>
-        /// <param name="completionCheck">Read will block until true to ensure processing has completed, use '()=> true' to continue without blocking. If cancelation or timeout is required it should be implemented in the completion method</param>
-        /// <param name="checkpoint">The starting point to read from.</param>
+        /// <param name="completionCheck">Read will block until true to ensure processing has completed, use '()=> true' to continue without blocking. If cancellation or timeout is required it should be implemented in the completion method</param>
+        /// <param name="checkpoint">The event number of the last received event. Reading will start with the next event.</param>
         /// <param name="count">The count of items to read</param>
         /// <param name="readBackwards">Read the stream backwards</param>
         /// <returns>Returns true if any events were read from the stream</returns>
@@ -150,8 +147,6 @@ namespace ReactiveDomain.Foundation
                             long? count = null,
                             bool readBackwards = false)
         {
-
-
             if (checkpoint != null)
                 Ensure.Nonnegative((long)checkpoint, nameof(checkpoint));
             if (count != null)
@@ -162,7 +157,11 @@ namespace ReactiveDomain.Foundation
             _cancelled = false;
             FirstEventRead = false;
             StreamName = streamName;
-            long sliceStart = checkpoint ?? (readBackwards ? -1 : 0);
+            long sliceStart;
+            if (checkpoint is null)
+                sliceStart = readBackwards ? -1 : 0;
+            else
+                sliceStart = checkpoint.Value + (readBackwards ? -1 : 1);
             long remaining = count ?? long.MaxValue;
             StreamEventsSlice currentSlice;
 
@@ -185,11 +184,17 @@ namespace ReactiveDomain.Foundation
             if (FirstEventRead && completionCheck != null) { SpinWait.SpinUntil(() => { try { return completionCheck(); } catch { return true; } }); }
             return FirstEventRead;
         }
+
+        /// <summary>
+        /// Determines whether the string is the name of an existing stream.
+        /// </summary>
+        /// <param name="streamName">The stream name to validate.</param>
         public bool ValidateStreamName(string streamName)
         {
             var currentSlice = _streamStoreConnection.ReadStreamForward(streamName, 0, 1);
             return !(currentSlice is StreamDeletedSlice);
         }
+
         protected virtual void EventRead(RecordedEvent recordedEvent)
         {
             // do not publish or increase counters if cancelled
@@ -204,6 +209,9 @@ namespace ReactiveDomain.Foundation
             }
         }
 
+        /// <summary>
+        /// Cancels reading the stream.
+        /// </summary>
         public void Cancel()
         {
             _cancelled = true;


### PR DESCRIPTION
- Keeps existing ctor of `ReadModelBase` but tags it for future removal.
- New ctor takes an `IConfiguredConnection` instead of a `Func<IListener>`. After playing back historical events with a `StreamReader`, `ReadModelBase.Start()` switches to a `StreamListener`.
- Resolves #112.
- When starting a `StreamListener` from a checkpoint, sets the `StreamPosition` to the checkpoint before reading any events so that immediate queries will return the checkpoint as the current stream position.
- Cleans up some XML comments