### PR TITLE
Migration to xUnit v3

### DIFF
--- a/src/Dependency.Versions.props
+++ b/src/Dependency.Versions.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Xunit>2.4.1</Xunit>
+        <Xunit>1.1.0</Xunit>
         <DotNetWatcher>1.0.1</DotNetWatcher>
         <NewtonsoftJson>12.0.2</NewtonsoftJson>
     </PropertyGroup>

--- a/src/ReactiveDomain.Foundation.Tests/ReactiveDomain.Foundation.Tests.csproj
+++ b/src/ReactiveDomain.Foundation.Tests/ReactiveDomain.Foundation.Tests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit.runner.console" Version="2.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ReactiveDomain.Foundation.Tests/ReactiveDomain.Foundation.Tests.csproj
+++ b/src/ReactiveDomain.Foundation.Tests/ReactiveDomain.Foundation.Tests.csproj
@@ -15,16 +15,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_future_stream.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_future_stream.cs
@@ -42,7 +42,7 @@ namespace ReactiveDomain.Foundation.Tests.StreamListenerTests
                    new PrefixedCamelCaseStreamNameBuilder(),
                    _eventSerializer);
             listener.EventStream.Subscribe(new AdHocHandler<Event>(Handle));
-            Assert.Throws<ArgumentException>(() => listener.Start(missingStream, validateStream: true));
+            Assert.Throws<ArgumentException>(() => listener.Start(missingStream, validateStream: true, cancelWaitToken: TestContext.Current.CancellationToken));
             listener.Dispose();
         }
         [Fact]
@@ -55,7 +55,7 @@ namespace ReactiveDomain.Foundation.Tests.StreamListenerTests
                    new PrefixedCamelCaseStreamNameBuilder(),
                    _eventSerializer);
             listener.EventStream.Subscribe(new AdHocHandler<Event>(Handle));
-            listener.Start(missingStream, validateStream: false);
+            listener.Start(missingStream, validateStream: false, cancelWaitToken: TestContext.Current.CancellationToken);
             Assert.True(listener.IsLive);
             listener.Dispose();
         }

--- a/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base.cs
@@ -61,7 +61,7 @@ namespace ReactiveDomain.Foundation.Tests
             var aggId = Guid.NewGuid();
             var s1 = Namer.GenerateForAggregate(typeof(TestAggregate), aggId);
             AppendEvents(1, _conn, s1, 7);
-            Start<TestAggregate>(aggId);
+            Start<TestAggregate>(aggId, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.AtLeastModelVersion(this, 2, msg: $"Expected 2 got {Version}"); // 1 message + CatchupSubscriptionBecameLive
             AssertEx.IsOrBecomesTrue(() => Sum == 7);
         }
@@ -73,7 +73,7 @@ namespace ReactiveDomain.Foundation.Tests
             AppendEvents(1, _conn, s1, 7);
             var s2 = Namer.GenerateForAggregate(typeof(ReadModelTestCategoryAggregate), Guid.NewGuid());
             AppendEvents(1, _conn, s2, 5);
