### PR TITLE
Adds overloads with TimeSpan timeouts to AssertEx methods

### DIFF
--- a/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base.cs
@@ -62,7 +62,7 @@ namespace ReactiveDomain.Foundation.Tests
             var s1 = Namer.GenerateForAggregate(typeof(TestAggregate), aggId);
             AppendEvents(1, _conn, s1, 7);
             Start<TestAggregate>(aggId);
-            AssertEx.AtLeastModelVersion(this, 2, 1000, msg: $"Expected 2 got {Version}"); // 1 message + CatchupSubscriptionBecameLive
+            AssertEx.AtLeastModelVersion(this, 2, msg: $"Expected 2 got {Version}"); // 1 message + CatchupSubscriptionBecameLive
             AssertEx.IsOrBecomesTrue(() => Sum == 7);
         }
         [Fact]
@@ -75,14 +75,14 @@ namespace ReactiveDomain.Foundation.Tests
             AppendEvents(1, _conn, s2, 5);
             Start<ReadModelTestCategoryAggregate>(null, true);
 
-            AssertEx.AtLeastModelVersion(this, 3, 1000, msg: $"Expected 3 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 3, msg: $"Expected 3 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 12);
         }
         [Fact]
         public void can_read_one_stream()
         {
             Start(_stream1);
-            AssertEx.AtLeastModelVersion(this, 11, 1000, msg: $"Expected 11 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 11, msg: $"Expected 11 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20);
             //confirm checkpoints
             Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
@@ -93,7 +93,7 @@ namespace ReactiveDomain.Foundation.Tests
         {
             Start(_stream1);
             Start(_stream2);
-            AssertEx.AtLeastModelVersion(this, 22, 1000, msg: $"Expected 22 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 22, msg: $"Expected 22 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50);
             //confirm checkpoints
             Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
@@ -105,29 +105,29 @@ namespace ReactiveDomain.Foundation.Tests
         public void can_wait_for_one_stream_to_go_live()
         {
             Start(_stream1, null, true);
-            AssertEx.AtLeastModelVersion(this, 11, 100, msg: $"Expected 11 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 11, TimeSpan.FromMilliseconds(100), msg: $"Expected 11 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20, 100);
         }
         [Fact]
         public void can_wait_for_two_streams_to_go_live()
         {
             Start(_stream1, null, true);
-            AssertEx.AtLeastModelVersion(this, 11, 100, msg: $"Expected 11 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 11, TimeSpan.FromMilliseconds(100), msg: $"Expected 11 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20, 150);
 
             Start(_stream2, null, true);
-            AssertEx.AtLeastModelVersion(this, 21, 100, msg: $"Expected 21 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 21, TimeSpan.FromMilliseconds(100), msg: $"Expected 21 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50, 150);
         }
         [Fact]
         public void can_listen_to_one_stream()
         {
             Start(_stream1);
-            AssertEx.AtLeastModelVersion(this, 11, 1000, msg: $"Expected 11 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 11, msg: $"Expected 11 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20);
             //add more messages
             AppendEvents(10, _conn, _stream1, 5);
-            AssertEx.AtLeastModelVersion(this, 21, 1000, msg: $"Expected 21 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 21, msg: $"Expected 21 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 70);
             //confirm checkpoints
             Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
@@ -139,12 +139,12 @@ namespace ReactiveDomain.Foundation.Tests
         {
             Start(_stream1);
             Start(_stream2);
-            AssertEx.AtLeastModelVersion(this, 22, 1000, msg: $"Expected 22 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 22, msg: $"Expected 22 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50);
             //add more messages
             AppendEvents(10, _conn, _stream1, 5);
             AppendEvents(10, _conn, _stream2, 7);
-            AssertEx.AtLeastModelVersion(this, 42, 1000, msg: $"Expected 42 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 42, msg: $"Expected 42 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 170);
             //confirm checkpoints
             Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
@@ -161,11 +161,11 @@ namespace ReactiveDomain.Foundation.Tests
             //start at the checkpoint
             Start(_stream1, checkPoint);
             //add the one recorded event
-            AssertEx.AtLeastModelVersion(this, 2, 100, msg: $"Expected 2 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 2, TimeSpan.FromMilliseconds(100), msg: $"Expected 2 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20);
             //add more messages
             AppendEvents(10, _conn, _stream1, 5);
-            AssertEx.AtLeastModelVersion(this, 12, 100, msg: $"Expected 12 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 12, TimeSpan.FromMilliseconds(100), msg: $"Expected 12 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 70);
             //confirm checkpoints
             Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
@@ -181,12 +181,12 @@ namespace ReactiveDomain.Foundation.Tests
             Start(_stream1, checkPoint1);
             Start(_stream2, checkPoint2);
             //add the recorded events 2 on stream 1 & 5 on stream 2
-            AssertEx.AtLeastModelVersion(this, 7, 1000, msg: $"Expected 7 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 7, msg: $"Expected 7 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50, msg: $"Expected 50 got {Sum}");
             //add more messages
             AppendEvents(10, _conn, _stream1, 5);
             AppendEvents(10, _conn, _stream2, 7);
-            AssertEx.AtLeastModelVersion(this, 27, 1000, msg: $"Expected 27 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 27, msg: $"Expected 27 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 170);
             //confirm checkpoints
             Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
@@ -203,11 +203,11 @@ namespace ReactiveDomain.Foundation.Tests
             Start(_stream1);
             Start(_stream1);
             //double events
-            AssertEx.AtLeastModelVersion(this, 22, 1000, msg: $"Expected 22 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 22, msg: $"Expected 22 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 40);
             //even more doubled events
             AppendEvents(10, _conn, _stream1, 5);
-            AssertEx.AtLeastModelVersion(this, 42, 2000, msg: $"Expected 42 got {Version}");
+            AssertEx.AtLeastModelVersion(this, 42, TimeSpan.FromSeconds(2), msg: $"Expected 42 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 140);
         }
 

--- a/src/ReactiveDomain.Testing/AssertEx.cs
+++ b/src/ReactiveDomain.Testing/AssertEx.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Data.SqlTypes;
 using System.Threading;
-using System.Threading.Tasks;
 using ReactiveDomain.Foundation;
 using ReactiveDomain.Messaging.Bus;
-using ReactiveDomain.Util;
 using Xunit;
 
 
@@ -50,9 +47,26 @@ namespace ReactiveDomain.Testing
         /// Will yield the thread after each evaluation.  
         /// </summary>
         /// <param name="func">The function to evaluate.</param>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="msg">A message to display if the condition is not satisfied.</param>
+        public static void IsOrBecomesFalse(Func<bool> func, TimeSpan timeout, string msg = null)
+        {
+            if (timeout <= TimeSpan.Zero)
+                throw new ArgumentException("Timeout must be greater than zero", nameof(timeout));
+            IsOrBecomesFalse(func, (int)timeout.TotalMilliseconds, msg);
+        }
+
+        /// <summary>
+        /// Asserts the given function will return false before the timeout expires.  
+        /// Repeatedly evaluates the function until false is returned or the timeout expires.  
+        /// Will return immediately when the condition is false.  
+        /// Evaluates the condition on an exponential back off up to 250 ms until timeout.  
+        /// Will yield the thread after each evaluation.  
+        /// </summary>
+        /// <param name="func">The function to evaluate.</param>
         /// <param name="timeout">A timeout in milliseconds. If not specified, defaults to 1000.</param>
         /// <param name="msg">A message to display if the condition is not satisfied.</param>
-        /// <param name="yieldThread">Ignored, will be removed in a future release</param>
+        /// <param name="yieldThread">Ignored, will be removed in a future release.</param>
         public static void IsOrBecomesFalse(Func<bool> func, int? timeout = null, string msg = null, bool yieldThread = false)
         {
             IsOrBecomesTrue(() => !func(), timeout, msg);
@@ -66,12 +80,29 @@ namespace ReactiveDomain.Testing
         /// Will yield the thread after each evaluation.  
         /// </summary>
         /// <param name="func">The function to evaluate.</param>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="msg">A message to display if the condition is not satisfied.</param>
+        public static void IsOrBecomesTrue(Func<bool> func, TimeSpan timeout, string msg = null)
+        {
+            if (timeout <= TimeSpan.Zero)
+                throw new ArgumentException("Timeout must be greater than zero", nameof(timeout));
+            IsOrBecomesTrue(func, (int)timeout.TotalMilliseconds, msg);
+        }
+
+        /// <summary>
+        /// Asserts the given function will return true before the timeout expires.  
+        /// Repeatedly evaluates the function until true is returned or the timeout expires.  
+        /// Will return immediately when the condition is true.  
+        /// Evaluates the condition on an exponential back off up to 250 ms until timeout.  
+        /// Will yield the thread after each evaluation.  
+        /// </summary>
+        /// <param name="func">The function to evaluate.</param>
         /// <param name="timeout">A timeout in milliseconds. If not specified, defaults to 1000.</param>
         /// <param name="msg">A message to display if the condition is not satisfied.</param>
-        /// <param name="yieldThread">Ignored, will be removed in a future release</param>
+        /// <param name="yieldThread">Ignored, will be removed in a future release.</param>
         public static void IsOrBecomesTrue(Func<bool> func, int? timeout = null, string msg = null, bool yieldThread = false)
         {
-            if (func() == true)
+            if (func())
             {
                 Assert.True(true, msg ?? "");
                 return;
@@ -104,7 +135,24 @@ namespace ReactiveDomain.Testing
 
         /// <summary>
         /// Asserts that the given read model will have at least the expected version before the
-        /// timeout expires.  If a test needs to check an exact model version use 'IsOrBecomesTrue(()=> ReadModel.Version == [expectedVersion], [timeout])'. 
+        /// timeout expires.  If a test needs to check an exact model version use
+        /// 'IsOrBecomesTrue(()=> ReadModel.Version == [expectedVersion], [timeout])'. 
+        /// </summary>
+        /// <param name="readModel">The read model.</param>
+        /// <param name="expectedVersion">The read model's expected minimum version.</param>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="msg">A message to display if the condition is not satisfied.</param>
+        public static void AtLeastModelVersion(ReadModelBase readModel, int expectedVersion, TimeSpan timeout, string msg = null)
+        {
+            if (timeout <= TimeSpan.Zero)
+                throw new ArgumentException("Timeout must be greater than zero", nameof(timeout));
+            AtLeastModelVersion(readModel, expectedVersion, (int)timeout.TotalMilliseconds, msg);
+        }
+
+        /// <summary>
+        /// Asserts that the given read model will have at least the expected version before the
+        /// timeout expires.  If a test needs to check an exact model version use
+        /// 'IsOrBecomesTrue(()=> ReadModel.Version == [expectedVersion], [timeout])'. 
         /// </summary>
         /// <param name="readModel">The read model.</param>
         /// <param name="expectedVersion">The read model's expected minimum version.</param>
@@ -120,7 +168,7 @@ namespace ReactiveDomain.Testing
         /// The current thread will yield at the start of the delay.  
         /// </summary>
         /// <param name="func">The function to evaluate.</param>
-        /// <param name="delay">A delay timeSpan.</param>
+        /// <param name="delay">A delay <see cref="TimeSpan"/>.</param>
         public static bool EvaluateAfterDelay(Func<bool> func, TimeSpan delay)
         {
             Thread.Sleep(delay);

--- a/src/ReactiveDomain.Testing/EventStore/StreamStoreSubscriptionTests.cs
+++ b/src/ReactiveDomain.Testing/EventStore/StreamStoreSubscriptionTests.cs
@@ -119,12 +119,12 @@ namespace ReactiveDomain.Testing.EventStore
                                             (reason, ex) => dropped = true);
 
 
-                AssertEx.IsOrBecomesTrue(() => liveProcessingStarted, 2000, msg: "Failed handle live processing start");
-                AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref evtCount) == 2, 5000, msg: $"Expected 2 Events got { Interlocked.Read(ref evtCount)}");
+                AssertEx.IsOrBecomesTrue(() => liveProcessingStarted, TimeSpan.FromSeconds(2), msg: "Failed handle live processing start");
+                AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref evtCount) == 2, TimeSpan.FromSeconds(5), msg: $"Expected 2 Events got { Interlocked.Read(ref evtCount)}");
                 Task.Run(() => AppendEvents(5, conn, streamName));
-                AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref evtCount) == 7, 5000, msg: $"Expected 7 Events got { Interlocked.Read(ref evtCount)}");
+                AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref evtCount) == 7, TimeSpan.FromSeconds(5), msg: $"Expected 7 Events got { Interlocked.Read(ref evtCount)}");
                 AppendEvents(5, conn, streamName);
