### PR TITLE
Add netstandard2.0 support to `ReactiveDomain.UI` and `ReactiveDomain.UI.Testing` projects

### DIFF
--- a/src/ReactiveDomain.UI.Debug.nuspec
+++ b/src/ReactiveDomain.UI.Debug.nuspec
@@ -9,22 +9,31 @@
     <license type="expression">MIT</license>
     <description>Package includes all ReactiveDomain UI assembly</description>
     <copyright>Copyright © 2014-2022 PerkinElmer, Linedata Inc.</copyright>
-
-    <dependencies>     
+    <dependencies>
       <group targetFramework="net48">
         <dependency id="ReactiveDomain" version="0.9.0.0" exclude="Build,Analyzers" />
-        <dependency id="ReactiveUI" version="8.7.2" exclude="Build,Analyzers" />
+        <dependency id="ReactiveUI" version="9.22.1" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="netstandard2.0">
+        <dependency id="ReactiveDomain" version="0.9.0.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveUI" version="9.22.1" exclude="Build,Analyzers" />
       </group>
     </dependencies>
-    <references>      
+    <references>
       <group targetFramework="net48">
+        <reference file="ReactiveDomain.UI.dll" />
+      </group>
+      <group targetFramework="netstandard2.0">
         <reference file="ReactiveDomain.UI.dll" />
       </group>
     </references>    
   </metadata>
   <files>
     <file src="..\bld\Debug\net48\ReactiveDomain.UI.dll" target="lib\net48" />
-    <file src="..\bld\Debug\net48\ReactiveDomain.UI.dll" target="ref\net48" />
     <file src="..\bld\Debug\net48\ReactiveDomain.UI.pdb" target="lib\net48" />
+    <file src="..\bld\Debug\net48\ReactiveDomain.UI.dll" target="ref\net48" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.UI.dll" target="lib\netstandard2.0" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.UI.pdb" target="lib\netstandard2.0" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.UI.dll" target="ref\netstandard2.0" />
   </files>
 </package>

--- a/src/ReactiveDomain.UI.Testing.Debug.nuspec
+++ b/src/ReactiveDomain.UI.Testing.Debug.nuspec
@@ -8,11 +8,13 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <description>Package includes all ReactiveDomain UI assemblies for unit testing</description>
-    <copyright>Copyright © 2014-2022 PerkinElmer, Linedata Inc.</copyright>
-
+    <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework="net48">
-        <dependency id="Microsoft.NET.Test.Sdk" version="16.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.Testing" version="0.9.0.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.UI" version="0.9.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="netstandard2.0">
         <dependency id="ReactiveDomain.Testing" version="0.9.0.0" exclude="Build,Analyzers" />
         <dependency id="ReactiveDomain.UI" version="0.9.0.0" exclude="Build,Analyzers" />
       </group>
@@ -21,11 +23,17 @@
       <group targetFramework="net48">
         <reference file="ReactiveDomain.UI.Testing.dll" />
       </group>
+      <group targetFramework="netstandard2.0">
+        <reference file="ReactiveDomain.UI.Testing.dll" />
+      </group>
     </references>   
   </metadata>
   <files>
     <file src="..\bld\Debug\net48\ReactiveDomain.UI.Testing.dll" target="lib\net48" />
-    <file src="..\bld\Debug\net48\ReactiveDomain.UI.Testing.dll" target="ref\net48" />
     <file src="..\bld\Debug\net48\ReactiveDomain.UI.Testing.pdb" target="lib\net48" />
+    <file src="..\bld\Debug\net48\ReactiveDomain.UI.Testing.dll" target="ref\net48" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.UI.Testing.dll" target="lib\netstandard2.0" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.UI.Testing.pdb" target="lib\netstandard2.0" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.UI.Testing.dll" target="ref\netstandard2.0" />
   </files>
 </package>

--- a/src/ReactiveDomain.UI.Testing.nuspec
+++ b/src/ReactiveDomain.UI.Testing.nuspec
@@ -10,8 +10,11 @@
     <description>Package includes all ReactiveDomain UI assemblies for unit testing</description>
     <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>
-      <group targetFramework=".NETFramework48">
-        <dependency id="Microsoft.NET.Test.Sdk" version="16.2.0" exclude="Build,Analyzers" />
+      <group targetFramework="net48">
+        <dependency id="ReactiveDomain.Testing" version="0.9.0.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.UI" version="0.9.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="netstandard2.0">
         <dependency id="ReactiveDomain.Testing" version="0.9.0.0" exclude="Build,Analyzers" />
         <dependency id="ReactiveDomain.UI" version="0.9.0.0" exclude="Build,Analyzers" />
       </group>