-            Start<ReadModelTestCategoryAggregate>(null, true);
+            Start<ReadModelTestCategoryAggregate>(null, true, cancelWaitToken: TestContext.Current.CancellationToken);
 
             AssertEx.AtLeastModelVersion(this, 3, msg: $"Expected 3 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 12);
@@ -81,7 +81,7 @@ namespace ReactiveDomain.Foundation.Tests
         [Fact]
         public void can_read_one_stream()
         {
-            Start(_stream1);
+            Start(_stream1, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.AtLeastModelVersion(this, 11, msg: $"Expected 11 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20);
             //confirm checkpoints
@@ -91,8 +91,8 @@ namespace ReactiveDomain.Foundation.Tests
         [Fact]
         public void can_read_two_streams()
         {
-            Start(_stream1);
-            Start(_stream2);
+            Start(_stream1, cancelWaitToken: TestContext.Current.CancellationToken);
+            Start(_stream2, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.AtLeastModelVersion(this, 22, msg: $"Expected 22 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50);
             //confirm checkpoints
@@ -104,25 +104,25 @@ namespace ReactiveDomain.Foundation.Tests
         [Fact]
         public void can_wait_for_one_stream_to_go_live()
         {
-            Start(_stream1, null, true);
+            Start(_stream1, null, true, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.AtLeastModelVersion(this, 11, TimeSpan.FromMilliseconds(100), msg: $"Expected 11 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20, 100);
         }
         [Fact]
         public void can_wait_for_two_streams_to_go_live()
         {
-            Start(_stream1, null, true);
+            Start(_stream1, null, true, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.AtLeastModelVersion(this, 11, TimeSpan.FromMilliseconds(100), msg: $"Expected 11 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20, 150);
 
-            Start(_stream2, null, true);
+            Start(_stream2, null, true, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.AtLeastModelVersion(this, 21, TimeSpan.FromMilliseconds(100), msg: $"Expected 21 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50, 150);
         }
         [Fact]
         public void can_listen_to_one_stream()
         {
-            Start(_stream1);
+            Start(_stream1, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.AtLeastModelVersion(this, 11, msg: $"Expected 11 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20);
             //add more messages
@@ -137,8 +137,8 @@ namespace ReactiveDomain.Foundation.Tests
         [Fact]
         public void can_listen_to_two_streams()
         {
-            Start(_stream1);
-            Start(_stream2);
+            Start(_stream1, cancelWaitToken: TestContext.Current.CancellationToken);
+            Start(_stream2, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.AtLeastModelVersion(this, 22, msg: $"Expected 22 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50);
             //add more messages
@@ -159,7 +159,7 @@ namespace ReactiveDomain.Foundation.Tests
             var checkPoint = 8L;//Zero based, ignore the first 9 events
             Sum = 18;
             //start at the checkpoint
-            Start(_stream1, checkPoint);
+            Start(_stream1, checkPoint, cancelWaitToken: TestContext.Current.CancellationToken);
             //add the one recorded event
             AssertEx.AtLeastModelVersion(this, 2, TimeSpan.FromMilliseconds(100), msg: $"Expected 2 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20);
@@ -180,8 +180,8 @@ namespace ReactiveDomain.Foundation.Tests
             var checkPoint1 = 8L;//Zero based, ignore the first 9 events
             var checkPoint2 = 5L;//Zero based, ignore the first 6 events
             Sum = (9 * 2) + (6 * 3);
-            Start(_stream1, checkPoint1);
-            Start(_stream2, checkPoint2);
+            Start(_stream1, checkPoint1, cancelWaitToken: TestContext.Current.CancellationToken);
+            Start(_stream2, checkPoint2, cancelWaitToken: TestContext.Current.CancellationToken);
             //add the recorded events 2 on stream 1 & 5 on stream 2
             AssertEx.AtLeastModelVersion(this, 7, msg: $"Expected 7 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50, msg: $"Expected 50 got {Sum}");
@@ -202,8 +202,8 @@ namespace ReactiveDomain.Foundation.Tests
             Assert.Equal(0, Version);
             //weird but true
             //n.b. Don't do this on purpose
-            Start(_stream1);
-            Start(_stream1);
+            Start(_stream1, cancelWaitToken: TestContext.Current.CancellationToken);
+            Start(_stream1, cancelWaitToken: TestContext.Current.CancellationToken);
             //double events
             AssertEx.AtLeastModelVersion(this, 22, msg: $"Expected 22 got {Version}");
             AssertEx.IsOrBecomesTrue(() => Sum == 40);

--- a/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base_with_reader.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base_with_reader.cs
@@ -60,7 +60,7 @@ namespace ReactiveDomain.Foundation.Tests
             var aggId = Guid.NewGuid();
             var s1 = Namer.GenerateForAggregate(typeof(TestAggregate), aggId);
             AppendEvents(1, _conn, s1, 7);
-            Start<TestAggregate>(aggId);
+            Start<TestAggregate>(aggId, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.IsOrBecomesTrue(() => Count == 1, 1000, msg: $"Expected 1 got {Count}");
             AssertEx.IsOrBecomesTrue(() => Sum == 7);
         }
@@ -72,7 +72,7 @@ namespace ReactiveDomain.Foundation.Tests
             AppendEvents(1, _conn, s1, 7);
             var s2 = Namer.GenerateForAggregate(typeof(ReadModelTestCategoryAggregate), Guid.NewGuid());
             AppendEvents(1, _conn, s2, 5);
-            Start<ReadModelTestCategoryAggregate>(null, true);
+            Start<ReadModelTestCategoryAggregate>(null, true, cancelWaitToken: TestContext.Current.CancellationToken);
 
             AssertEx.IsOrBecomesTrue(() => Count == 2, 1000, msg: $"Expected 2 got {Count}");
             AssertEx.IsOrBecomesTrue(() => Sum == 12);
@@ -80,7 +80,7 @@ namespace ReactiveDomain.Foundation.Tests
         [Fact]
         public void can_read_one_stream()
         {
-            Start(_stream1);
+            Start(_stream1, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.IsOrBecomesTrue(() => Count == 10, 1000, msg: $"Expected 10 got {Count}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20);
             //confirm checkpoints
@@ -90,8 +90,8 @@ namespace ReactiveDomain.Foundation.Tests
         [Fact]
         public void can_read_two_streams()
         {
-            Start(_stream1);
-            Start(_stream2);
+            Start(_stream1, cancelWaitToken: TestContext.Current.CancellationToken);
+            Start(_stream2, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50);
             //confirm checkpoints
@@ -103,25 +103,25 @@ namespace ReactiveDomain.Foundation.Tests
         [Fact]
         public void can_wait_for_one_stream_to_go_live()
         {
-            Start(_stream1, null, true);
+            Start(_stream1, null, true, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.IsOrBecomesTrue(() => Count == 10, 100, msg: $"Expected 10 got {Count}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20, 100);
         }
         [Fact]
         public void can_wait_for_two_streams_to_go_live()
         {
-            Start(_stream1, null, true);
+            Start(_stream1, null, true, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.IsOrBecomesTrue(() => Count == 10, 100, msg: $"Expected 10 got {Count}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20, 100);
 
-            Start(_stream2, null, true);
+            Start(_stream2, null, true, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.IsOrBecomesTrue(() => Count == 20, 100, msg: $"Expected 20 got {Count}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50, 100);
         }
         [Fact]
         public void can_listen_to_one_stream()
         {
-            Start(_stream1);
+            Start(_stream1, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.IsOrBecomesTrue(() => Count == 10, 1000, msg: $"Expected 10 got {Count}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20);
             //add more messages
@@ -136,8 +136,8 @@ namespace ReactiveDomain.Foundation.Tests
         [Fact]
         public void can_listen_to_two_streams()
         {
-            Start(_stream1);
-            Start(_stream2);
+            Start(_stream1, cancelWaitToken: TestContext.Current.CancellationToken);
+            Start(_stream2, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50);
             //add more messages
@@ -159,7 +159,7 @@ namespace ReactiveDomain.Foundation.Tests
             Count = 9;
             Sum = 18;
             //start at the checkpoint
-            Start(_stream1, checkPoint);
+            Start(_stream1, checkPoint, cancelWaitToken: TestContext.Current.CancellationToken);
             //add the one recorded event
             AssertEx.IsOrBecomesTrue(() => Count == 10, 100, msg: $"Expected 10 got {Count}");
             AssertEx.IsOrBecomesTrue(() => Sum == 20);
@@ -179,8 +179,8 @@ namespace ReactiveDomain.Foundation.Tests
             var checkPoint2 = 5L;//Zero based, ignore the first 6 events
             Count = (9) + (6);
             Sum = (9 * 2) + (6 * 3);
-            Start(_stream1, checkPoint1);
-            Start(_stream2, checkPoint2);
+            Start(_stream1, checkPoint1, cancelWaitToken: TestContext.Current.CancellationToken);
+            Start(_stream2, checkPoint2, cancelWaitToken: TestContext.Current.CancellationToken);
             //add the recorded events 2 on stream 1 & 5 on stream 2
             AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
             AssertEx.IsOrBecomesTrue(() => Sum == 50, msg: $"Expected 50 got {Sum}");
@@ -201,8 +201,8 @@ namespace ReactiveDomain.Foundation.Tests
             Assert.Equal(0, Count);
             //weird but true
             //n.b. Don't do this on purpose
-            Start(_stream1);
-            Start(_stream1);
+            Start(_stream1, cancelWaitToken: TestContext.Current.CancellationToken);
+            Start(_stream1, cancelWaitToken: TestContext.Current.CancellationToken);
             //double events
             AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
             AssertEx.IsOrBecomesTrue(() => Sum == 40);

--- a/src/ReactiveDomain.Foundation.Tests/when_using_snapshot_read_model.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_snapshot_read_model.cs
@@ -120,7 +120,7 @@ namespace ReactiveDomain.Foundation.Tests {
             AssertEx.IsOrBecomesTrue(() => rm.Sum == 20);
 
             //can manually start
-            rm.Start<SnapReadModelTestAggregate>(_aggId, 9, true);
+            rm.Start<SnapReadModelTestAggregate>(_aggId, 9, true, cancelWaitToken: TestContext.Current.CancellationToken);
             AssertEx.IsOrBecomesTrue(() => rm.Count == 11, 1000);
             AssertEx.IsOrBecomesTrue(() => rm.Sum == 25);
             AppendEvents(1, _conn, _stream, 5);

--- a/src/ReactiveDomain.IdentityStorage.Tests/ReactiveDomain.IdentityStorage.Tests.csproj
+++ b/src/ReactiveDomain.IdentityStorage.Tests/ReactiveDomain.IdentityStorage.Tests.csproj
@@ -7,7 +7,7 @@
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="xunit" Version="2.9.2" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
       <PackageReference Include="xunit.runner.console" Version="2.9.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ReactiveDomain.IdentityStorage.Tests/ReactiveDomain.IdentityStorage.Tests.csproj
+++ b/src/ReactiveDomain.IdentityStorage.Tests/ReactiveDomain.IdentityStorage.Tests.csproj
@@ -6,16 +6,8 @@
     </PropertyGroup>
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="xunit" Version="2.9.2" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-      <PackageReference Include="xunit.runner.console" Version="2.9.2">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
+      <PackageReference Include="xunit.v3" Version="1.1.0" />
       <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     </ItemGroup>
     <ItemGroup>

--- a/src/ReactiveDomain.Messaging.Tests/LaterServiceTests.cs
+++ b/src/ReactiveDomain.Messaging.Tests/LaterServiceTests.cs
@@ -120,7 +120,7 @@ namespace ReactiveDomain.Messaging.Tests {
                     delay.Handle(new DelaySendEnvelope(timeSource, TimeSpan.FromMilliseconds(50), new TestMessage()));
                 }
                 timeSource.AdvanceTime(50);
-                cd.Wait(1000);
+                cd.Wait(1000, TestContext.Current.CancellationToken);
             }
             Assert.True(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - start <= 15000, $"elapsed {DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - start}");
         }
@@ -135,7 +135,7 @@ namespace ReactiveDomain.Messaging.Tests {
                 for (int i = 0; i < iterations; i++) {
                     delay.Handle(new DelaySendEnvelope(TimeSource.System, TimeSpan.FromMilliseconds(50), new TestMessage()));
                 }
-                cd.Wait(1000);
+                cd.Wait(1000, TestContext.Current.CancellationToken);
             }
             Assert.True(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - start <= 15000, $"elapsed {DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - start}");
         }

--- a/src/ReactiveDomain.Messaging.Tests/ReactiveDomain.Messaging.Tests.csproj
+++ b/src/ReactiveDomain.Messaging.Tests/ReactiveDomain.Messaging.Tests.csproj
@@ -10,16 +10,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3-beta1" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ReactiveDomain.Messaging.Tests/ReactiveDomain.Messaging.Tests.csproj
+++ b/src/ReactiveDomain.Messaging.Tests/ReactiveDomain.Messaging.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3-beta1" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit.runner.console" Version="2.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ReactiveDomain.Messaging.Tests/when_sending_commands_via_single_queued_dispatcher.cs
+++ b/src/ReactiveDomain.Messaging.Tests/when_sending_commands_via_single_queued_dispatcher.cs
@@ -31,7 +31,7 @@ namespace ReactiveDomain.Messaging.Tests {
 
         [Fact]
         public void send_cmd_msg_sequence_is_correct() {
-            var t1 = Task.Run(() => _dispatcher.Send(new TestCommands.Command1()));
+            var t1 = Task.Run(() => _dispatcher.Send(new TestCommands.Command1()), TestContext.Current.CancellationToken);
             AssertEx.EnsureRunning(t1);
             AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _gotAck) == 1);
             Assert.True(_commandHandleStarted == 0);

--- a/src/ReactiveDomain.Messaging.Tests/when_sending_remote_handled_commands.cs
+++ b/src/ReactiveDomain.Messaging.Tests/when_sending_remote_handled_commands.cs
@@ -42,12 +42,12 @@ namespace ReactiveDomain.Messaging.Tests {
             {
                 var ts1 = new CancellationTokenSource();
                 CommandResponse response1 = null;
-                var t1 = Task.Run(()=> Assert.False(_fixture.LocalBus.TrySend(new TestCommands.RemoteCancel(ts1.Token), out response1)));
+                var t1 = Task.Run(()=> Assert.False(_fixture.LocalBus.TrySend(new TestCommands.RemoteCancel(ts1.Token), out response1)), TestContext.Current.CancellationToken);
                 ts1.Cancel();
 
                 var ts2 = new CancellationTokenSource();
                 CommandResponse response2 = null;
-                var t2 = Task.Run(() => Assert.False(_fixture.RemoteBus.TrySend(new TestCommands.RemoteCancel(ts2.Token), out response2)));
+                var t2 = Task.Run(() => Assert.False(_fixture.RemoteBus.TrySend(new TestCommands.RemoteCancel(ts2.Token), out response2)), TestContext.Current.CancellationToken);
                 ts2.Cancel();
 
                 AssertEx.EnsureComplete(t1, t2);

--- a/src/ReactiveDomain.Policy.Tests/ReactiveDomain.Policy.Tests.csproj
+++ b/src/ReactiveDomain.Policy.Tests/ReactiveDomain.Policy.Tests.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="xunit" Version="2.9.2" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
       <PackageReference Include="xunit.runner.console" Version="2.9.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ReactiveDomain.Policy.Tests/ReactiveDomain.Policy.Tests.csproj
+++ b/src/ReactiveDomain.Policy.Tests/ReactiveDomain.Policy.Tests.csproj
@@ -10,16 +10,8 @@
   
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="xunit" Version="2.9.2" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-      <PackageReference Include="xunit.runner.console" Version="2.9.2">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
+      <PackageReference Include="xunit.v3" Version="1.1.0" />
       <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     </ItemGroup>
     <ItemGroup>

--- a/src/ReactiveDomain.PolicyStorage.Tests/ReactiveDomain.PolicyStorage.Tests.csproj
+++ b/src/ReactiveDomain.PolicyStorage.Tests/ReactiveDomain.PolicyStorage.Tests.csproj
@@ -16,7 +16,7 @@
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="xunit" Version="2.9.2" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
       <PackageReference Include="xunit.runner.console" Version="2.9.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ReactiveDomain.PolicyStorage.Tests/ReactiveDomain.PolicyStorage.Tests.csproj
+++ b/src/ReactiveDomain.PolicyStorage.Tests/ReactiveDomain.PolicyStorage.Tests.csproj
@@ -15,16 +15,8 @@
     </ItemGroup>   
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="xunit" Version="2.9.2" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-      <PackageReference Include="xunit.runner.console" Version="2.9.2">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
+      <PackageReference Include="xunit.v3" Version="1.1.0" />
       <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     </ItemGroup>
     <ItemGroup>

--- a/src/ReactiveDomain.Testing/EventStore/StreamReaderTests.cs
+++ b/src/ReactiveDomain.Testing/EventStore/StreamReaderTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
 
 // ReSharper disable UnusedParameter.Local
 

--- a/src/ReactiveDomain.Testing/ReactiveDomain.Testing.csproj
+++ b/src/ReactiveDomain.Testing/ReactiveDomain.Testing.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit.runner.console" Version="2.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ReactiveDomain.Testing/ReactiveDomain.Testing.csproj
+++ b/src/ReactiveDomain.Testing/ReactiveDomain.Testing.csproj
@@ -11,16 +11,8 @@
     <None Remove="Domain\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ReactiveDomain.Testing/Specifications/TestQueueTests.cs
+++ b/src/ReactiveDomain.Testing/Specifications/TestQueueTests.cs
@@ -1,9 +1,6 @@
-﻿
-
-using ReactiveDomain.Messaging;
+﻿using ReactiveDomain.Messaging;
 using ReactiveDomain.Messaging.Bus;
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -133,8 +130,8 @@ namespace ReactiveDomain.Testing.Specifications
         {
             using (var tq = new TestQueue(_dispatcher, new[] { typeof(Event), typeof(Command) }))
             {
-                Task.Run(() => Assert.Throws<InvalidOperationException>(() => tq.WaitFor<TestEvent>(TimeSpan.FromMilliseconds(100))))
-                    .ContinueWith(t => tq.Clear());
+                Task.Run(() => Assert.Throws<InvalidOperationException>(() => tq.WaitFor<TestEvent>(TimeSpan.FromMilliseconds(100))), TestContext.Current.CancellationToken)
+                    .ContinueWith(t => tq.Clear(), TestContext.Current.CancellationToken);
                 tq.AssertEmpty();
             }
         }
@@ -143,8 +140,8 @@ namespace ReactiveDomain.Testing.Specifications
         {
             using (var tq = new TestQueue(_dispatcher, new[] { typeof(Event), typeof(Command) }))
             {
-                Task.Run(() => Assert.Throws<InvalidOperationException>(() => tq.WaitForMsgId(Guid.NewGuid(), TimeSpan.FromMilliseconds(100))))
-                    .ContinueWith(t => tq.Clear());
+                Task.Run(() => Assert.Throws<InvalidOperationException>(() => tq.WaitForMsgId(Guid.NewGuid(), TimeSpan.FromMilliseconds(100))), TestContext.Current.CancellationToken)
+                    .ContinueWith(t => tq.Clear(), TestContext.Current.CancellationToken);
                 tq.AssertEmpty();
             }
         }
@@ -157,8 +154,8 @@ namespace ReactiveDomain.Testing.Specifications
                 var evt = new TestEvent();
                 var evt2 = new TestEvent();
                 //before
-                var t1 = Task.Run(() => tq.WaitForMsgId(evt.MsgId, TimeSpan.FromMilliseconds(1000)));
-                var t2 = Task.Run(() => tq.WaitForMsgId(evt2.MsgId, TimeSpan.FromMilliseconds(1000)));
+                var t1 = Task.Run(() => tq.WaitForMsgId(evt.MsgId, TimeSpan.FromMilliseconds(1000)), TestContext.Current.CancellationToken);
+                var t2 = Task.Run(() => tq.WaitForMsgId(evt2.MsgId, TimeSpan.FromMilliseconds(1000)), TestContext.Current.CancellationToken);
                 AssertEx.EnsureRunning(t1,t2);
 
                 _dispatcher.Publish(evt);
@@ -179,8 +176,8 @@ namespace ReactiveDomain.Testing.Specifications
             using (var tq = new TestQueue(_dispatcher))
             {
                 var evt = new TestEvent();
-                var t1 = Task.Run(() => tq.WaitForMsgId(evt.MsgId, TimeSpan.FromMilliseconds(1000)));
-                var t2 = Task.Run(() => tq.WaitForMsgId(evt.MsgId, TimeSpan.FromMilliseconds(1000)));
+                var t1 = Task.Run(() => tq.WaitForMsgId(evt.MsgId, TimeSpan.FromMilliseconds(1000)), TestContext.Current.CancellationToken);
+                var t2 = Task.Run(() => tq.WaitForMsgId(evt.MsgId, TimeSpan.FromMilliseconds(1000)), TestContext.Current.CancellationToken);
 
                 tq.Handle(evt);
                 tq.AssertNext<TestEvent>(evt.CorrelationId)
@@ -214,8 +211,8 @@ namespace ReactiveDomain.Testing.Specifications
                 var evt = new TestEvent();
                 var evt2 = new TestEvent();
 
-                var t1 = Task.Run(() => tq.WaitForMsgId(evt.MsgId, TimeSpan.FromMilliseconds(200)));
-                var t2 = Task.Run(() => tq.WaitForMsgId(evt2.MsgId, TimeSpan.FromMilliseconds(200)));
+                var t1 = Task.Run(() => tq.WaitForMsgId(evt.MsgId, TimeSpan.FromMilliseconds(200)), TestContext.Current.CancellationToken);
+                var t2 = Task.Run(() => tq.WaitForMsgId(evt2.MsgId, TimeSpan.FromMilliseconds(200)), TestContext.Current.CancellationToken);
 
                 _dispatcher.Publish(evt);
                 _dispatcher.Publish(evt2);

--- a/src/ReactiveDomain.Transport.Tests/ReactiveDomain.Transport.Tests.csproj
+++ b/src/ReactiveDomain.Transport.Tests/ReactiveDomain.Transport.Tests.csproj
@@ -5,16 +5,8 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ReactiveDomain.Transport.Tests/ReactiveDomain.Transport.Tests.csproj
+++ b/src/ReactiveDomain.Transport.Tests/ReactiveDomain.Transport.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit.runner.console" Version="2.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Migrates to xUnit.v3 v1.1.0 from xUnit testing framework.

This is nothing more than re-targeting to xunit.v3 libraries and code patches to relieve code analysis warnings in the solution.

If running nCrunch, you will need to set two custom settings, as shown in the screenshot below:

![image](https://github.com/user-attachments/assets/3acfb001-59e1-4def-99ba-7f7e271b9620)