-                AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref evtCount) == 12, 5000, msg: $"Expected 12 Events got { Interlocked.Read(ref evtCount)}");
+                AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref evtCount) == 12, TimeSpan.FromSeconds(5), msg: $"Expected 12 Events got { Interlocked.Read(ref evtCount)}");
                 sub.Dispose();
                 AssertEx.IsOrBecomesTrue(() => dropped, msg: "Failed to handle drop");
             }
@@ -224,7 +224,7 @@ namespace ReactiveDomain.Testing.EventStore
                     conn.TryConfirmStream(stream, 5);
                 }
                 Assert.False(dropped);
-                AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref evtCount) >= 10, 2000, $"Expected 10 got {Interlocked.Read(ref evtCount)}");
+                AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref evtCount) >= 10, TimeSpan.FromSeconds(2), $"Expected 10 got {Interlocked.Read(ref evtCount)}");
                 sub.Dispose();
                 AssertEx.IsOrBecomesTrue(() => dropped, msg: "Failed to handle drop");
             }
@@ -260,7 +260,7 @@ namespace ReactiveDomain.Testing.EventStore
                 AppendEvents(5, conn, streams[0]);
                 AppendEvents(5, conn, streams[1]);
                 Assert.True(conn.TryConfirmStream(streamTypeName, 12), "Stream not ready.");
-                AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref evtCount) == 10, 2000,
+                AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref evtCount) == 10, TimeSpan.FromSeconds(2),
                     $"Expected 10 got {Interlocked.Read(ref evtCount)} on {conn.ConnectionName}");
                 sub.Dispose();
                 AssertEx.IsOrBecomesTrue(() => dropped, msg: "Failed to handle drop");


### PR DESCRIPTION
**What does this pull request do?**
A number of users have requested versions of the `IsOrBecomes` methods in `AssertEx` that have timeouts specified using `TimeSpan` instead of as an integer number of milliseconds.

**How does this pull request accomplish that goal?**
Adds overloads of both methods. The timeouts are required for these overloads, and do not implement the deprecated `yieldThread` parameter.

**Why is this pull request important?**
Makes test code more readable.

**Link to any issues that this resolves**
This does not address any open issues.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports
- [x] Any new code must be covered by at least one unit test
- [x] All public methods must be documented with XML comments