### PR TITLE
Removes .NET 6 support

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -48,7 +48,7 @@ jobs:
 
     strategy:
       matrix:
-        dotnet-version: [ '6.0', '8.0']
+        dotnet-version: [ '8.0' ]
         os: [windows-latest, ubuntu-latest]              
              
     runs-on: ${{ matrix.os }}       

--- a/src/ReactiveDomain.Debug.nuspec
+++ b/src/ReactiveDomain.Debug.nuspec
@@ -16,24 +16,9 @@
         <dependency id="System.Configuration.ConfigurationManager" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="System.Diagnostics.PerformanceCounter" version="8.0.0" exclude="Build,Analyzers" />
       </group>
-      <group targetFramework="net6.0">
-        <dependency id="EventStore.Client" version="21.2.2" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.CSharp" version="4.7.0" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-        <dependency id="System.Reactive" version="6.0.1" exclude="Build,Analyzers"/>
-        <dependency id="System.Configuration.ConfigurationManager" version="8.0.0" exclude="Build,Analyzers" />
-        <dependency id="System.Diagnostics.PerformanceCounter" version="8.0.0" exclude="Build,Analyzers" />
-      </group>
     </dependencies>
     <references>
       <group targetFramework="net8.0">
-        <reference file="ReactiveDomain.Core.dll" />
-        <reference file="ReactiveDomain.Foundation.dll" />
-        <reference file="ReactiveDomain.Messaging.dll" />
-        <reference file="ReactiveDomain.Persistence.dll" />
-        <reference file="ReactiveDomain.Transport.dll" />
-      </group>
-      <group targetFramework="net6.0">
         <reference file="ReactiveDomain.Core.dll" />
         <reference file="ReactiveDomain.Foundation.dll" />
         <reference file="ReactiveDomain.Messaging.dll" />
@@ -61,23 +46,5 @@
     <file src="..\bld\Debug\net8.0\ReactiveDomain.Messaging.dll" target="ref\net8.0" />
     <file src="..\bld\Debug\net8.0\ReactiveDomain.Persistence.dll" target="ref\net8.0" />
     <file src="..\bld\Debug\net8.0\ReactiveDomain.Transport.dll" target="ref\net8.0" />
-
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Core.pdb" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Foundation.pdb" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Messaging.pdb" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Persistence.pdb" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Transport.pdb" target="lib\net6.0" />
-    
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Core.dll" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Foundation.dll" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Messaging.dll" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Persistence.dll" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Transport.dll" target="lib\net6.0" />
-    
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Core.dll" target="ref\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Foundation.dll" target="ref\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Messaging.dll" target="ref\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Persistence.dll" target="ref\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Transport.dll" target="ref\net6.0" />
   </files>
 </package>

--- a/src/ReactiveDomain.Policy.Debug.nuspec
+++ b/src/ReactiveDomain.Policy.Debug.nuspec
@@ -18,24 +18,9 @@
         <dependency id="System.DirectoryServices" version="8.0.0" exclude="Build,Analyzers"/>
         <dependency id="System.DirectoryServices.AccountManagement" version="8.0.0" exclude="Build,Analyzers" />
       </group>
-      <group targetFramework="net6.0">
-        <dependency id="ReactiveDomain" version="0.11.0.0" exclude="Build,Analyzers" />
-        <dependency id="DynamicData" version="8.4.1" exclude="Build,Analyzers" />
-        <dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
-        <dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>
-        <dependency id="Microsoft.CSharp" version="4.7.0" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-        <dependency id="System.DirectoryServices" version="8.0.0" exclude="Build,Analyzers"/>
-        <dependency id="System.DirectoryServices.AccountManagement" version="8.0.0" exclude="Build,Analyzers" />
-      </group>
     </dependencies>
     <references>
       <group targetFramework="net8.0">
-        <reference file="ReactiveDomain.Policy.dll" />
-        <reference file="ReactiveDomain.PolicyStorage.dll" />
-        <reference file="ReactiveDomain.IdentityStorage.dll" />
-      </group>
-      <group targetFramework="net6.0">
         <reference file="ReactiveDomain.Policy.dll" />
         <reference file="ReactiveDomain.PolicyStorage.dll" />
         <reference file="ReactiveDomain.IdentityStorage.dll" />
