### PR TITLE
Allows for providing credentials to ESDB

### DIFF
--- a/src/ReactiveDomain.Persistence/EventStore/EventStoreConnectionManager.cs
+++ b/src/ReactiveDomain.Persistence/EventStore/EventStoreConnectionManager.cs
@@ -14,16 +14,23 @@ namespace ReactiveDomain.EventStore
         private readonly ILogger _log = LogManager.GetLogger(nameof(EventStoreConnectionManager));
         private static readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None };
 
+        /// <summary>
+        /// Gets the connection to ESDB as an <see cref="IStreamStoreConnection"/>.
+        /// </summary>
         public IStreamStoreConnection Connection => ESConnection;
-        public EventStoreConnectionWrapper ESConnection { get; private set; }
+        /// <summary>
+        /// Gets the connection to ESDB.
+        /// </summary>
+        public EventStoreConnectionWrapper ESConnection { get; }
 
         /// <summary>
         /// Setup EventStore based on the config settings provided by the caller
         /// </summary>
         /// <param name="config"><see cref="EsdbConfig"/> defined by the caller.</param>
-        public EventStoreConnectionManager(EsdbConfig config)
+        /// <param name="credentials">User credentials to use for the connection.</param>
+        public EventStoreConnectionManager(EsdbConfig config, UserCredentials credentials = null)
         {
-            ESConnection = new EventStoreConnectionWrapper(EventStoreConnection.Create(config.ConnectionString));
+            ESConnection = new EventStoreConnectionWrapper(EventStoreConnection.Create(config.ConnectionString), credentials);
 
             //TODO: The connection settings to keep retrying in the EventStore code circumvents this loop of 8 tries never returning from the Connect call.
             Connection.Connect();

--- a/src/ReactiveDomain.Persistence/IStreamStoreConnection.cs
+++ b/src/ReactiveDomain.Persistence/IStreamStoreConnection.cs
@@ -68,13 +68,13 @@ namespace ReactiveDomain
         /// <param name="stream">The stream to subscribe to.</param>
         /// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
         /// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
-        /// <param name="userCredentials">User credentials to use for the operation.</param>
+        /// <param name="credentials">User credentials to use for the operation.</param>
         /// <returns>An IDisposable that can be used to dispose the subscription.</returns>
         IDisposable SubscribeToStream(
             string stream,
             Action<RecordedEvent> eventAppeared,
             Action<SubscriptionDropReason, Exception> subscriptionDropped = null,
-            UserCredentials userCredentials = null);
+            UserCredentials credentials = null);
 
         /// <summary>
         /// Subscribes to a single event stream. Existing events from
@@ -103,7 +103,7 @@ namespace ReactiveDomain
         /// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
         /// <param name="liveProcessingStarted">An action invoked when the subscription switches to newly-pushed events.</param>
         /// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
-        /// <param name="userCredentials">User credentials to use for the operation.</param>
+        /// <param name="credentials">User credentials to use for the operation.</param>
         /// <param name="settings">The <see cref="T:ReactiveDomain.CatchUpSubscriptionSettings" /> for the subscription.</param>
         /// <returns>An IDisposable that can be used to close the subscription.</returns>
         IDisposable SubscribeToStreamFrom(
@@ -113,7 +113,7 @@ namespace ReactiveDomain
                  Action<RecordedEvent> eventAppeared,
                  Action<Unit> liveProcessingStarted = null,
                  Action<SubscriptionDropReason, Exception> subscriptionDropped = null,
-                 UserCredentials userCredentials = null);
+                 UserCredentials credentials = null);
 
         /// <summary>
         /// Asynchronously subscribes to all events. New
@@ -122,13 +122,13 @@ namespace ReactiveDomain
         /// </summary>
         /// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
         /// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
