### PR TITLE
`ReadThroughAggregateCache` indexes by both type and ID

### DIFF
--- a/src/ReactiveDomain.Foundation/StreamStore/CachingRepository.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/CachingRepository.cs
@@ -37,8 +37,8 @@ namespace ReactiveDomain.Foundation.StreamStore {
         public void HardDelete(IEventSource aggregate) {
             _cache.HardDelete(aggregate);
         }
-        public bool ClearCache(Guid id) {
-            return _cache.Remove(id);
+        public bool ClearCache<TAggregate>(Guid id) {
+            return _cache.Remove<TAggregate>(id);
         }
         public void ClearCache() {
             _cache.Clear();

--- a/src/ReactiveDomain.Foundation/StreamStore/IAggregateCache.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/IAggregateCache.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 
-namespace ReactiveDomain.Foundation.StreamStore {
+namespace ReactiveDomain.Foundation.StreamStore
+{
     /// <summary>
     /// While it might seem more natural to save and restore the event set behind the aggregate,
     /// this cache stores only the collapsed state in the aggregate  
     /// </summary>
-    public interface IAggregateCache:IRepository, IDisposable
+    public interface IAggregateCache : IRepository, IDisposable
     {
-        bool Remove(Guid id);
+        bool Remove<TAggregate>(Guid id);
         void Clear();
     }
 }


### PR DESCRIPTION
This changes the `ReadThroughAggregateCache` so that its `Dictionary` of known aggregates indexes by a tuple of type and ID rather than just by ID. This resolves #125.