### PR TITLE
Add props files and set Visible to false in targets file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,4 @@ paket-files/
 src/ReactiveDomain/.vs/ReactiveDomain/v14/.suo
 .vscode/
 /history
+/nupkgs

--- a/build/ReactiveDomain.Policy.props
+++ b/build/ReactiveDomain.Policy.props
@@ -1,0 +1,10 @@
+<Project>
+  <ItemGroup>
+    <Compile Update="@(Compile)">
+      <Visible Condition="'%(NuGetItemType)' == 'Compile' and '%(NuGetPackageId)' == 'ReactiveDomain.Policy'">false</Visible>
+    </Compile>
+    <None Include="@(None)">
+      <Visible Condition="'%(NuGetItemType)' == 'None' and '%(NuGetPackageId)' == 'ReactiveDomain.Policy'">false</Visible>
+    </None>
+  </ItemGroup>
+</Project>

--- a/build/ReactiveDomain.Testing.props
+++ b/build/ReactiveDomain.Testing.props
@@ -1,0 +1,10 @@
+<Project>
+  <ItemGroup>
+    <Compile Update="@(Compile)">
+      <Visible Condition="'%(NuGetItemType)' == 'Compile' and '%(NuGetPackageId)' == 'ReactiveDomain.Testing'">false</Visible>
+    </Compile>
+    <None Include="@(None)">
+      <Visible Condition="'%(NuGetItemType)' == 'None' and '%(NuGetPackageId)' == 'ReactiveDomain.Testing'">false</Visible>
+    </None>
+  </ItemGroup>
+</Project>

--- a/build/ReactiveDomain.UI.Testing.props
+++ b/build/ReactiveDomain.UI.Testing.props
@@ -1,0 +1,10 @@
+<Project>
+  <ItemGroup>
+    <Compile Update="@(Compile)">
+      <Visible Condition="'%(NuGetItemType)' == 'Compile' and '%(NuGetPackageId)' == 'ReactiveDomain.UI.Testing'">false</Visible>
+    </Compile>
+    <None Include="@(None)">
+      <Visible Condition="'%(NuGetItemType)' == 'None' and '%(NuGetPackageId)' == 'ReactiveDomain.UI.Testing'">false</Visible>
+    </None>
+  </ItemGroup>
+</Project>

--- a/build/ReactiveDomain.UI.props
+++ b/build/ReactiveDomain.UI.props
@@ -1,0 +1,10 @@
+<Project>
+  <ItemGroup>
+    <Compile Update="@(Compile)">
+      <Visible Condition="'%(NuGetItemType)' == 'Compile' and '%(NuGetPackageId)' == 'ReactiveDomain.UI'">false</Visible>
+    </Compile>
+    <None Include="@(None)">
+      <Visible Condition="'%(NuGetItemType)' == 'None' and '%(NuGetPackageId)' == 'ReactiveDomain.UI'">false</Visible>
+    </None>
+  </ItemGroup>
+</Project>

--- a/build/ReactiveDomain.props
+++ b/build/ReactiveDomain.props
@@ -1,0 +1,10 @@
+<Project>
+  <ItemGroup>
+    <Compile Update="@(Compile)">
+      <Visible Condition="'%(NuGetItemType)' == 'Compile' and '%(NuGetPackageId)' == 'ReactiveDomain'">false</Visible>
+    </Compile>
+    <None Include="@(None)">
+      <Visible Condition="'%(NuGetItemType)' == 'None' and '%(NuGetPackageId)' == 'ReactiveDomain'">false</Visible>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/ReactiveDomain.Debug.nuspec
+++ b/src/ReactiveDomain.Debug.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain</id>
-    <version>0.9.2.0</version>
+    <version>0.9.3.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
@@ -27,6 +27,7 @@
     </references>
   </metadata>
   <files>