-        /// <param name="userCredentials">User credentials to use for the operation.</param>
+        /// <param name="credentials">User credentials to use for the operation.</param>
         /// <param name="resolveLinkTos">If true, resolve link events.</param>
         /// <returns>An IDisposable that can be used to close the subscription.</returns>
         IDisposable SubscribeToAll(
             Action<RecordedEvent> eventAppeared,
             Action<SubscriptionDropReason, Exception> subscriptionDropped = null,
-            UserCredentials userCredentials = null,
+            UserCredentials credentials = null,
             bool resolveLinkTos = true);
 
         IDisposable SubscribeToAllFrom(
@@ -137,7 +137,7 @@ namespace ReactiveDomain
             CatchUpSubscriptionSettings settings = null,
             Action liveProcessingStarted = null,
             Action<SubscriptionDropReason, Exception> subscriptionDropped = null,
-            UserCredentials userCredentials = null,
+            UserCredentials credentials = null,
             bool resolveLinkTos = true);
 
         void DeleteStream(string stream, long expectedVersion, UserCredentials credentials = null);

--- a/src/ReactiveDomain.Testing/EventStore/MockStreamStoreConnection.cs
+++ b/src/ReactiveDomain.Testing/EventStore/MockStreamStoreConnection.cs
@@ -324,7 +324,7 @@ namespace ReactiveDomain.Testing.EventStore
             string stream,
             Action<RecordedEvent> eventAppeared,
             Action<SubscriptionDropReason, Exception> subscriptionDropped = null,
-            UserCredentials userCredentials = null)
+            UserCredentials credentials = null)
         {
             long currentPos = 0;
             lock (_store) {
@@ -340,7 +340,7 @@ namespace ReactiveDomain.Testing.EventStore
                 eventAppeared,
                 null, //live processing started
                 subscriptionDropped,
-                userCredentials);
+                credentials);
         }
         public IDisposable SubscribeToStreamFrom(
             string stream,
@@ -349,7 +349,7 @@ namespace ReactiveDomain.Testing.EventStore
             Action<RecordedEvent> eventAppeared,
             Action<Unit> liveProcessingStarted = null,
             Action<SubscriptionDropReason, Exception> subscriptionDropped = null,
-            UserCredentials userCredentials = null)
+            UserCredentials credentials = null)
         {
 
             var start = (lastCheckpoint ?? -1) + 1;
@@ -386,7 +386,7 @@ namespace ReactiveDomain.Testing.EventStore
 
         public IDisposable SubscribeToAllFrom(Position @from, Action<RecordedEvent> eventAppeared, CatchUpSubscriptionSettings settings = null,
                                               Action liveProcessingStarted = null, Action<SubscriptionDropReason, Exception> subscriptionDropped = null,
-                                              UserCredentials userCredentials = null, bool resolveLinkTos = true)
+                                              UserCredentials credentials = null, bool resolveLinkTos = true)
         {
             var current = (int)@from.CommitPosition;
             var currentEvents = new RecordedEvent[] { };
@@ -417,7 +417,7 @@ namespace ReactiveDomain.Testing.EventStore
         public IDisposable SubscribeToAll(
                                 Action<RecordedEvent> eventAppeared,
                                 Action<SubscriptionDropReason, Exception> subscriptionDropped = null,
-                                UserCredentials userCredentials = null,
+                                UserCredentials credentials = null,
                                 bool resolveLinkTos = true)
         {
             return SubscribeToAllFrom(
@@ -426,7 +426,7 @@ namespace ReactiveDomain.Testing.EventStore
                 null,
                 null,
                 subscriptionDropped,
-                userCredentials);
+                credentials);
         }
 
         public void DeleteStream(string stream, long expectedVersion, UserCredentials credentials = null)


### PR DESCRIPTION
**What does this pull request do?**
Enables authenticated connections to ESDB instances using the standard wrapper classes in ReactiveDomain. This allows a workaround for a recent TPC connection string processing change from EventStore.


**How does this pull request accomplish that goal?**
Callers to `EventStoreConnectionManager` and `EventStoreConnectionWrapper` can provide credentials for the ESDB connection.

**Why is this pull request important?**
Enables connecting to an ESDB instance that requires authentication.

**Link to any issues that this resolves**
"This does not address any open issues."