### PR TITLE
Remove SpinWait from IsOrBecomesTrue

### DIFF
--- a/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base.cs
@@ -62,7 +62,7 @@ namespace ReactiveDomain.Foundation.Tests
             var s1 = Namer.GenerateForAggregate(typeof(TestAggregate), aggId);
             AppendEvents(1, _conn, s1, 7);
             Start<TestAggregate>(aggId);
-            AssertEx.IsModelVersion(this, 2, 1000, msg: $"Expected 2 got {Version}"); // 1 message + CatchupSubscriptionBecameLive
+            AssertEx.AtLeastModelVersion(this, 2, 1000, msg: $"Expected 2 got {Version}"); // 1 message + CatchupSubscriptionBecameLive
             AssertEx.IsOrBecomesTrue(() => Sum == 7);
         }
         [Fact]
@@ -75,14 +75,14 @@ namespace ReactiveDomain.Foundation.Tests
             AppendEvents(1, _conn, s2, 5);
             Start<ReadModelTestCategoryAggregate>(null, true);
 
-            AssertEx.IsModelVersion(this, 3, 1000, msg: $"Expected 3 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 3, 1000, msg: $"Expected 3 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 12);
         }
         [Fact]
         public void can_read_one_stream()
         {
             Start(_stream1);
-            AssertEx.IsModelVersion(this, 11, 1000, msg: $"Expected 11 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 11, 1000, msg: $"Expected 11 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20);
             //confirm checkpoints
             Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
@@ -93,7 +93,7 @@ namespace ReactiveDomain.Foundation.Tests
         {
             Start(_stream1);
             Start(_stream2);
-            AssertEx.IsModelVersion(this, 22, 1000, msg: $"Expected 22 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 22, 1000, msg: $"Expected 22 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50);
             //confirm checkpoints
             Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
@@ -105,29 +105,29 @@ namespace ReactiveDomain.Foundation.Tests
         public void can_wait_for_one_stream_to_go_live()
         {
             Start(_stream1, null, true);
-            AssertEx.IsModelVersion(this, 11, 100, msg: $"Expected 11 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 11, 100, msg: $"Expected 11 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20, 100);
         }
         [Fact]
         public void can_wait_for_two_streams_to_go_live()
         {
             Start(_stream1, null, true);
-            AssertEx.IsModelVersion(this, 11, 100, msg: $"Expected 11 got {Version}");
-            AssertEx.IsOrBecomesTrue(() => Sum == 20, 100);
+            AssertEx.AtLeastModelVersion(this, 11, 100, msg: $"Expected 11 got {Version}");
+            AssertEx.IsOrBecomesTrue(() => Sum == 20, 150);
 
             Start(_stream2, null, true);
-            AssertEx.IsModelVersion(this, 21, 100, msg: $"Expected 21 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 21, 100, msg: $"Expected 21 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50, 150);
         }
         [Fact]
         public void can_listen_to_one_stream()
         {
             Start(_stream1);
-            AssertEx.IsModelVersion(this, 11, 1000, msg: $"Expected 11 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 11, 1000, msg: $"Expected 11 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20);
             //add more messages
             AppendEvents(10, _conn, _stream1, 5);
-            AssertEx.IsModelVersion(this, 21, 1000, msg: $"Expected 21 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 21, 1000, msg: $"Expected 21 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 70);
             //confirm checkpoints
             Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
@@ -139,12 +139,12 @@ namespace ReactiveDomain.Foundation.Tests
         {
             Start(_stream1);
             Start(_stream2);
-            AssertEx.IsModelVersion(this, 22, 1000, msg: $"Expected 22 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 22, 1000, msg: $"Expected 22 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50);
             //add more messages
             AppendEvents(10, _conn, _stream1, 5);
             AppendEvents(10, _conn, _stream2, 7);
-            AssertEx.IsModelVersion(this, 42, 1000, msg: $"Expected 42 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 42, 1000, msg: $"Expected 42 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 170);
             //confirm checkpoints
             Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
@@ -161,11 +161,11 @@ namespace ReactiveDomain.Foundation.Tests
             //start at the checkpoint
             Start(_stream1, checkPoint);
             //add the one recorded event
-            AssertEx.IsModelVersion(this, 2, 100, msg: $"Expected 2 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 2, 100, msg: $"Expected 2 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20);
             //add more messages
             AppendEvents(10, _conn, _stream1, 5);
-            AssertEx.IsModelVersion(this, 12, 100, msg: $"Expected 12 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 12, 100, msg: $"Expected 12 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 70);
             //confirm checkpoints
             Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
@@ -181,12 +181,12 @@ namespace ReactiveDomain.Foundation.Tests
             Start(_stream1, checkPoint1);
             Start(_stream2, checkPoint2);
             //add the recorded events 2 on stream 1 & 5 on stream 2
-            AssertEx.IsModelVersion(this, 7, 1000, msg: $"Expected 7 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 7, 1000, msg: $"Expected 7 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50, msg: $"Expected 50 got {Sum}");
             //add more messages
             AppendEvents(10, _conn, _stream1, 5);
             AppendEvents(10, _conn, _stream2, 7);
-            AssertEx.IsModelVersion(this, 27, 1000, msg: $"Expected 27 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 27, 1000, msg: $"Expected 27 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 170);
             //confirm checkpoints
             Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
@@ -203,11 +203,11 @@ namespace ReactiveDomain.Foundation.Tests
             Start(_stream1);
             Start(_stream1);
             //double events
-            AssertEx.IsModelVersion(this, 22, 1000, msg: $"Expected 22 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 22, 1000, msg: $"Expected 22 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 40);
             //even more doubled events
             AppendEvents(10, _conn, _stream1, 5);
-            AssertEx.IsModelVersion(this, 42, 2000, msg: $"Expected 42 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 42, 2000, msg: $"Expected 42 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 140);
         }
 

--- a/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base.cs
@@ -37,7 +37,8 @@ namespace ReactiveDomain.Foundation.Tests
 
             AppendEvents(10, _conn, _stream1, 2);
             AppendEvents(10, _conn, _stream2, 3);
-            _conn.TryConfirmStream(_stream1, 10);
+
+            _conn.TryConfirmStream(_stream1, 10);          
             _conn.TryConfirmStream(_stream2, 10);
             _conn.TryConfirmStream(Namer.GenerateForCategory(typeof(TestAggregate)), 20);
         }
@@ -116,7 +117,7 @@ namespace ReactiveDomain.Foundation.Tests
 
             Start(_stream2, null, true);
             AssertEx.IsModelVersion(this, 21, 100, msg: $"Expected 21 got {Version}");
-            AssertEx.IsOrBecomesTrue(() => Sum == 50, 100);
+            AssertEx.IsOrBecomesTrue(() => Sum == 50, 150);
         }
         [Fact]
         public void can_listen_to_one_stream()

--- a/src/ReactiveDomain.Testing/ConnectionUtil.cs
+++ b/src/ReactiveDomain.Testing/ConnectionUtil.cs
@@ -7,7 +7,7 @@ namespace ReactiveDomain.Testing {
             while (true) {
                 try {
                     var slice = conn.ReadStreamForward(streamTypeName, StreamPosition.Start, 500);
-                    if (slice.IsEndOfStream && slice.Events.Length == expectedEventCount) {
+                    if (slice.IsEndOfStream && slice.Events.Length >= expectedEventCount) {
                         return true;
                     }
                     Thread.Sleep(10);

--- a/src/ReactiveDomain.Testing/Specifications/TestQueue.cs
+++ b/src/ReactiveDomain.Testing/Specifications/TestQueue.cs
@@ -126,15 +126,11 @@ namespace ReactiveDomain.Testing
             var endTime = startTime + (int)timeout.TotalMilliseconds;
 
             var delay = 1;
-            while (true)
+            //Evaluating the entire queue is a bit heavy, but is required to support waiting on base types, interfaces, etc. 
+            while (!AssertEx.EvaluateAfterDelay(() => Messages.Count(x => x is T) >= num, TimeSpan.FromMilliseconds(delay)))
             {
                 if (_disposed) { throw new ObjectDisposedException(nameof(TestQueue)); }
-                //Evaluating the entire queue is a bit heavy, but is required to support waiting on base types, interfaces, etc. 
-                using (var task = AssertEx.EvaluateAfterDelay(() => Messages.Count(x => x is T) >= num, TimeSpan.FromMilliseconds(delay)))
-                {
-                    task.Wait();
-                    if (task.Result == true) { break; }
-                }
+
                 var now = Environment.TickCount;
                 if ((endTime - now) <= 0) { throw new TimeoutException(); }
 


### PR DESCRIPTION
**What does this pull request do?**
Fix multiplatform test issues from the use of spinwait


**How does this pull request accomplish that goal?**
remove spinwait, use await


**Why is this pull request important?**
tests should run on all platforms


This does not address any open issues.


**Checklist**
- [X] All unit tests in the solution must pass on all versions of .NET that the solution supports
- [X] Any new code must be covered by at least one unit test
- [X] All public methods must be documented with XML comments