+    <file src="..\build\ReactiveDomain.props" target="build" />
     <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Core.pdb" target="lib\netstandard2.0" />
     <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Foundation.pdb" target="lib\netstandard2.0" />
     <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Messaging.pdb" target="lib\netstandard2.0" />

--- a/src/ReactiveDomain.Policy.Debug.nuspec
+++ b/src/ReactiveDomain.Policy.Debug.nuspec
@@ -27,13 +27,11 @@
       </group>
     </references>    
   </metadata>
-    <contentFiles>
-    <file src="..\bld\tools\ReactiveDomain.PolicyTool.exe" target="Build\PolicyTool.exe" />
-    <file src="..\bld\tools\es_settings.json" target="Build\es_settings.json" />
-  </contentFiles>
-	<files>
+  <files>
     <file src="..\build\ReactiveDomain.Policy.props" target="build" />
     <file src="ReactiveDomain.Policy.targets" target="build" />
+    <file src="..\bld\tools\ReactiveDomain.PolicyTool.exe" target="build\PolicyTool.exe" />
+    <file src="..\bld\tools\es_settings.json" target="build\es_settings.json" />
     
     <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Policy.pdb" target="lib\netstandard2.0" />
     <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Policy.dll" target="lib\netstandard2.0" />

--- a/src/ReactiveDomain.Policy.Debug.nuspec
+++ b/src/ReactiveDomain.Policy.Debug.nuspec
@@ -2,14 +2,14 @@
 <package>
   <metadata>
     <id>ReactiveDomain.Policy</id>
-    <version>0.9.2.0</version>
+    <version>0.9.3.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <description>Package includes all ReactiveDomain Identity and Policy assemblies</description>       
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="ReactiveDomain" version="0.9.2" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.3.0" exclude="Build,Analyzers" />
         <dependency id="DynamicData" version="7.1.17" exclude="Build,Analyzers" />
         <dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
         <dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>
@@ -27,11 +27,13 @@
       </group>
     </references>    
   </metadata>
-  
-  <files>
+    <contentFiles>
     <file src="..\bld\tools\ReactiveDomain.PolicyTool.exe" target="Build\PolicyTool.exe" />
     <file src="..\bld\tools\es_settings.json" target="Build\es_settings.json" />
-    <file src="ReactiveDomain.Policy.targets" target="Build\" />
+  </contentFiles>
+	<files>
+    <file src="..\build\ReactiveDomain.Policy.props" target="build" />
+    <file src="ReactiveDomain.Policy.targets" target="build" />
     
     <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Policy.pdb" target="lib\netstandard2.0" />
     <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Policy.dll" target="lib\netstandard2.0" />

--- a/src/ReactiveDomain.Policy.nuspec
+++ b/src/ReactiveDomain.Policy.nuspec
@@ -7,7 +7,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <description>Package includes all ReactiveDomain Core assemblies</description>
-    <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
+    <copyright>Copyright © 2014-2023 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>     
       <group targetFramework="netstandard2.0">
         <dependency id="ReactiveDomain" version="0.9.3.0" exclude="Build,Analyzers" />

--- a/src/ReactiveDomain.Policy.nuspec
+++ b/src/ReactiveDomain.Policy.nuspec
@@ -7,7 +7,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <description>Package includes all ReactiveDomain Core assemblies</description>
-    <copyright>Copyright Â© 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
+    <copyright>Copyright Ã‚Â© 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>     
       <group targetFramework="netstandard2.0">
         <dependency id="ReactiveDomain" version="0.9.3.0" exclude="Build,Analyzers" />
@@ -28,13 +28,11 @@
       </group>
     </references>    
   </metadata>
-  <contentFiles>
-    <file src="..\bld\tools\ReactiveDomain.PolicyTool.exe" target="Build\PolicyTool.exe" />
-    <file src="..\bld\tools\es_settings.json" target="Build\es_settings.json" />
-  </contentFiles>
   <files>
     <file src="..\build\ReactiveDomain.Policy.props" target="build" />
     <file src="ReactiveDomain.Policy.targets" target="build" />
