### PR TITLE
Test specifications implement IDisposable

### DIFF
--- a/src/ReactiveDomain.Testing/ReactiveDomain.Testing.csproj.DotSettings
+++ b/src/ReactiveDomain.Testing/ReactiveDomain.Testing.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=specifications/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/ReactiveDomain.Testing/Specifications/DispatcherSpecification.cs
+++ b/src/ReactiveDomain.Testing/Specifications/DispatcherSpecification.cs
@@ -4,7 +4,7 @@ using ReactiveDomain.Messaging.Bus;
 
 namespace ReactiveDomain.Testing
 {
-    public abstract class DispatcherSpecification
+    public abstract class DispatcherSpecification : IDisposable
     {
         public readonly IDispatcher Dispatcher;
         public readonly IDispatcher LocalBus;
@@ -15,6 +15,26 @@ namespace ReactiveDomain.Testing
             Dispatcher = new Dispatcher("Fixture Bus", slowMsgThreshold: TimeSpan.FromMilliseconds(500));
             LocalBus = new Dispatcher("Fixture LocalBus");
             TestQueue = new TestQueue(Dispatcher, new[] { typeof(Event), typeof(Command) });
+        }
+
+        private bool _disposed;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+            if (disposing)
+            {
+                Dispatcher?.Dispose();
+                LocalBus?.Dispose();
+                TestQueue?.Dispose();
+            }
+            _disposed = true;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
+++ b/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
@@ -15,8 +15,7 @@ namespace ReactiveDomain.Testing
         public IEventSerializer EventSerializer { get; }
         public IConfiguredConnection ConfiguredConnection { get; }
 
-        private string _schema;
-        public string Schema => _schema;
+        public string Schema { get; }
 
         /// <summary>
         /// Creates a mock repository.
@@ -25,7 +24,7 @@ namespace ReactiveDomain.Testing
         /// <param name="dataStore">Stream store connection.</param>
         private MockRepositorySpecification(string schema, IStreamStoreConnection dataStore)
         {
-            _schema = schema;
+            Schema = schema;
             StreamNameBuilder = string.IsNullOrEmpty(schema) ? new PrefixedCamelCaseStreamNameBuilder() : new PrefixedCamelCaseStreamNameBuilder(schema);
             StreamStoreConnection = dataStore;
             StreamStoreConnection.Connect();
@@ -47,17 +46,13 @@ namespace ReactiveDomain.Testing
         /// Creates a mock repository with a prefix.
         /// </summary>
         /// <param name="schema">Schema prefix for stream name. Default value is "Test".</param>
-        public MockRepositorySpecification(string schema = "Test") : this(schema, new MockStreamStoreConnection(schema))
-        {
-        }
+        public MockRepositorySpecification(string schema = "Test") : this(schema, new MockStreamStoreConnection(schema)) { }
 
         /// <summary>
         /// Creates a mock repository connected to a StreamStore. 
         /// </summary>
         /// <param name="dataStore">Stream store connection.</param>
-        public MockRepositorySpecification(IStreamStoreConnection dataStore) : this(dataStore.ConnectionName, dataStore)
-        {
-        }
+        public MockRepositorySpecification(IStreamStoreConnection dataStore) : this(dataStore.ConnectionName, dataStore) { }
 
         public virtual void ClearQueues()
         {
@@ -71,5 +66,19 @@ namespace ReactiveDomain.Testing
                                 StreamStoreConnection,
                                 StreamNameBuilder,
                                 EventSerializer);
+
+        private bool _disposed;
+        protected override void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+            if (disposing)
+            {
+                StreamStoreConnection.Dispose();
+                RepositoryEvents.Dispose();
+            }
+            _disposed = true;
+            base.Dispose(disposing);
+        }
     }
 }

--- a/src/ReactiveDomain.Testing/Specifications/MockRepositoryTests.cs
+++ b/src/ReactiveDomain.Testing/Specifications/MockRepositoryTests.cs
@@ -21,6 +21,7 @@ namespace ReactiveDomain.Testing
         public void Dispose()
         {
             _fixture.Dispatcher.Unsubscribe<TestCommands.Command1>(this);
+            _fixture.Dispose();
         }
         [Fact]
         public void can_get_repository_events()


### PR DESCRIPTION
**What does this pull request do?**
Explicitly dispose of resources in test specifications

**How does this pull request accomplish that goal?**
`DispatcherSpecification` and `MockRepositorySpecification` implement the `IDisposable` interface.

**Why is this pull request important?**
Test specifications predictably dispose of their resources.

**Link to any issues that this resolves**
This does not address any open issues.

**Potential breaking change**
Note that any test classes that inherit from these specification classes and then implement `IDisposable` will need to be updated to use `Dispose(bool)` so as not to hide the base class's `Dispose` method.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports
- [x] Any new code must be covered by at least one unit test
- [x] All public methods must be documented with XML comments