### PR TITLE
Add a `ClientSvc` to front the `Client` aggregate

### DIFF
--- a/src/ReactiveDomain.Debug.nuspec
+++ b/src/ReactiveDomain.Debug.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain</id>
-    <version>0.9.1.0</version>
+    <version>0.9.2.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>

--- a/src/ReactiveDomain.IdentityStorage/Domain/Client.cs
+++ b/src/ReactiveDomain.IdentityStorage/Domain/Client.cs
@@ -5,13 +5,12 @@ using static ReactiveDomain.IdentityStorage.Messages.ClientMsgs;
 
 namespace ReactiveDomain.IdentityStorage.Domain
 {
-
     public class Client : AggregateRoot
     {
         public string ClientName { get; private set; }
         public string[] RedirectUris { get; private set; }
         public string[] LogoutRedirectUris { get; private set; }
-        public string FrontChannlLogoutUri { get; private set; }
+        public string FrontChannelLogoutUri { get; private set; }
 
         private Client()
         {
@@ -26,7 +25,7 @@ namespace ReactiveDomain.IdentityStorage.Domain
                 ClientName = @event.ClientName;
                 RedirectUris = @event.RedirectUris;
                 LogoutRedirectUris = @event.PostLogoutRedirectUris;
-                FrontChannlLogoutUri = @event.FrontChannelLogoutUri;
+                FrontChannelLogoutUri = @event.FrontChannelLogoutUri;
             });
             Register<ClientSecretAdded>(@event => { });
             Register<ClientSecretRemoved>(@event => { });
@@ -56,12 +55,12 @@ namespace ReactiveDomain.IdentityStorage.Domain
             Raise(new ClientCreated(
                 id,
                 applicationId,
-                 clientName,
-                 new[] { "client_credentials", "password", "authorization_code" },
-                 new[] { "openid", "profile", "rd-policy", "enabled-policies" },
-                 redirectUris,
-                 postLogoutRedirectUris,
-                 frontChannelLogoutUri));
+                clientName,
+                new[] { "client_credentials", "password", "authorization_code" },
+                new[] { "openid", "profile", "rd-policy", "enabled-policies" },
+                redirectUris,
+                postLogoutRedirectUris,
+                frontChannelLogoutUri));
 
             Raise(new ClientSecretAdded(id, encryptedClientSecret));
         }

--- a/src/ReactiveDomain.IdentityStorage/Messages/ClientMsgs.cs
+++ b/src/ReactiveDomain.IdentityStorage/Messages/ClientMsgs.cs
@@ -5,6 +5,35 @@ namespace ReactiveDomain.IdentityStorage.Messages
 {
     public class ClientMsgs
     {
+        public class CreateClient : Command
+        {
+            public readonly Guid ClientId;
+            public readonly Guid ApplicationId;
+            public readonly string ClientName;
+            public readonly string[] RedirectUris;
+            public readonly string[] PostLogoutRedirectUris;
+            public readonly string FrontChannelLogoutUri;
+            public readonly string EncryptedClientSecret;
+
+            public CreateClient(
+                Guid clientId,
+                Guid applicationId,
+                string clientName,
+                string[] redirectUris,
+                string[] postLogoutRedirectUris,
+                string frontChannelLogoutUri,
+                string encryptedClientSecret)
+            {
+                ClientId = clientId;
+                ApplicationId = applicationId;
+                ClientName = clientName;
+                RedirectUris = redirectUris;
+                PostLogoutRedirectUris = postLogoutRedirectUris;
+                FrontChannelLogoutUri = frontChannelLogoutUri;
+                EncryptedClientSecret = encryptedClientSecret;
+            }
+        }
+
         public class ClientCreated : Event
         {
             public readonly Guid ClientId;
@@ -36,9 +65,21 @@ namespace ReactiveDomain.IdentityStorage.Messages
                 FrontChannelLogoutUri = frontChannelLogoutUri;
             }
         }
+
+        public class AddClientSecret : Command
+        {
+            public readonly Guid ClientId;
+            public readonly string EncryptedClientSecret;
+
+            public AddClientSecret(Guid clientId, string encryptedClientSecret)
+            {
+                ClientId = clientId;
+                EncryptedClientSecret = encryptedClientSecret;
+            }
+        }
+
         public class ClientSecretAdded : Event
         {
-
             public readonly Guid ClientId;
             public readonly string EncryptedClientSecret;
 
@@ -48,6 +89,19 @@ namespace ReactiveDomain.IdentityStorage.Messages
                 EncryptedClientSecret = encryptedClientSecret;
             }
         }