+    <file src="..\bld\tools\ReactiveDomain.PolicyTool.exe" target="build\PolicyTool.exe" />
+    <file src="..\bld\tools\es_settings.json" target="build\es_settings.json" />
 
     <file src="..\bld\Release\netstandard2.0\ReactiveDomain.Policy.pdb" target="lib\netstandard2.0" />
     <file src="..\bld\Release\netstandard2.0\ReactiveDomain.Policy.dll" target="lib\netstandard2.0" />

--- a/src/ReactiveDomain.Policy.nuspec
+++ b/src/ReactiveDomain.Policy.nuspec
@@ -2,15 +2,15 @@
 <package>
   <metadata>
     <id>ReactiveDomain.Policy</id>
-    <version>0.9.2.0</version>
+    <version>0.9.3.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <description>Package includes all ReactiveDomain Core assemblies</description>
-    <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
+    <copyright>Copyright Â© 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>     
       <group targetFramework="netstandard2.0">
-        <dependency id="ReactiveDomain" version="0.9.2" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.3.0" exclude="Build,Analyzers" />
         <dependency id="DynamicData" version="7.1.17" exclude="Build,Analyzers" />
         <dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
         <dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>
@@ -28,10 +28,13 @@
       </group>
     </references>    
   </metadata>
-  <files>
+  <contentFiles>
     <file src="..\bld\tools\ReactiveDomain.PolicyTool.exe" target="Build\PolicyTool.exe" />
     <file src="..\bld\tools\es_settings.json" target="Build\es_settings.json" />
-    <file src="ReactiveDomain.Policy.targets" target="Build\" />
+  </contentFiles>
+  <files>
+    <file src="..\build\ReactiveDomain.Policy.props" target="build" />
+    <file src="ReactiveDomain.Policy.targets" target="build" />
 
     <file src="..\bld\Release\netstandard2.0\ReactiveDomain.Policy.pdb" target="lib\netstandard2.0" />
     <file src="..\bld\Release\netstandard2.0\ReactiveDomain.Policy.dll" target="lib\netstandard2.0" />

--- a/src/ReactiveDomain.Policy.nuspec
+++ b/src/ReactiveDomain.Policy.nuspec
@@ -7,7 +7,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <description>Package includes all ReactiveDomain Core assemblies</description>
-    <copyright>Copyright Ã‚Â© 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
+    <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>     
       <group targetFramework="netstandard2.0">
         <dependency id="ReactiveDomain" version="0.9.3.0" exclude="Build,Analyzers" />

--- a/src/ReactiveDomain.Policy.targets
+++ b/src/ReactiveDomain.Policy.targets
@@ -3,10 +3,12 @@
       <None Include="$(MSBuildThisFileDirectory)PolicyTool.exe">
         <Link>PolicyTool.exe</Link>
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        <Visible>false</Visible>
       </None>
       <None Include="$(MSBuildThisFileDirectory)es_settings.json">
         <Link>es_settings.json</Link>
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        <Visible>false</Visible>
       </None>
     </ItemGroup>
   </Project>

--- a/src/ReactiveDomain.Testing.Debug.nuspec
+++ b/src/ReactiveDomain.Testing.Debug.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain.Testing</id>
-    <version>0.9.2.0</version>
+    <version>0.9.3.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <owners>PerkinElmer,Linedata</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -14,7 +14,7 @@
         <dependency id="Microsoft.NET.Test.Sdk" version="16.11.0" exclude="Build,Analyzers" />
         <dependency id="xunit" version="2.4.1" exclude="Build,Analyzers" />
         <dependency id="xunit.runner.console" version="2.4.1" exclude="Build,Analyzers" />
-        <dependency id="ReactiveDomain" version="0.9.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.3.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
     <references>
