### PR TITLE
Suppresses warnings about obsolete SslStream properties

### DIFF
--- a/src/ReactiveDomain.Transport/TcpConnectionSsl.cs
+++ b/src/ReactiveDomain.Transport/TcpConnectionSsl.cs
@@ -221,9 +221,11 @@ public class TcpConnectionSsl : TcpConnectionBase, ITcpConnection {
 	private void DisplaySslStreamInfo(SslStream stream) {
 		var sb = new StringBuilder();
 		sb.AppendFormat("[S{0}, L{1}]:\n", RemoteEndPoint, LocalEndPoint);
+#pragma warning disable SYSLIB0058
 		sb.AppendFormat("Cipher: {0} strength {1}\n", stream.CipherAlgorithm, stream.CipherStrength);
 		sb.AppendFormat("Hash: {0} strength {1}\n", stream.HashAlgorithm, stream.HashStrength);
 		sb.AppendFormat("Key exchange: {0} strength {1}\n", stream.KeyExchangeAlgorithm, stream.KeyExchangeStrength);
+#pragma warning restore SYSLIB0058
 		sb.AppendFormat("Protocol: {0}\n", stream.SslProtocol);
 		sb.AppendFormat("Is authenticated: {0} as server? {1}\n", stream.IsAuthenticated, stream.IsServer);
 		sb.AppendFormat("IsSigned: {0}\n", stream.IsSigned);


### PR DESCRIPTION
**What does this pull request do?**
Reduce the number of compiler warnings.

**How does this pull request accomplish that goal?**
Suppresses warnings about obsolete `SslStream` properties. The use of these properties is not problematic in context.

**Why is this pull request important?**
Ideally, we should compile with zero warnings.

**Link to any issues that this resolves**
This does not address any open issues.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports
- [x] Any new code must be covered by at least one unit test
- [x] All public methods must be documented with XML comments