+
+        public class RemoveClientSecret : Command
+        {
+            public readonly Guid ClientId;
+            public readonly string EncryptedClientSecret;
+
+            public RemoveClientSecret(Guid clientId, string encryptedClientSecret)
+            {
+                ClientId = clientId;
+                EncryptedClientSecret = encryptedClientSecret;
+            }
+        }
+
         public class ClientSecretRemoved : Event
         {
             public readonly Guid ClientId;

--- a/src/ReactiveDomain.IdentityStorage/Services/ClientSvc.cs
+++ b/src/ReactiveDomain.IdentityStorage/Services/ClientSvc.cs
@@ -1,0 +1,63 @@
+﻿using ReactiveDomain.Foundation;
+using ReactiveDomain.IdentityStorage.Domain;
+using ReactiveDomain.IdentityStorage.Messages;
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Messaging.Bus;
+
+namespace ReactiveDomain.IdentityStorage.Services
+{
+    public class ClientSvc :
+        TransientSubscriber,
+        IHandleCommand<ClientMsgs.CreateClient>,
+        IHandleCommand<ClientMsgs.AddClientSecret>,
+        IHandleCommand<ClientMsgs.RemoveClientSecret>
+    {
+        private readonly CorrelatedStreamStoreRepository _repo;
+
+        public ClientSvc(IRepository repo, IDispatcher bus) : base(bus)
+        {
+            _repo = new CorrelatedStreamStoreRepository(repo);
+            Subscribe<ClientMsgs.CreateClient>(this);
+            Subscribe<ClientMsgs.AddClientSecret>(this);
+            Subscribe<ClientMsgs.RemoveClientSecret>(this);
+        }
+
+        public CommandResponse Handle(ClientMsgs.CreateClient command)
+        {
+            var client = new Client(
+                                command.ClientId,
+                                command.ApplicationId,
+                                command.ClientName,
+                                command.EncryptedClientSecret,
+                                command.RedirectUris,
+                                command.PostLogoutRedirectUris,
+                                command.FrontChannelLogoutUri,
+                                command);
+            try
+            {
+                _repo.Save(client);
+            }
+            catch (WrongExpectedVersionException)
+            {
+                throw new DuplicateClientException(command.ClientId, command.ClientName);
+            }
+            return command.Succeed();
+        }
+
+        public CommandResponse Handle(ClientMsgs.AddClientSecret command)
+        {
+            var client = _repo.GetById<Client>(command.ClientId, command);
+            client.AddClientSecret(command.EncryptedClientSecret);
+            _repo.Save(client);
+            return command.Succeed();
+        }
+
+        public CommandResponse Handle(ClientMsgs.RemoveClientSecret command)
+        {
+            var client = _repo.GetById<Client>(command.ClientId, command);
+            client.RemoveClientSecret(command.EncryptedClientSecret);
+            _repo.Save(client);
+            return command.Succeed();
+        }
+    }
+}

--- a/src/ReactiveDomain.IdentityStorage/UserExceptions.cs
+++ b/src/ReactiveDomain.IdentityStorage/UserExceptions.cs
@@ -14,9 +14,7 @@ namespace ReactiveDomain.IdentityStorage
             : base($"User {id}: {fullName}\\{email} already exists.")
         { }
     }
-
     
-   
     /// <summary>
     /// Throw this exception when a user lookup returns no results.
     /// </summary>
@@ -43,5 +41,12 @@ namespace ReactiveDomain.IdentityStorage
             : base(message)
         {
         }
+    }
+
+    public class DuplicateClientException : Exception
+    {
+        public DuplicateClientException(Guid id, string name)
+            : base($"Client {name} with ID {id} already exists.")
+        { }
     }
 }