@@ -24,6 +24,7 @@
     </references>
   </metadata>
   <files>
+    <file src="..\build\ReactiveDomain.Testing.props" target="build" />
     <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Testing.pdb" target="lib\netstandard2.0" />
     <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Testing.dll" target="lib\netstandard2.0" />
     <file src="..\bld\Debug\netstandard2.0\ReactiveDomain.Testing.dll" target="ref\netstandard2.0" />   

--- a/src/ReactiveDomain.Testing.Debug.nuspec
+++ b/src/ReactiveDomain.Testing.Debug.nuspec
@@ -8,7 +8,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <description>Package includes ReactiveDomain assemblies needed for unit testing</description>
-    <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
+    <copyright>Copyright © 2014-2023 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>      
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.NET.Test.Sdk" version="16.11.0" exclude="Build,Analyzers" />

--- a/src/ReactiveDomain.Testing.nuspec
+++ b/src/ReactiveDomain.Testing.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain.Testing</id>
-    <version>0.9.2.0</version>
+    <version>0.9.3.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <owners>PerkinElmer,Linedata</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -14,7 +14,7 @@
         <dependency id="Microsoft.NET.Test.Sdk" version="16.11.0" exclude="Build,Analyzers" />
         <dependency id="xunit" version="2.4.1" exclude="Build,Analyzers" />
         <dependency id="xunit.runner.console" version="2.4.1" exclude="Build,Analyzers" />
-        <dependency id="ReactiveDomain" version="0.9.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.3.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
     <references>
@@ -24,6 +24,7 @@
     </references>
   </metadata>
   <files>
+    <file src="..\build\ReactiveDomain.Testing.props" target="build" />
     <file src="..\bld\Release\netstandard2.0\ReactiveDomain.Testing.pdb" target="lib\netstandard2.0" />
     <file src="..\bld\Release\netstandard2.0\ReactiveDomain.Testing.dll" target="lib\netstandard2.0" />
     <file src="..\bld\Release\netstandard2.0\ReactiveDomain.Testing.dll" target="ref\netstandard2.0" />

--- a/src/ReactiveDomain.Testing.nuspec
+++ b/src/ReactiveDomain.Testing.nuspec
@@ -8,7 +8,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <description>Package includes ReactiveDomain assemblies needed for unit testing</description>
-    <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
+    <copyright>Copyright © 2014-2023 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.NET.Test.Sdk" version="16.11.0" exclude="Build,Analyzers" />

--- a/src/ReactiveDomain.UI.Debug.nuspec
+++ b/src/ReactiveDomain.UI.Debug.nuspec
@@ -8,7 +8,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <description>Package includes all ReactiveDomain UI assembly</description>
-    <copyright>Copyright © 2014-2022 PerkinElmer, Linedata Inc.</copyright>
+    <copyright>Copyright © 2014-2023 PerkinElmer, Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework="net48">
         <dependency id="ReactiveDomain" version="0.9.3.0" exclude="Build,Analyzers" />

--- a/src/ReactiveDomain.UI.Debug.nuspec
+++ b/src/ReactiveDomain.UI.Debug.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain.UI</id>
-    <version>0.9.2.0</version>
+    <version>0.9.3.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <owners>PerkinElmer,Linedata</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -11,11 +11,11 @@
     <copyright>Copyright © 2014-2022 PerkinElmer, Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework="net48">
-        <dependency id="ReactiveDomain" version="0.9.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.3.0" exclude="Build,Analyzers" />
         <dependency id="ReactiveUI" version="9.22.1" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="ReactiveDomain" version="0.9.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.3.0" exclude="Build,Analyzers" />
         <dependency id="ReactiveUI" version="9.22.1" exclude="Build,Analyzers" />
       </group>
     </dependencies>
@@ -29,6 +29,7 @@
     </references>    
   </metadata>
   <files>
