### PR TITLE
Roles are case-insensitive

### DIFF
--- a/src/ReactiveDomain.Policy/Policy.cs
+++ b/src/ReactiveDomain.Policy/Policy.cs
@@ -38,7 +38,7 @@ namespace ReactiveDomain.Policy
         public bool Equals(Policy other)
         {
             if (other is null) return false;           
-            return string.Equals(PolicyName, other.PolicyName);
+            return string.Equals(PolicyName, other.PolicyName, StringComparison.OrdinalIgnoreCase);
         }
        
         public override bool Equals(object obj) => Equals(obj as Policy);

--- a/src/ReactiveDomain.Policy/Role.cs
+++ b/src/ReactiveDomain.Policy/Role.cs
@@ -22,14 +22,14 @@ namespace ReactiveDomain.Policy
         }
         public Role(string roleName)
         {
-            Ensure.NotNullOrEmpty(roleName, nameof(roleName));
-            RoleName = roleName;
+            Ensure.NotNullOrEmpty(roleName.Trim(), nameof(roleName));
+            RoleName = roleName.Trim();
         }
         #region IEquatable<T> Implementation
         public bool Equals(Role other)
         {
             if (other is null) return false;
-            return string.Equals(RoleName, other.RoleName);
+            return string.Equals(RoleName.ToLowerInvariant(), other.RoleName.ToLowerInvariant());
         }
 
         public override bool Equals(object obj) => Equals(obj as Role);

--- a/src/ReactiveDomain.Policy/UserPolicy.cs
+++ b/src/ReactiveDomain.Policy/UserPolicy.cs
@@ -41,7 +41,7 @@ namespace ReactiveDomain.Policy
         public void AddRole(Role role)
         {
             _roles.Add(role);
-            _roleNames.Add(role.RoleName);
+            _roleNames.Add(role.RoleName.Trim().ToLowerInvariant());
             foreach (var permission in role.Permissions)
             {
                 _permissions.Add(permission);
@@ -56,7 +56,7 @@ namespace ReactiveDomain.Policy
         public bool HasRole(string roleName)
         {
             if (string.IsNullOrWhiteSpace(roleName)) { return false; }
-            return _roleNames.Contains(roleName);
+            return _roleNames.Contains(roleName.Trim().ToLowerInvariant());
         }
         public bool HasRole(Role role)
         {

--- a/src/ReactiveDomain.PolicyStorage/ReadModels/PolicyUserRm.cs
+++ b/src/ReactiveDomain.PolicyStorage/ReadModels/PolicyUserRm.cs
@@ -111,7 +111,7 @@ namespace ReactiveDomain.Policy.ReadModels
                 _policyByPolicyUser[@event.PolicyUserId] = @event.PolicyId;
             }
 
-            if (!RolesByPolicyUser.TryGetValue(@event.PolicyUserId, out var roles))
+            if (!RolesByPolicyUser.TryGetValue(@event.PolicyUserId, out _))
             {
                 RolesByPolicyUser.Add(@event.PolicyUserId, new HashSet<string>());
             }
@@ -121,7 +121,7 @@ namespace ReactiveDomain.Policy.ReadModels
         {
             if (RolesByPolicyUser.TryGetValue(@event.PolicyUserId, out var roles))
             {
-                roles.Add(@event.RoleName);
+                roles.Add(@event.RoleName.Trim().ToLowerInvariant());
             }
         }
 
@@ -129,7 +129,7 @@ namespace ReactiveDomain.Policy.ReadModels
         {
             if (RolesByPolicyUser.TryGetValue(@event.PolicyUserId, out var roles))
             {
-                roles.Remove(@event.RoleName);
+                roles.Remove(@event.RoleName.Trim().ToLowerInvariant());
             }
         }
 

--- a/src/ReactiveDomain.PolicyStorage/ReadModels/RoleDTO.cs
+++ b/src/ReactiveDomain.PolicyStorage/ReadModels/RoleDTO.cs
@@ -12,14 +12,14 @@ namespace ReactiveDomain.Policy.ReadModels
         {
             Id = id;
             PolicyId = policyId;
-            Name = name;
+            Name = name.Trim().ToLowerInvariant();
         }
 
         public RoleDTO(ApplicationMsgs.RoleCreated @event)
         {
             Id = @event.RoleId;
             PolicyId = @event.PolicyId;
-            Name = @event.Name;
+            Name = @event.Name.Trim().ToLowerInvariant();
         }
     }
 }


### PR DESCRIPTION
Resolves #120 
- Trim role names before persisting.
- Role name comparisons are always case-insensitive.