### PR TITLE
Update nuget package references

### DIFF
--- a/src/ReactiveDomain.Core/ReactiveDomain.Core.csproj
+++ b/src/ReactiveDomain.Core/ReactiveDomain.Core.csproj
@@ -8,6 +8,6 @@
   <ItemGroup>
     <InternalsVisibleTo Include="ReactiveDomain.Persistence" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.2" />
   </ItemGroup>
 </Project>

--- a/src/ReactiveDomain.Foundation.Tests/ReactiveDomain.Foundation.Tests.csproj
+++ b/src/ReactiveDomain.Foundation.Tests/ReactiveDomain.Foundation.Tests.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.2">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/ReactiveDomain.IdentityStorage.Tests/ReactiveDomain.IdentityStorage.Tests.csproj
+++ b/src/ReactiveDomain.IdentityStorage.Tests/ReactiveDomain.IdentityStorage.Tests.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="xunit" Version="2.9.2" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-      <PackageReference Include="xunit.runner.console" Version="2.9.2">
+      <PackageReference Include="xunit" Version="2.9.3" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+      <PackageReference Include="xunit.runner.console" Version="2.9.3">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/ReactiveDomain.IdentityStorage/ReactiveDomain.IdentityStorage.csproj
+++ b/src/ReactiveDomain.IdentityStorage/ReactiveDomain.IdentityStorage.csproj
@@ -10,13 +10,13 @@
     </AssemblyAttribute>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DynamicData" Version="8.4.1" />
+    <PackageReference Include="DynamicData" Version="9.1.2" />
     <PackageReference Include="IdentityModel" Version="4.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.DirectoryServices" Version="8.0.0" />
-    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="8.0.0" />
+    <PackageReference Include="System.DirectoryServices" Version="9.0.2" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="9.0.2" />
     <PackageReference Include="IdentityServer4.Storage" Version="4.1.2" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />

--- a/src/ReactiveDomain.Messaging.Tests/ReactiveDomain.Messaging.Tests.csproj
+++ b/src/ReactiveDomain.Messaging.Tests/ReactiveDomain.Messaging.Tests.csproj
@@ -5,14 +5,14 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
-    <PackageReference Include="System.CodeDom" Version="8.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageReference Include="System.CodeDom" Version="9.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3-beta1" />
+    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.2">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/ReactiveDomain.Messaging/ReactiveDomain.Messaging.csproj
+++ b/src/ReactiveDomain.Messaging/ReactiveDomain.Messaging.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.2" />
     <ProjectReference Include="..\ReactiveDomain.Core\ReactiveDomain.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/ReactiveDomain.Policy.Tests/ReactiveDomain.Policy.Tests.csproj
+++ b/src/ReactiveDomain.Policy.Tests/ReactiveDomain.Policy.Tests.csproj
@@ -10,9 +10,9 @@
   
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="xunit" Version="2.9.2" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-      <PackageReference Include="xunit.runner.console" Version="2.9.2">
+      <PackageReference Include="xunit" Version="2.9.3" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+      <PackageReference Include="xunit.runner.console" Version="2.9.3">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/ReactiveDomain.PolicyStorage.Tests/ReactiveDomain.PolicyStorage.Tests.csproj
+++ b/src/ReactiveDomain.PolicyStorage.Tests/ReactiveDomain.PolicyStorage.Tests.csproj
@@ -15,9 +15,9 @@
     </ItemGroup>   
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="xunit" Version="2.9.2" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-      <PackageReference Include="xunit.runner.console" Version="2.9.2">
+      <PackageReference Include="xunit" Version="2.9.3" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+      <PackageReference Include="xunit.runner.console" Version="2.9.3">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/ReactiveDomain.PolicyStorage/ReactiveDomain.PolicyStorage.csproj
+++ b/src/ReactiveDomain.PolicyStorage/ReactiveDomain.PolicyStorage.csproj
@@ -7,12 +7,12 @@
     <RootNamespace>ReactiveDomain.Policy</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DynamicData" Version="8.4.1" />
+    <PackageReference Include="DynamicData" Version="9.1.2" />
     <PackageReference Include="IdentityModel" Version="4.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.DirectoryServices" Version="8.0.0" />
-    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="8.0.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+    <PackageReference Include="System.DirectoryServices" Version="9.0.2" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="9.0.2" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />

--- a/src/ReactiveDomain.PolicyTool/ReactiveDomain.PolicyTool.csproj
+++ b/src/ReactiveDomain.PolicyTool/ReactiveDomain.PolicyTool.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>  
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.2" />
     <PackageReference Include="EventStore.Client" Version="22.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />

--- a/src/ReactiveDomain.Testing/ReactiveDomain.Testing.csproj
+++ b/src/ReactiveDomain.Testing/ReactiveDomain.Testing.csproj
@@ -11,9 +11,9 @@
     <None Remove="Domain\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.2">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/ReactiveDomain.Transport.Tests/ReactiveDomain.Transport.Tests.csproj
+++ b/src/ReactiveDomain.Transport.Tests/ReactiveDomain.Transport.Tests.csproj
@@ -5,9 +5,9 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.2">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Updates nuget package references.

Excludes `xunit.runner.visualstudio` from the updates, which can wait until we update to xunit 3 across the board. Updating before then would require lots of changes for compatibility anyway.
