### PR TITLE
Adds TryReadMetadataum extension method for Message

### DIFF
--- a/src/ReactiveDomain.Messaging.Tests/MessageExtensionsTests.cs
+++ b/src/ReactiveDomain.Messaging.Tests/MessageExtensionsTests.cs
@@ -1,0 +1,51 @@
+﻿using Xunit;
+
+namespace ReactiveDomain.Messaging.Tests
+{
+    public class MessageExtensionsTests
+    {
+        [Fact]
+        public void can_write_and_read_metadatum()
+        {
+            var metadatum = new CustomMetadata { Data = "Test" };
+            var message = new TestEvent();
+            message.WriteMetadatum(metadatum);
+
+            var md = message.ReadMetadatum<CustomMetadata>();
+            Assert.Equal(metadatum.Data, md.Data);
+        }
+
+        [Fact]
+        public void read_metadatum_throws_if_not_found()
+        {
+            var message = new TestEvent();
+            Assert.Throws<MetadatumNotFoundException>(() => message.ReadMetadatum<CustomMetadata>());
+        }
+
+        [Fact]
+        public void can_try_read_metadatum()
+        {
+            var metadatum = new CustomMetadata { Data = "Test" };
+            var message = new TestEvent();
+            message.WriteMetadatum(metadatum);
+
+            Assert.True(message.TryReadMetadatum<CustomMetadata>(out var md));
+            Assert.Equal(metadatum.Data, md.Data);
+        }
+
+        [Fact]
+        public void try_read_metadatum_reports_if_not_found()
+        {
+            var message = new TestEvent();
+            Assert.False(message.TryReadMetadatum<CustomMetadata>(out var md));
+            Assert.Equal(default, md);
+        }
+
+        public class TestEvent : Event { }
+
+        public class CustomMetadata
+        {
+            public string Data;
+        }
+    }
+}

--- a/src/ReactiveDomain.Messaging/Messages/MessageExtensions.cs
+++ b/src/ReactiveDomain.Messaging/Messages/MessageExtensions.cs
@@ -21,13 +21,28 @@
         /// Reads the metadata of the specified type from a <see cref="Message"/>.
         /// </summary>
         /// <typeparam name="T">The type of the metadata.</typeparam>
-        /// <param name="msg">The message to update.</param>
-        /// <returns>The metadata from the message or a default object of the specified type if no metadatum of that type is found on the message.</returns>
+        /// <param name="msg">The message to read.</param>
+        /// <returns>The metadata from the message.</returns>
+        /// <exception cref="MetadatumNotFoundException">Thrown if no metadatum of that type is found on the message.</exception>
         public static T ReadMetadatum<T>(this Message msg)
         {
             var mds = (IMetadataSource)msg;
             var md = mds.ReadMetadata() ?? mds.Initialize();
             return md.Read<T>();
+        }
+
+        /// <summary>
+        /// Tries to read the metadata of the specified type from a <see cref="Message"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the metadata.</typeparam>
+        /// <param name="msg">The message to read.</param>
+        /// <param name="metadatum">The metadata from the message.</param>
+        /// <returns>The metadata from the message or a default object of the specified type if no metadatum of that type is found on the message.</returns>
+        public static bool TryReadMetadatum<T>(this Message msg, out T metadatum)
+        {
+            var mds = (IMetadataSource)msg;
+            var md = mds.ReadMetadata() ?? mds.Initialize();
+            return md.TryRead(out metadatum);
         }
     }
 }


### PR DESCRIPTION
**What does this pull request do?**
Enables trying to read a metadatum object off a message if the caller isn't sure whether the message carries that type of metadata without having to pay the penalty performance of handling an exception.

**How does this pull request accomplish that goal?**
Adds a `TryReadMetadatum<T>` extension method for `Message`.

**Why is this pull request important?**
Performance can suffer when reading metadata off messages if the caller is uncertain which metadata are there.

**Link to any issues that this resolves**
This does not address any open issues.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports
- [x] Any new code must be covered by at least one unit test
- [x] All public methods must be documented with XML comments