### PR TITLE
Adds a method to `AssertEx` to verify an RM's `Version`

### DIFF
--- a/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
@@ -35,7 +35,9 @@ namespace ReactiveDomain.Foundation
         /// The version is incremented after all handlers have been processed.
         /// The number of handlers (including none) will not impact the version.
         /// This can be used to ensure read model state for tests. This is *not*
-        /// the same as the version of any particular stream being read.
+        /// the same as the version of any particular stream being read. This can
+        /// include <see cref="StreamStoreMsgs.CatchupSubscriptionBecameLive"/>,
+        /// which may result in the Version being 1 greater than otherwise expected.
         /// </summary>
         public int Version { get; private set; }
 


### PR DESCRIPTION
**What does this pull request do?**
Makes it easier to wait for a read model to reach a particular `Version` in unit tests. This makes for more readable and more easily reviewable code.

**How does this pull request accomplish that goal?**
Adds a method to `AssertEx` to verify an RM's `Version` property.

**Why is this pull request important?**
Continued enhancement of `ReadModelBase` testability.

**Link to any issues that this resolves**
This does not address any open issues.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports
- [x] Any new code must be covered by at least one unit test
- [x] All public methods must be documented with XML comments