@@ -59,17 +44,5 @@
     <file src="..\bld\Debug\net8.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net8.0" />
     <file src="..\bld\Debug\net8.0\ReactiveDomain.IdentityStorage.dll" target="lib\net8.0" />
     <file src="..\bld\Debug\net8.0\ReactiveDomain.IdentityStorage.dll" target="ref\net8.0" />
-    
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Policy.pdb" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Policy.dll" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Policy.dll" target="ref\net6.0" />
-
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.PolicyStorage.pdb" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.PolicyStorage.dll" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.PolicyStorage.dll" target="ref\net6.0" />
-
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.IdentityStorage.dll" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.IdentityStorage.dll" target="ref\net6.0" />
   </files>
 </package>

--- a/src/ReactiveDomain.Policy.nuspec
+++ b/src/ReactiveDomain.Policy.nuspec
@@ -6,7 +6,7 @@
     <authors>Reactive Domain Group</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
-    <description>Package includes all ReactiveDomain Core assemblies</description>
+    <description>Package includes all ReactiveDomain Identity and Policy assemblies</description>
     <copyright>Copyright © 2024 Reactive Domain Group</copyright>
     <dependencies>     
       <group targetFramework="net8.0">
@@ -19,24 +19,9 @@
         <dependency id="System.DirectoryServices" version="8.0.0" exclude="Build,Analyzers"/>
         <dependency id="System.DirectoryServices.AccountManagement" version="8.0.0" exclude="Build,Analyzers" />
       </group>
-      <group targetFramework="net6.0">
-        <dependency id="ReactiveDomain" version="0.11.0.0" exclude="Build,Analyzers" />
-        <dependency id="DynamicData" version="8.4.1" exclude="Build,Analyzers" />
-        <dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
-        <dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>
-        <dependency id="Microsoft.CSharp" version="4.7.0" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-        <dependency id="System.DirectoryServices" version="8.0.0" exclude="Build,Analyzers"/>
-        <dependency id="System.DirectoryServices.AccountManagement" version="8.0.0" exclude="Build,Analyzers" />
-      </group>
     </dependencies>
     <references>
       <group targetFramework="net8.0">
-        <reference file="ReactiveDomain.Policy.dll" />
-        <reference file="ReactiveDomain.PolicyStorage.dll" />
-        <reference file="ReactiveDomain.IdentityStorage.dll" />
-      </group>
-      <group targetFramework="net6.0">
         <reference file="ReactiveDomain.Policy.dll" />
         <reference file="ReactiveDomain.PolicyStorage.dll" />
         <reference file="ReactiveDomain.IdentityStorage.dll" />
@@ -60,17 +45,5 @@
     <file src="..\bld\Release\net8.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net8.0" />
     <file src="..\bld\Release\net8.0\ReactiveDomain.IdentityStorage.dll" target="lib\net8.0" />
     <file src="..\bld\Release\net8.0\ReactiveDomain.IdentityStorage.dll" target="ref\net8.0" />
-
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Policy.pdb" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Policy.dll" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Policy.dll" target="ref\net6.0" />
-
-    <file src="..\bld\Release\net6.0\ReactiveDomain.PolicyStorage.pdb" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.PolicyStorage.dll" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.PolicyStorage.dll" target="ref\net6.0" />
-
-    <file src="..\bld\Release\net6.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.IdentityStorage.dll" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.IdentityStorage.dll" target="ref\net6.0" />
   </files>
 </package>

--- a/src/ReactiveDomain.Testing.Debug.nuspec
+++ b/src/ReactiveDomain.Testing.Debug.nuspec
@@ -16,18 +16,9 @@
         <dependency id="xunit" version="2.9.0" exclude="Build,Analyzers" />
         <dependency id="xunit.runner.console" version="2.9.0" exclude="Build,Analyzers" />
       </group>
-      <group targetFramework="net6.0">
-        <dependency id="ReactiveDomain" version="0.11.0.0" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.NET.Test.Sdk" version="17.10.0" exclude="Build,Analyzers" />
-        <dependency id="xunit" version="2.9.0" exclude="Build,Analyzers" />
-        <dependency id="xunit.runner.console" version="2.9.0" exclude="Build,Analyzers" />
-      </group>
     </dependencies>
     <references>
       <group targetFramework="net8.0">
-        <reference file="ReactiveDomain.Testing.dll" />
-      </group>
-      <group targetFramework="net6.0">
         <reference file="ReactiveDomain.Testing.dll" />
       </group>
     </references>
