### PR TITLE
Fixes flaky tests that don't need to be in a Collection.

### DIFF
--- a/src/ReactiveDomain.Foundation.Tests/Domain/with_correlated_repository.cs
+++ b/src/ReactiveDomain.Foundation.Tests/Domain/with_correlated_repository.cs
@@ -4,7 +4,6 @@ using Xunit;
 
 namespace ReactiveDomain.Foundation.Tests.Domain;
 
-[Collection(nameof(EmbeddedStreamStoreConnectionCollection))]
 // ReSharper disable once InconsistentNaming
 public sealed class with_correlated_repository : IClassFixture<StreamStoreConnectionFixture> {
 	private readonly CorrelatedStreamStoreRepository _repo;

--- a/src/ReactiveDomain.Foundation.Tests/Domain/with_repository.cs
+++ b/src/ReactiveDomain.Foundation.Tests/Domain/with_repository.cs
@@ -5,9 +5,8 @@ using Xunit;
 
 namespace ReactiveDomain.Foundation.Tests.Domain;
 
-[Collection(nameof(EmbeddedStreamStoreConnectionCollection))]
 // ReSharper disable once InconsistentNaming
-public class with_repository {
+public class with_repository : IClassFixture<StreamStoreConnectionFixture> {
 	private readonly StreamStoreConnectionFixture _fixture;
 	private readonly IRepository _repo;
 	private readonly PrefixedCamelCaseStreamNameBuilder _streamNameBuilder = new();

--- a/src/ReactiveDomain.Foundation.Tests/EmbeddedStreamStoreConnectionCollection.cs
+++ b/src/ReactiveDomain.Foundation.Tests/EmbeddedStreamStoreConnectionCollection.cs
@@ -3,7 +3,9 @@ using Xunit;
 
 namespace ReactiveDomain.Foundation.Tests;
 
-//n.b a copy of this marker class must be in the assembly with the test classes
-//copy and place in the local namespace to avoid collisions
+// n.b a copy of this marker class must be in the assembly with the test classes
+// copy and place in the local namespace to avoid collisions. This is not currently used,
+// but is useful for the "Common" tests if we want to use StreamStoreConnectionFixture
+// in LIVE_ES_CONNECTION mode.
 [CollectionDefinition(nameof(EmbeddedStreamStoreConnectionCollection))]
 public class EmbeddedStreamStoreConnectionCollection : ICollectionFixture<StreamStoreConnectionFixture>;

--- a/src/ReactiveDomain.Foundation.Tests/PrefixedCamelCaseStreamNameBuilderTests.cs
+++ b/src/ReactiveDomain.Foundation.Tests/PrefixedCamelCaseStreamNameBuilderTests.cs
@@ -3,8 +3,7 @@ using Xunit;
 
 namespace ReactiveDomain.Foundation.Tests;
 
-[Collection(nameof(EmbeddedStreamStoreConnectionCollection))]
-public sealed class PrefixedCamelCaseStreamNameBuilderTests {
+public sealed class PrefixedCamelCaseStreamNameBuilderTests : IClassFixture<StreamStoreConnectionFixture> {
 	[Theory]
 	[InlineData("")]
 	[InlineData("  ")]

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_aggregate_and_guid.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_aggregate_and_guid.cs
@@ -7,8 +7,7 @@ using Xunit;
 namespace ReactiveDomain.Foundation.Tests.StreamListenerTests;
 
 // ReSharper disable once InconsistentNaming
-[Collection(nameof(EmbeddedStreamStoreConnectionCollection))]
-public sealed class when_using_listener_start_with_aggregate_and_guid {
+public sealed class when_using_listener_start_with_aggregate_and_guid : IClassFixture<StreamStoreConnectionFixture> {
 	private readonly IStreamNameBuilder _streamNameBuilder = new PrefixedCamelCaseStreamNameBuilder();
 	private readonly IEventSerializer _eventSerializer = new JsonMessageSerializer();
 

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_category_aggregate.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_category_aggregate.cs
@@ -7,8 +7,7 @@ using Xunit;
 namespace ReactiveDomain.Foundation.Tests.StreamListenerTests;
 
 // ReSharper disable once InconsistentNaming
-[Collection(nameof(EmbeddedStreamStoreConnectionCollection))]
-public sealed class when_using_listener_start_with_category_aggregate {
+public sealed class when_using_listener_start_with_category_aggregate : IClassFixture<StreamStoreConnectionFixture> {
 	private readonly IEventSerializer _eventSerializer = new JsonMessageSerializer();
 
 	public when_using_listener_start_with_category_aggregate(StreamStoreConnectionFixture fixture) {

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_custom_stream_not_synced.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_custom_stream_not_synced.cs
@@ -7,8 +7,7 @@ using Xunit;
 namespace ReactiveDomain.Foundation.Tests.StreamListenerTests;
 
 // ReSharper disable once InconsistentNaming
-[Collection(nameof(EmbeddedStreamStoreConnectionCollection))]
-public sealed class when_using_listener_start_with_custom_stream_not_synced {
+public sealed class when_using_listener_start_with_custom_stream_not_synced : IClassFixture<StreamStoreConnectionFixture> {
 	private readonly JsonMessageSerializer _eventSerializer = new();
 
 	public when_using_listener_start_with_custom_stream_not_synced(StreamStoreConnectionFixture fixture) {

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_custom_stream_synced.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_custom_stream_synced.cs
@@ -7,8 +7,7 @@ using Xunit;
 namespace ReactiveDomain.Foundation.Tests.StreamListenerTests;
 
 // ReSharper disable once InconsistentNaming
-[Collection(nameof(EmbeddedStreamStoreConnectionCollection))]
-public sealed class when_using_listener_start_with_custom_stream_synced {
+public sealed class when_using_listener_start_with_custom_stream_synced : IClassFixture<StreamStoreConnectionFixture> {
 	private readonly JsonMessageSerializer _eventSerializer = new();
 
 	public when_using_listener_start_with_custom_stream_synced(StreamStoreConnectionFixture fixture) {

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_custom_stream_synced_bus.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_custom_stream_synced_bus.cs
@@ -8,8 +8,7 @@ using Xunit;
 namespace ReactiveDomain.Foundation.Tests.StreamListenerTests;
 
 // ReSharper disable once InconsistentNaming
-[Collection(nameof(EmbeddedStreamStoreConnectionCollection))]
-public sealed class when_using_listener_start_with_custom_stream_synced_bus : IDisposable {
+public sealed class when_using_listener_start_with_custom_stream_synced_bus : IClassFixture<StreamStoreConnectionFixture>, IDisposable {
 	private readonly JsonMessageSerializer _eventSerializer = new();
 	private readonly IStreamStoreConnection _conn;
 	private readonly StreamListener _listener;

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_event_type.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_event_type.cs
@@ -7,22 +7,25 @@ using Xunit;
 namespace ReactiveDomain.Foundation.Tests.StreamListenerTests;
 
 // ReSharper disable once InconsistentNaming
-[Collection(nameof(EmbeddedStreamStoreConnectionCollection))]
-public sealed class when_using_listener_start_with_event_type {
+public sealed class when_using_listener_start_with_event_type : IClassFixture<StreamStoreConnectionFixture>, IDisposable {
 	private readonly JsonMessageSerializer _eventSerializer = new();
+	private readonly IStreamStoreConnection _conn;
+	private readonly QueuedStreamListener _listener;
+	private readonly IDisposable _subscriptionDisposer;
 
 	public when_using_listener_start_with_event_type(StreamStoreConnectionFixture fixture) {
 		var streamNameBuilder = new PrefixedCamelCaseStreamNameBuilder();
-		var conn = fixture.Connection;
-		conn.Connect();
+		_conn = fixture.Connection;
+		_conn.Connect();
 
 		var originalAggregateStream =
 			streamNameBuilder.GenerateForAggregate(
 				typeof(TestAggregate),
 				Guid.NewGuid());
 		var evt = new EventProjectionTestEvent();
+
 		//drop the event into the stream
-		var result = conn.AppendToStream(
+		var result = _conn.AppendToStream(
 			originalAggregateStream,
 			ExpectedVersion.NoStream,
 			null,
@@ -30,17 +33,17 @@ public sealed class when_using_listener_start_with_event_type {
 		Assert.Equal(0, result.NextExpectedVersion);
 
 		//wait for the projection to be written
-		CommonHelpers.WaitForStream(conn, streamNameBuilder.GenerateForEventType(nameof(EventProjectionTestEvent)));
+		CommonHelpers.WaitForStream(_conn, streamNameBuilder.GenerateForEventType(nameof(EventProjectionTestEvent)));
 
 		//build the listener
-		StreamListener listener = new QueuedStreamListener(
+		_listener = new QueuedStreamListener(
 			"event listener",
-			conn,
+			_conn,
 			streamNameBuilder,
 			_eventSerializer);
 
-		listener.EventStream.Subscribe(new AdHocHandler<EventProjectionTestEvent>(Handle));
-		listener.Start(typeof(EventProjectionTestEvent));
+		_subscriptionDisposer = _listener.EventStream.Subscribe(new AdHocHandler<EventProjectionTestEvent>(Handle));
+		_listener.Start(typeof(EventProjectionTestEvent));
 	}
 
 	private long _testEventCount;
@@ -57,4 +60,10 @@ public sealed class when_using_listener_start_with_event_type {
 
 	}
 	public record EventProjectionTestEvent : Event;
+
+	public void Dispose() {
+		_conn.Dispose();
+		_listener.Dispose();
+		_subscriptionDisposer.Dispose();
+	}
 }

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_future_stream.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_future_stream.cs
@@ -7,8 +7,7 @@ using Xunit;
 namespace ReactiveDomain.Foundation.Tests.StreamListenerTests;
 
 // ReSharper disable once InconsistentNaming
-[Collection(nameof(EmbeddedStreamStoreConnectionCollection))]
-public sealed class when_using_listener_start_with_future_stream {
+public sealed class when_using_listener_start_with_future_stream : IClassFixture<StreamStoreConnectionFixture> {
 	private readonly JsonMessageSerializer _eventSerializer = new();
 	private readonly string _originStreamName = $"testStream-{Guid.NewGuid():N}";
 	private readonly IStreamStoreConnection _connection;


### PR DESCRIPTION
**What does this pull request do?**
Fixes flaky tests that don't need to be in a `Collection`.

**How does this pull request accomplish that goal?**
The collection was causing the test fixture to be disposed before all the tests has completed, possibly since the tests have code that runs async without being awaited. This changes the configuration of those tests to use `IClassFixture<T>` instead of a `Collection`.

**Why is this pull request important?**
These tests would frequently fail in build checks.

**Link to any issues that this resolves**
This does not address any open issues.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports
- [x] Any new code must be covered by at least one unit test
- [x] All public methods must be documented with XML comments