@@ -20,14 +23,17 @@
       <group targetFramework=".NETFramework48">
         <reference file="ReactiveDomain.UI.Testing.dll" />
       </group>
+      <group targetFramework="netstandard2.0">
+        <reference file="ReactiveDomain.UI.Testing.dll" />
+      </group>
     </references>
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="Microsoft.CSharp" targetFramework=".NETFramework4.0" />
-    </frameworkAssemblies>
   </metadata>
   <files>
     <file src="..\bld\Release\net48\ReactiveDomain.UI.Testing.dll" target="lib\net48" />
     <file src="..\bld\Release\net48\ReactiveDomain.UI.Testing.pdb" target="lib\net48" />
     <file src="..\bld\Release\net48\ReactiveDomain.UI.Testing.dll" target="ref\net48" />
+    <file src="..\bld\Release\netstandard2.0\ReactiveDomain.UI.Testing.dll" target="lib\netstandard2.0" />
+    <file src="..\bld\Release\netstandard2.0\ReactiveDomain.UI.Testing.pdb" target="lib\netstandard2.0" />
+    <file src="..\bld\Release\netstandard2.0\ReactiveDomain.UI.Testing.dll" target="ref\netstandard2.0" />
   </files>
 </package>

--- a/src/ReactiveDomain.UI.Testing/ReactiveDomain.UI.Testing.csproj
+++ b/src/ReactiveDomain.UI.Testing/ReactiveDomain.UI.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../ci.build.imports" />
   <PropertyGroup>
-    <TargetFrameworks>net48</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/ReactiveDomain.UI.Testing/ReactiveDomain.UI.Testing.csproj
+++ b/src/ReactiveDomain.UI.Testing/ReactiveDomain.UI.Testing.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" Condition="'$(TargetFramework)'=='net48'">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/ReactiveDomain.UI.nuspec
+++ b/src/ReactiveDomain.UI.nuspec
@@ -10,23 +10,30 @@
     <description>Package includes ReactiveDomain UI assembly</description>
     <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>
-      <group targetFramework=".NETFramework48">
+      <group targetFramework="net48">
         <dependency id="ReactiveDomain" version="0.9.0.0" exclude="Build,Analyzers" />
-        <dependency id="reactiveui" version="9.22.1" exclude="Build,Analyzers" />
+        <dependency id="ReactiveUI" version="9.22.1" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="netstandard2.0">
+        <dependency id="ReactiveDomain" version="0.9.0.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveUI" version="9.22.1" exclude="Build,Analyzers" />
       </group>
     </dependencies>
     <references>
-      <group targetFramework=".NETFramework48">
+      <group targetFramework="net48">
+        <reference file="ReactiveDomain.UI.dll" />
+      </group>
+      <group targetFramework="netstandard2.0">
         <reference file="ReactiveDomain.UI.dll" />
       </group>
     </references>
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="Microsoft.CSharp" targetFramework=".NETFramework4.0" />
-    </frameworkAssemblies>
   </metadata>
   <files>
     <file src="..\bld\Release\net48\ReactiveDomain.UI.dll" target="lib\net48" />
-    <file src="..\bld\Release\net48\ReactiveDomain.UI.pdb" target="lib\net48" />
+    <file src="..\bld\Debug\net48\ReactiveDomain.UI.pdb" target="lib\net48" />
     <file src="..\bld\Release\net48\ReactiveDomain.UI.dll" target="ref\net48" />
+    <file src="..\bld\Release\netstandard2.0\ReactiveDomain.UI.dll" target="lib\netstandard2.0" />
+    <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.UI.pdb" target="lib\netstandard2.0" />
+    <file src="..\bld\Release\netstandard2.0\ReactiveDomain.UI.dll" target="ref\netstandard2.0" />
   </files>
 </package>

--- a/src/ReactiveDomain.UI/ReactiveDomain.UI.csproj
+++ b/src/ReactiveDomain.UI/ReactiveDomain.UI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../ci.build.imports" />
   <PropertyGroup>
-    <TargetFrameworks>net48</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
  

--- a/src/ReactiveDomain.UI/ViewObjects/Threading.cs
+++ b/src/ReactiveDomain.UI/ViewObjects/Threading.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if NET48
+using System;
 using System.Reactive.Concurrency;
 using System.Threading.Tasks;
 
@@ -76,3 +77,4 @@ namespace ReactiveDomain.UI
         }
     }
 }
+#endif


### PR DESCRIPTION
The `Threading` class in `ReactiveDomain.UI` is only supported with .NET Framework 4.8 since it has dependencies that are unsupported in .NET Standard 2.0.