--- a/src/ReactiveDomain.Policy.Debug.nuspec
+++ b/src/ReactiveDomain.Policy.Debug.nuspec
@@ -2,14 +2,14 @@
 <package>
   <metadata>
     <id>ReactiveDomain.Policy</id>
-    <version>0.9.1.0</version>
+    <version>0.9.2.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <description>Package includes all ReactiveDomain Identity and Policy assemblies</description>       
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="ReactiveDomain" version="0.9.1" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.2" exclude="Build,Analyzers" />
         <dependency id="DynamicData" version="7.1.17" exclude="Build,Analyzers" />
         <dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
         <dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>

--- a/src/ReactiveDomain.Policy.nuspec
+++ b/src/ReactiveDomain.Policy.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain.Policy</id>
-    <version>0.9.1.0</version>
+    <version>0.9.2.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
@@ -10,7 +10,7 @@
     <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>     
       <group targetFramework="netstandard2.0">
-        <dependency id="ReactiveDomain" version="0.9.1" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.2" exclude="Build,Analyzers" />
         <dependency id="DynamicData" version="7.1.17" exclude="Build,Analyzers" />
         <dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
         <dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>

--- a/src/ReactiveDomain.Policy/Permissions.cs
+++ b/src/ReactiveDomain.Policy/Permissions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ReactiveDomain.Messaging;
+
+namespace ReactiveDomain.Policy
+{
+    public static class Permissions
+    {
+        private static readonly Type CommandType = typeof(Command);
+
+        public static Permission[] GetCommandPermissions(Type type)
+        {
+            return GetCommands(type).Select(t => new Permission(t)).ToArray();
+        }
+
+        public static IEnumerable<Type> GetCommands(Type type)
+        {
+            return type.GetNestedTypes().Where(t => CommandType.IsAssignableFrom(t));
+        }
+    }
+}

--- a/src/ReactiveDomain.Testing.Debug.nuspec
+++ b/src/ReactiveDomain.Testing.Debug.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain.Testing</id>
-    <version>0.9.1.0</version>
+    <version>0.9.2.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <owners>PerkinElmer,Linedata</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -14,7 +14,7 @@
         <dependency id="Microsoft.NET.Test.Sdk" version="16.11.0" exclude="Build,Analyzers" />
         <dependency id="xunit" version="2.4.1" exclude="Build,Analyzers" />
         <dependency id="xunit.runner.console" version="2.4.1" exclude="Build,Analyzers" />
-        <dependency id="ReactiveDomain" version="0.9.1.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.2.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
     <references>

--- a/src/ReactiveDomain.Testing.nuspec
+++ b/src/ReactiveDomain.Testing.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain.Testing</id>
-    <version>0.9.1.0</version>
+    <version>0.9.2.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <owners>PerkinElmer,Linedata</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -14,7 +14,7 @@
         <dependency id="Microsoft.NET.Test.Sdk" version="16.11.0" exclude="Build,Analyzers" />
         <dependency id="xunit" version="2.4.1" exclude="Build,Analyzers" />
         <dependency id="xunit.runner.console" version="2.4.1" exclude="Build,Analyzers" />
-        <dependency id="ReactiveDomain" version="0.9.1.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.2.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
     <references>

--- a/src/ReactiveDomain.UI.Debug.nuspec
+++ b/src/ReactiveDomain.UI.Debug.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain.UI</id>
-    <version>0.9.1.0</version>
+    <version>0.9.2.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <owners>PerkinElmer,Linedata</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -11,11 +11,11 @@
     <copyright>Copyright © 2014-2022 PerkinElmer, Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework="net48">
-        <dependency id="ReactiveDomain" version="0.9.1.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.2.0" exclude="Build,Analyzers" />
         <dependency id="ReactiveUI" version="9.22.1" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="ReactiveDomain" version="0.9.1.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.2.0" exclude="Build,Analyzers" />
         <dependency id="ReactiveUI" version="9.22.1" exclude="Build,Analyzers" />
       </group>
     </dependencies>