+    <file src="..\build\ReactiveDomain.UI.props" target="build" />
     <file src="..\bld\Debug\net48\ReactiveDomain.UI.dll" target="lib\net48" />
     <file src="..\bld\Debug\net48\ReactiveDomain.UI.pdb" target="lib\net48" />
     <file src="..\bld\Debug\net48\ReactiveDomain.UI.dll" target="ref\net48" />

--- a/src/ReactiveDomain.UI.Testing.Debug.nuspec
+++ b/src/ReactiveDomain.UI.Testing.Debug.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain.UI.Testing</id>
-    <version>0.9.2.0</version>
+    <version>0.9.3.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <owners>PerkinElmer,Linedata</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -11,12 +11,12 @@
     <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework="net48">
-        <dependency id="ReactiveDomain.Testing" version="0.9.2.0" exclude="Build,Analyzers" />
-        <dependency id="ReactiveDomain.UI" version="0.9.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.Testing" version="0.9.3.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.UI" version="0.9.3.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="ReactiveDomain.Testing" version="0.9.2.0" exclude="Build,Analyzers" />
-        <dependency id="ReactiveDomain.UI" version="0.9.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.Testing" version="0.9.3.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.UI" version="0.9.3.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
     <references>     
@@ -29,6 +29,7 @@
     </references>   
   </metadata>
   <files>
+    <file src="..\build\ReactiveDomain.UI.Testing.props" target="build" />
     <file src="..\bld\Debug\net48\ReactiveDomain.UI.Testing.dll" target="lib\net48" />
     <file src="..\bld\Debug\net48\ReactiveDomain.UI.Testing.pdb" target="lib\net48" />
     <file src="..\bld\Debug\net48\ReactiveDomain.UI.Testing.dll" target="ref\net48" />

--- a/src/ReactiveDomain.UI.Testing.Debug.nuspec
+++ b/src/ReactiveDomain.UI.Testing.Debug.nuspec
@@ -8,7 +8,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <description>Package includes all ReactiveDomain UI assemblies for unit testing</description>
-    <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
+    <copyright>Copyright © 2014-2023 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework="net48">
         <dependency id="ReactiveDomain.Testing" version="0.9.3.0" exclude="Build,Analyzers" />

--- a/src/ReactiveDomain.UI.Testing.nuspec
+++ b/src/ReactiveDomain.UI.Testing.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain.UI.Testing</id>
-    <version>0.9.2.0</version>
+    <version>0.9.3.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <owners>PerkinElmer,Linedata</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -11,12 +11,12 @@
     <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework="net48">
-        <dependency id="ReactiveDomain.Testing" version="0.9.2.0" exclude="Build,Analyzers" />
-        <dependency id="ReactiveDomain.UI" version="0.9.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.Testing" version="0.9.3.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.UI" version="0.9.3.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="ReactiveDomain.Testing" version="0.9.2.0" exclude="Build,Analyzers" />
-        <dependency id="ReactiveDomain.UI" version="0.9.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.Testing" version="0.9.3.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain.UI" version="0.9.3.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
     <references>
@@ -29,6 +29,7 @@
     </references>
   </metadata>
   <files>
+    <file src="..\build\ReactiveDomain.UI.Testing.props" target="build" />
     <file src="..\bld\Release\net48\ReactiveDomain.UI.Testing.dll" target="lib\net48" />
     <file src="..\bld\Release\net48\ReactiveDomain.UI.Testing.pdb" target="lib\net48" />
     <file src="..\bld\Release\net48\ReactiveDomain.UI.Testing.dll" target="ref\net48" />

--- a/src/ReactiveDomain.UI.Testing.nuspec
+++ b/src/ReactiveDomain.UI.Testing.nuspec
@@ -8,7 +8,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <description>Package includes all ReactiveDomain UI assemblies for unit testing</description>
-    <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
+    <copyright>Copyright © 2014-2023 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework="net48">
         <dependency id="ReactiveDomain.Testing" version="0.9.3.0" exclude="Build,Analyzers" />

