### PR TITLE
Fixes setting of correlation ID in AggregateRoot ctor

### DIFF
--- a/src/ReactiveDomain.Foundation/Domain/AggregateRoot.cs
+++ b/src/ReactiveDomain.Foundation/Domain/AggregateRoot.cs
@@ -14,8 +14,7 @@ namespace ReactiveDomain
         protected AggregateRoot(ICorrelatedMessage source = null)
         {
             if (source == null) { return; }
-            _correlationId = source.CorrelationId;
-            _causationId = source.MsgId;
+            Source = source;
         }
 
         internal void RegisterChild(ChildEntity childAggregate, out Action<object> raise, out EventRouter router)
@@ -27,7 +26,7 @@ namespace ReactiveDomain
 
         private Guid _correlationId;
         private Guid _causationId;
-        ICorrelatedMessage ICorrelatedEventSource.Source
+        public ICorrelatedMessage Source
         {
             get
             {


### PR DESCRIPTION
**What does this pull request do?**
Uses the `Source` property to set the correlation source in the ctor of `AggregateRoot` so that the `correlationId` gets set correctly when the injected correlation source is a root message.

**How does this pull request accomplish that goal?**
Uses the existing logic in the `Source` setter to ensure consistency.

**Why is this pull request important?**
When using a root message as the correlation source in the ctor of AggregateRoot, the correlation ID would not be set correctly.

**Link to any issues that this resolves**
This does not address any open issues.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports
- [x] Any new code must be covered by at least one unit test
- [x] All public methods must be documented with XML comments