### PR TITLE
Build symbols packages with nuget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,7 @@ PublishScripts/
 
 # NuGet Packages
 *.nupkg
+*.snupkg
 # The packages folder can be ignored because of Package Restore
 **/packages/*
 # except build/, which is used as an MSBuild target.

--- a/tools/CreateNuget.ps1
+++ b/tools/CreateNuget.ps1
@@ -233,9 +233,9 @@ UpdateDependencyVersions $ReactiveDomainTestingNuspec $ReactiveDomainTestingProj
 Write-Host "Packing reactivedomain nuget packages"
 $versionInfo = (Get-Item $ReactiveDomainDll).VersionInfo
 $versionString = $versionInfo.FileMajorPart.ToString() + "." + $versionInfo.FileMinorPart.ToString() + "." + $versionInfo.FileBuildPart.ToString()
-& $nuget pack $ReactiveDomainNuspec -Version $versionString
-& $nuget pack $ReactiveDomainPolicyNuspec -Version $versionString
-& $nuget pack $ReactiveDomainTestingNuspec -Version $versionString
+& $nuget pack $ReactiveDomainNuspec -Version $versionString -Symbols -SymbolPackageFormat snupkg
+& $nuget pack $ReactiveDomainPolicyNuspec -Version $versionString -Symbols -SymbolPackageFormat snupkg
+& $nuget pack $ReactiveDomainTestingNuspec -Version $versionString -Symbols -SymbolPackageFormat snupkg
 
 # *******************************************************************************************************************************
 


### PR DESCRIPTION
The CreateNuget script builds snupkg files along with nupkg files. When we use `nuget push`, they should get included automatically.