--- a/src/ReactiveDomain.UI.Testing.Debug.nuspec
+++ b/src/ReactiveDomain.UI.Testing.Debug.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain.UI.Testing</id>
-    <version>0.9.1.0</version>
+    <version>0.9.2.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <owners>PerkinElmer,Linedata</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -11,12 +11,12 @@
     <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework="net48">
-        <dependency id="ReactiveDomain.Testing" version="0.9.1.0" exclude="Build,Analyzers" />
-        <dependency id="ReactiveDomain.UI" version="0.9.1.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.Testing" version="0.9.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.UI" version="0.9.2.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="ReactiveDomain.Testing" version="0.9.1.0" exclude="Build,Analyzers" />
-        <dependency id="ReactiveDomain.UI" version="0.9.1.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.Testing" version="0.9.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.UI" version="0.9.2.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
     <references>     

--- a/src/ReactiveDomain.UI.Testing.nuspec
+++ b/src/ReactiveDomain.UI.Testing.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain.UI.Testing</id>
-    <version>0.9.1.0</version>
+    <version>0.9.2.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <owners>PerkinElmer,Linedata</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -11,12 +11,12 @@
     <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework="net48">
-        <dependency id="ReactiveDomain.Testing" version="0.9.1.0" exclude="Build,Analyzers" />
-        <dependency id="ReactiveDomain.UI" version="0.9.1.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.Testing" version="0.9.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.UI" version="0.9.2.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="ReactiveDomain.Testing" version="0.9.1.0" exclude="Build,Analyzers" />
-        <dependency id="ReactiveDomain.UI" version="0.9.1.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.Testing" version="0.9.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.UI" version="0.9.2.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
     <references>

--- a/src/ReactiveDomain.UI.nuspec
+++ b/src/ReactiveDomain.UI.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain.UI</id>
-    <version>0.9.1.0</version>
+    <version>0.9.2.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <owners>PerkinElmer,Linedata</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -11,11 +11,11 @@
     <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework="net48">
-        <dependency id="ReactiveDomain" version="0.9.1.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.2.0" exclude="Build,Analyzers" />
         <dependency id="ReactiveUI" version="9.22.1" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="ReactiveDomain" version="0.9.1.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.2.0" exclude="Build,Analyzers" />
         <dependency id="ReactiveUI" version="9.22.1" exclude="Build,Analyzers" />
       </group>
     </dependencies>

--- a/src/ReactiveDomain.nuspec
+++ b/src/ReactiveDomain.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain</id>
-    <version>0.9.1.0</version>
+    <version>0.9.2.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>

--- a/src/build.props
+++ b/src/build.props
@@ -9,7 +9,7 @@
         <DeployPackages Condition="$(CI) == 'true' and $(MSBuildRuntimeType) != 'Full' And $(OS) == 'WINDOWS_NT'">false</DeployPackages>
     </PropertyGroup>
     <PropertyGroup>
-        <PackageVersionPrefix>0.9.1</PackageVersionPrefix>
+        <PackageVersionPrefix>0.9.2</PackageVersionPrefix>
         <PackageVersionSuffix Condition="$(IsCIBuild) == false">-dev</PackageVersionSuffix>
         <PackageVersionSuffix Condition="$(IsCIBuild) == true">-build</PackageVersionSuffix>
         <PackageOutputPath>$(MSBuildThisFileDirectory)..\packages\</PackageOutputPath>
@@ -22,8 +22,8 @@
         <Company>PerkinElmer,Linedata</Company>
         <Copyright>Copyright © 2019-2022 PerkinElmer Inc., Linedata Inc.</Copyright>
         <Description />
-        <AssemblyVersion>0.9.1.0</AssemblyVersion>
-        <FileVersion>0.9.1.0</FileVersion>
+        <AssemblyVersion>0.9.2.0</AssemblyVersion>
+        <FileVersion>0.9.2.0</FileVersion>
         <NeutralLanguage />
         <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
         <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
This enables us to resolve a couple of TODOs in PolicyTool.

Other changes:
- Bump version to 0.9.2.
- Add static `Permissions` class to simplify getting commands and permissions from a Msgs class.