--- a/src/ReactiveDomain.UI.nuspec
+++ b/src/ReactiveDomain.UI.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain.UI</id>
-    <version>0.9.2.0</version>
+    <version>0.9.3.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <owners>PerkinElmer,Linedata</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -11,11 +11,11 @@
     <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework="net48">
-        <dependency id="ReactiveDomain" version="0.9.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.3.0" exclude="Build,Analyzers" />
         <dependency id="ReactiveUI" version="9.22.1" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="ReactiveDomain" version="0.9.2.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.9.3.0" exclude="Build,Analyzers" />
         <dependency id="ReactiveUI" version="9.22.1" exclude="Build,Analyzers" />
       </group>
     </dependencies>
@@ -29,6 +29,7 @@
     </references>
   </metadata>
   <files>
+    <file src="..\build\ReactiveDomain.UI.props" target="build" />
     <file src="..\bld\Release\net48\ReactiveDomain.UI.dll" target="lib\net48" />
     <file src="..\bld\Debug\net48\ReactiveDomain.UI.pdb" target="lib\net48" />
     <file src="..\bld\Release\net48\ReactiveDomain.UI.dll" target="ref\net48" />

--- a/src/ReactiveDomain.UI.nuspec
+++ b/src/ReactiveDomain.UI.nuspec
@@ -8,7 +8,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <description>Package includes ReactiveDomain UI assembly</description>
-    <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
+    <copyright>Copyright © 2014-2023 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework="net48">
         <dependency id="ReactiveDomain" version="0.9.3.0" exclude="Build,Analyzers" />

--- a/src/ReactiveDomain.nuspec
+++ b/src/ReactiveDomain.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain</id>
-    <version>0.9.2.0</version>
+    <version>0.9.3.0</version>
     <authors>PerkinElmer,Linedata</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
@@ -31,6 +31,7 @@
     </frameworkAssemblies>
   </metadata>
   <files>
+    <file src="..\build\ReactiveDomain.props" target="build" />
     <file src="..\bld\Release\netstandard2.0\ReactiveDomain.Core.pdb" target="lib\netstandard2.0" />
     <file src="..\bld\Release\netstandard2.0\ReactiveDomain.Foundation.pdb" target="lib\netstandard2.0" />
     <file src="..\bld\Release\netstandard2.0\ReactiveDomain.Messaging.pdb" target="lib\netstandard2.0" />

--- a/src/ReactiveDomain.nuspec
+++ b/src/ReactiveDomain.nuspec
@@ -7,7 +7,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <description>Package includes all ReactiveDomain Core assemblies</description>
-    <copyright>Copyright © 2014-2022 PerkinElmer Inc., Linedata Inc.</copyright>
+    <copyright>Copyright © 2014-2023 PerkinElmer Inc., Linedata Inc.</copyright>
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="EventStore.Client" version="21.2.2" exclude="Build,Analyzers" />

--- a/src/build.props
+++ b/src/build.props
@@ -20,7 +20,7 @@
         <Platforms>AnyCPU</Platforms>
         <Authors>PerkinElmer,Linedata</Authors>
         <Company>PerkinElmer,Linedata</Company>
-        <Copyright>Copyright © 2019-2022 PerkinElmer Inc., Linedata Inc.</Copyright>
+        <Copyright>Copyright Â© 2019-2023 PerkinElmer Inc., Linedata Inc.</Copyright>
         <Description />
         <AssemblyVersion>0.9.3.0</AssemblyVersion>
         <FileVersion>0.9.3.0</FileVersion>

--- a/src/build.props
+++ b/src/build.props
@@ -9,7 +9,7 @@
         <DeployPackages Condition="$(CI) == 'true' and $(MSBuildRuntimeType) != 'Full' And $(OS) == 'WINDOWS_NT'">false</DeployPackages>
     </PropertyGroup>
     <PropertyGroup>