@@ -37,9 +28,5 @@
     <file src="..\bld\Debug\net8.0\ReactiveDomain.Testing.pdb" target="lib\net8.0" />
     <file src="..\bld\Debug\net8.0\ReactiveDomain.Testing.dll" target="lib\net8.0" />
     <file src="..\bld\Debug\net8.0\ReactiveDomain.Testing.dll" target="ref\net8.0" />
-
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Testing.pdb" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Testing.dll" target="lib\net6.0" />
-    <file src="..\bld\Debug\net6.0\ReactiveDomain.Testing.dll" target="ref\net6.0" />
   </files>
 </package>

--- a/src/ReactiveDomain.Testing.nuspec
+++ b/src/ReactiveDomain.Testing.nuspec
@@ -16,18 +16,9 @@
         <dependency id="xunit" version="2.9.0" exclude="Build,Analyzers" />
         <dependency id="xunit.runner.console" version="2.9.0" exclude="Build,Analyzers" />
       </group>
-      <group targetFramework="net6.0">
-        <dependency id="ReactiveDomain" version="0.11.0.0" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.NET.Test.Sdk" version="17.10.0" exclude="Build,Analyzers" />
-        <dependency id="xunit" version="2.9.0" exclude="Build,Analyzers" />
-        <dependency id="xunit.runner.console" version="2.9.0" exclude="Build,Analyzers" />
-      </group>
     </dependencies>
     <references>
       <group targetFramework="net8.0">
-        <reference file="ReactiveDomain.Testing.dll" />
-      </group>
-      <group targetFramework="net6.0">
         <reference file="ReactiveDomain.Testing.dll" />
       </group>
     </references>
@@ -37,8 +28,5 @@
     <file src="..\bld\Release\net8.0\ReactiveDomain.Testing.pdb" target="lib\net8.0" />
     <file src="..\bld\Release\net8.0\ReactiveDomain.Testing.dll" target="lib\net8.0" />
     <file src="..\bld\Release\net8.0\ReactiveDomain.Testing.dll" target="ref\net8.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Testing.pdb" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Testing.dll" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Testing.dll" target="ref\net6.0" />
   </files>
 </package>

--- a/src/ReactiveDomain.nuspec
+++ b/src/ReactiveDomain.nuspec
@@ -17,14 +17,6 @@
         <dependency id="System.Configuration.ConfigurationManager" version="8.0.0" exclude="Build,Analyzers" />
         <dependency id="System.Diagnostics.PerformanceCounter" version="8.0.0" exclude="Build,Analyzers" />
       </group>
-      <group targetFramework="net6.0">
-        <dependency id="EventStore.Client" version="22.0.0" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.CSharp" version="4.7.0" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-        <dependency id="System.Reactive" version="6.0.1" exclude="Build,Analyzers" />
-        <dependency id="System.Configuration.ConfigurationManager" version="8.0.0" exclude="Build,Analyzers" />
-        <dependency id="System.Diagnostics.PerformanceCounter" version="8.0.0" exclude="Build,Analyzers" />
-      </group>
     </dependencies>
     <references>
       <group targetFramework="net8.0">
@@ -34,17 +26,7 @@
         <reference file="ReactiveDomain.Persistence.dll" />
         <reference file="ReactiveDomain.Transport.dll" />
       </group>
-      <group targetFramework="net6.0">
-        <reference file="ReactiveDomain.Core.dll" />
-        <reference file="ReactiveDomain.Foundation.dll" />
-        <reference file="ReactiveDomain.Messaging.dll" />
-        <reference file="ReactiveDomain.Persistence.dll" />
-        <reference file="ReactiveDomain.Transport.dll" />
-      </group>
     </references>
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="Microsoft.CSharp" targetFramework=".NETFramework4.0" />
-    </frameworkAssemblies>
   </metadata>
   <files>
     <file src="..\build\ReactiveDomain.props" target="build" />
@@ -63,20 +45,5 @@
     <file src="..\bld\Release\net8.0\ReactiveDomain.Messaging.dll" target="ref\net8.0" />
     <file src="..\bld\Release\net8.0\ReactiveDomain.Persistence.dll" target="ref\net8.0" />
     <file src="..\bld\Release\net8.0\ReactiveDomain.Transport.dll" target="ref\net8.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Core.pdb" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Foundation.pdb" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Messaging.pdb" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Persistence.pdb" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Transport.pdb" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Core.dll" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Foundation.dll" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Messaging.dll" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Persistence.dll" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Transport.dll" target="lib\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Core.dll" target="ref\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Foundation.dll" target="ref\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Messaging.dll" target="ref\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Persistence.dll" target="ref\net6.0" />
