### PR TITLE
PS scripts update nuspec refs in net10 section

### DIFF
--- a/tools/CreateDebugNuget.ps1
+++ b/tools/CreateDebugNuget.ps1
@@ -113,7 +113,7 @@ class PackagRef
 #     Parses and returns a PackagRef object (defined above) that contains:
 #         Version - (version of the package)
 #         ConditionOperator - (the equality operator for a framework, == or !=)
-#         Framework - The framework this Packageref applies to: (net452, net472, netstandard2.0)
+#         Framework - The framework this Packageref applies to: (net8.0, net10.0)
 #
 function GetPackageRefFromProject([string]$Id, [string]$CsProj, [string]$Framework)
 {
@@ -161,6 +161,11 @@ function GetPackageRefFromProject([string]$Id, [string]$CsProj, [string]$Framewo
     if ($currentCondition -match "net8.0")
     {
         $currentFramework = "net8.0"
+    }
+    
+    if ($currentCondition -match "net10.0")
+    {
+        $currentFramework = "net10.0"
     }
 
 

--- a/tools/CreateNuget.ps1
+++ b/tools/CreateNuget.ps1
@@ -81,7 +81,7 @@ class PackagRef
 #     Parses and returns a PackagRef object (defined above) that contains:
 #         Version - (version of the package)
 #         ConditionOperator - (the equality operator for a framework, == or !=)
-#         Framework - The framework this Packageref applies to: (net8.0)
+#         Framework - The framework this Packageref applies to: (net8.0, net10.0)
 #
 function GetPackageRefFromProject([string]$Id, [string]$CsProj, [string]$Framework)
 {
@@ -129,6 +129,11 @@ function GetPackageRefFromProject([string]$Id, [string]$CsProj, [string]$Framewo
     if ($currentCondition -match "net8.0")
     {
         $currentFramework = "net8.0"
+    }
+    
+    if ($currentCondition -match "net10.0")
+    {
+        $currentFramework = "net10.0"
     }
 
     $myObj = New-Object -TypeName PackagRef 


### PR DESCRIPTION
**What does this pull request do?**
Fixes the PS build scripts so the dependencies' versions in the nuspec files are updated for net10.0.

**How does this pull request accomplish that goal?**
Previously the script did not set the `currentFramework` correctly when traversing the net10.0 part of the nuspec file to update the package reference versions.

**Why is this pull request important?**
Having the incorrect versions could prevent the RD nuget packages from being loaded since they could force a downgrade of dependencies.

**Link to any issues that this resolves**
This does not address any open issues.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports
- [x] Any new code must be covered by at least one unit test
- [x] All public methods must be documented with XML comments