### PR TITLE
Fixes threading issues with `ReadModelBase`

### DIFF
--- a/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base.cs
@@ -11,14 +11,6 @@ namespace ReactiveDomain.Foundation.Tests {
                     IHandle<when_using_read_model_base.ReadModelTestEvent>,
                     IClassFixture<StreamStoreConnectionFixture> {
 
-        private static IListener GetListener() {
-            return new QueuedStreamListener(
-                        nameof(when_using_read_model_base),
-                        _conn,
-                        Namer,
-                        Serializer);
-        }
-
         private static IStreamStoreConnection _conn;
         private static readonly IEventSerializer Serializer =
             new JsonMessageSerializer();
@@ -30,8 +22,7 @@ namespace ReactiveDomain.Foundation.Tests {
 
 
         public when_using_read_model_base(StreamStoreConnectionFixture fixture)
-                    : base(nameof(when_using_read_model_base), GetListener) {
-            //_conn = new MockStreamStoreConnection("mockStore");
+                    : base(nameof(when_using_read_model_base), new ConfiguredConnection(fixture.Connection, Namer, Serializer)) {
             _conn = fixture.Connection;
             _conn.Connect();
 

--- a/src/ReactiveDomain.Foundation/StreamStore/SnapshotReadModel.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/SnapshotReadModel.cs
@@ -9,8 +9,8 @@ namespace ReactiveDomain.Foundation {
 
         protected SnapshotReadModel(
                 string name,
-                Func<IListener> getListener)
-            : base(name, getListener) {
+                IConfiguredConnection connection)
+            : base(name, connection) {
         }
 
         protected virtual void Restore(

--- a/src/ReactiveDomain.IdentityStorage/ReadModels/SubjectsRm.cs
+++ b/src/ReactiveDomain.IdentityStorage/ReadModels/SubjectsRm.cs
@@ -12,7 +12,7 @@ namespace ReactiveDomain.IdentityStorage.ReadModels
         IHandle<SubjectMsgs.SubjectCreated>
     {
         public SubjectsRm(IConfiguredConnection conn)
-            : base(nameof(SubjectsRm), () => conn.GetListener(nameof(SubjectsRm)))
+            : base(nameof(SubjectsRm), conn)
         {
             //set handlers
             EventStream.Subscribe<SubjectMsgs.SubjectCreated>(this);

--- a/src/ReactiveDomain.IdentityStorage/ReadModels/UsersRm.cs
+++ b/src/ReactiveDomain.IdentityStorage/ReadModels/UsersRm.cs
@@ -19,7 +19,7 @@ namespace ReactiveDomain.IdentityStorage.ReadModels
         private readonly SourceCache<UserDTO, Guid> _allUsers = new SourceCache<UserDTO, Guid>(x => x.UserId);
 
         private readonly List<Guid> _userIds = new List<Guid>();
-        public UsersRm(IConfiguredConnection conn) : base(nameof(UsersRm), () => conn.GetListener(nameof(UsersRm)))
+        public UsersRm(IConfiguredConnection conn) : base(nameof(UsersRm), conn)
         {
             long? position;
             EventStream.Subscribe<UserMsgs.UserEvent>(this);

--- a/src/ReactiveDomain.IdentityStorage/Services/ClientStore.cs
+++ b/src/ReactiveDomain.IdentityStorage/Services/ClientStore.cs
@@ -20,7 +20,7 @@ namespace ReactiveDomain.IdentityStorage.Services
         IHandle<ClientMsgs.ClientSecretRemoved>
     {
 
-        public ClientStore(IConfiguredConnection conn) : base(nameof(ClientStore), () => conn.GetListener(nameof(ClientStore)))
+        public ClientStore(IConfiguredConnection conn) : base(nameof(ClientStore), conn)
         {
             long checkpoint;
 

--- a/src/ReactiveDomain.PolicyStorage/ReadModels/ApplicationRm.cs
+++ b/src/ReactiveDomain.PolicyStorage/ReadModels/ApplicationRm.cs
@@ -29,7 +29,7 @@ namespace ReactiveDomain.Policy.ReadModels
 
 
         public ApplicationRm(IConfiguredConnection conn)
-           : base(nameof(ApplicationRm), () => conn.GetListener(nameof(ApplicationRm)))
+           : base(nameof(ApplicationRm), conn)
         {
             //set handlers
             EventStream.Subscribe<ApplicationMsgs.ApplicationCreated>(this);

--- a/src/ReactiveDomain.PolicyStorage/ReadModels/FilteredPoliciesRM.cs
+++ b/src/ReactiveDomain.PolicyStorage/ReadModels/FilteredPoliciesRM.cs
@@ -1,6 +1,5 @@
 ﻿using DynamicData;
 using ReactiveDomain.Foundation;
-using ReactiveDomain.Messaging;
 using ReactiveDomain.Messaging.Bus;
 using ReactiveDomain.Policy.Messages;
 using System;
@@ -28,7 +27,7 @@ namespace ReactiveDomain.Policy.ReadModels
         private readonly Dictionary<Guid, RoleDTO> _roles = new Dictionary<Guid, RoleDTO>();
 
         public FilteredPoliciesRM(IConfiguredConnection conn, List<string> policyFilter = null)
-           : base(nameof(FilteredPoliciesRM), () => conn.GetListener(nameof(FilteredPoliciesRM)))
+           : base(nameof(FilteredPoliciesRM), conn)
         {
             if (policyFilter != null)
             {

--- a/src/ReactiveDomain.PolicyStorage/ReadModels/PolicyUserRm.cs
+++ b/src/ReactiveDomain.PolicyStorage/ReadModels/PolicyUserRm.cs
@@ -22,7 +22,7 @@ namespace ReactiveDomain.Policy.ReadModels
         /// Create a read model for getting information about Policy Users.
         /// </summary>
         public PolicyUserRm(IConfiguredConnection conn)
-            : base(nameof(PolicyUserRm), () => conn.GetListener(nameof(PolicyUserRm)))
+            : base(nameof(PolicyUserRm), conn)
         {
             //set handlers
             EventStream.Subscribe<PolicyUserMsgs.PolicyUserAdded>(this);


### PR DESCRIPTION
**What does this pull request do?**
Fixes a threading issue where a read model that is queried for its state could simultaneously handle an event, potentially causing an error if the query and the handler access the same aspect of the read model's state.

**How does this pull request accomplish that goal?**
- Adds a `ReaderLock` property to `ReadModelBase` that can be used when reading the state of the read model.
- Adds a `Version` property to `ReadModelBase` that increments with the total number of messages passed to the read model. This can be used in tests to ensure the read model state.
- Fixes an issue in `ReadModelBase` that could cause events to be read twice if `Start` is called with a checkpoint that is already at the end of the stream.

**Why is this pull request important?**
This makes `ReadModelBase` more resilient in multi-threaded scenarios, including in unit tests.

**Link to any issues that this resolves**
"This does not address any open issues."