-    <file src="..\bld\Release\net6.0\ReactiveDomain.Transport.dll" target="ref\net6.0" />
   </files>
 </package>

--- a/src/build.props
+++ b/src/build.props
@@ -19,10 +19,10 @@
     <Prefer32Bit>false</Prefer32Bit>
     <Platforms>AnyCPU</Platforms>
     <Authors>Reactive Domain Group</Authors>
-    <Copyright>Copyright © 2024 Reactive Domain Group</Copyright>
+    <Copyright>Copyright © 2025 Reactive Domain Group</Copyright>
     <Description />
-    <AssemblyVersion>0.11.0.0</AssemblyVersion>
-    <FileVersion>0.11.0.0</FileVersion>
+    <AssemblyVersion>0.11.1.0</AssemblyVersion>
+    <FileVersion>0.11.1.0</FileVersion>
     <NeutralLanguage />
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <DebugSymbols>true</DebugSymbols>
@@ -50,7 +50,7 @@
     </When>
   </Choose>
   <PropertyGroup>
-    <LibTargetFrameworks>net6.0;net8.0</LibTargetFrameworks>
-    <TestTargetFrameworks>net6.0;net8.0</TestTargetFrameworks>
+    <LibTargetFrameworks>net8.0</LibTargetFrameworks>
+    <TestTargetFrameworks>net8.0</TestTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/tools/CreateDebugNuget.ps1
+++ b/tools/CreateDebugNuget.ps1
@@ -157,11 +157,6 @@ function GetPackageRefFromProject([string]$Id, [string]$CsProj, [string]$Framewo
     {
         $compOperator = "!="
     }
-
-     if ($currentCondition -match "net6.0")
-    {
-        $currentFramework = "net6.0"
-    }
       
     if ($currentCondition -match "net8.0")
     {
@@ -194,9 +189,6 @@ function UpdateDependencyVersions([string]$Nuspec, [string]$CsProj)
     $net8 = $xml | Select-XML -XPath "//package/metadata/dependencies/group[@targetFramework='net8.0']"
     $net8Nodes = $net8.Node.ChildNodes
        
-    $net6 = $xml | Select-XML -XPath "//package/metadata/dependencies/group[@targetFramework='net6.0']"
-    $net6Nodes = $net6.Node.ChildNodes
-    
     foreach($refnode in $net8Nodes)
     {
         if ( $refnode.id -match "ReactiveDomain")
@@ -214,24 +206,6 @@ function UpdateDependencyVersions([string]$Nuspec, [string]$CsProj)
             $refnode.version = $pRef.Version
         }      
     }   
-
-    foreach($refnode in $net6Nodes)
-    {
-        if ( $refnode.id -match "ReactiveDomain")
-        {
-            $refnode.version = $RDVersion
-            continue
-        }
-        
-        $pRef = GetPackageRefFromProject $refnode.id $CsProj "net6.0"
-        if ((($pRef.ComparisonOperator -eq "" -or $pRef.Framework -eq "") -or 
-            ($pRef.ComparisonOperator -eq "==" -and $pRef.Framework -eq "net6.0") -or 
-            ($pRef.ComparisonOperator -eq "!=" -and $pRef.Framework -ne "net6.0")) -and
-            ($pRef.version -ne ""))
-        { 
-            $refnode.version = $pRef.Version
-        }      
-    }    
     $xml.Save($Nuspec)
     Write-Host "Updated dependency versions of: $Nuspec"
 }


### PR DESCRIPTION
**What does this pull request do?**
Removes .NET 6 support. This leaves .NET 8 as the only target. The current plan is to only support LTS releases of .NET, but if there's enough of a reason to support .NET 9, that could be added later.


**How does this pull request accomplish that goal?**
Removes .NET 6 from build.props, from the GitHub Actions config, and from the nuspec files and related scripts.


**Why is this pull request important?**
.NET 6 is out of support, and is not supported on updated build VMs.


**Link to any issues that this resolves**
"This does not address any open issues."

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports
- [x] Any new code must be covered by at least one unit test
- [x] All public methods must be documented with XML comments