-        <PackageVersionPrefix>0.9.2</PackageVersionPrefix>
+        <PackageVersionPrefix>0.9.3</PackageVersionPrefix>
         <PackageVersionSuffix Condition="$(IsCIBuild) == false">-dev</PackageVersionSuffix>
         <PackageVersionSuffix Condition="$(IsCIBuild) == true">-build</PackageVersionSuffix>
         <PackageOutputPath>$(MSBuildThisFileDirectory)..\packages\</PackageOutputPath>
@@ -20,10 +20,10 @@
         <Platforms>AnyCPU</Platforms>
         <Authors>PerkinElmer,Linedata</Authors>
         <Company>PerkinElmer,Linedata</Company>
-        <Copyright>Copyright Â© 2019-2022 PerkinElmer Inc., Linedata Inc.</Copyright>
+        <Copyright>Copyright © 2019-2022 PerkinElmer Inc., Linedata Inc.</Copyright>
         <Description />
-        <AssemblyVersion>0.9.2.0</AssemblyVersion>
-        <FileVersion>0.9.2.0</FileVersion>
+        <AssemblyVersion>0.9.3.0</AssemblyVersion>
+        <FileVersion>0.9.3.0</FileVersion>
         <NeutralLanguage />
         <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
         <DebugSymbols>true</DebugSymbols>
@@ -53,7 +53,7 @@
     <Choose>
       <When Condition="$(OS) == 'WINDOWS_NT'">
         <PropertyGroup>
-          <LibTargetFrameworks>netstandard2.0</LibTargetFrameworks> <!--netstandard 2.0 is the highest version that still supports net472 -->
+          <LibTargetFrameworks>netstandard2.0</LibTargetFrameworks> <!--netstandard 2.0 is the highest version that still supports net48 -->
           <TestTargetFrameworks>net48;net5.0</TestTargetFrameworks> <!-- for testing we just want to check latest on framework and core -->
         </PropertyGroup>
       </When>

--- a/tools/CreateDebugNuget.ps1
+++ b/tools/CreateDebugNuget.ps1
@@ -33,11 +33,14 @@ Write-Host ("Copy ReactiveDomain build folder and nuspec files to a temp directo
 
 $TempDir = Join-Path $env:temp $TempNum.ToString()
 $buildDir = Join-Path $ReactiveDomainRepo "bld"
+$propsDir = Join-Path $ReactiveDomainRepo "build"
 $sourceDir = Join-Path $ReactiveDomainRepo "src"
 $tempBuildDir = Join-Path $TempDir "bld"
+$tempPropsDir = Join-Path $TempDir "build"
 $tempSourceDir = Join-Path $TempDir "src"
 New-Item -ItemType "directory" -Path $tempSourceDir
 Copy-Item -Path $buildDir -Destination $tempBuildDir -Recurse
+Copy-Item -Path $propsDir -Destination $tempPropsDir -Recurse
 
 #source nuspec file paths
 $sourceRDNuspec = Join-Path $sourceDir "ReactiveDomain.Debug.nuspec"


### PR DESCRIPTION
**What does this pull request do?**
When referencing ReactiveDomain from projects using modern SDK-style csproj files, this prevents the included files from showing up in Visual Studio's solution explorer as links, which can make it difficult for developers to find their own files. This is standard practice in modern nuget packages.

**How does this pull request accomplish that goal?**
Updates the nuspec files, adds .props files for each nuget package that set all `contentFiles` to be invisible, and sets items in explicit .targets files to `Visible=false`.

**Why is this pull request important?**
Polluting the solution explorer with lots of files from included nuget packages can make it difficult for developers to find their own files.

**Link to any issues that this resolves**
This does not address any open issues.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports
- [x] Any new code must be covered by at least one unit test
- [x] All public methods must be documented with XML comments