### PR TITLE
Order ReadModelProperty deliveries; fix unsynchronized collections in ReadModelProperty and ReadModelBase

### DIFF
--- a/src/ReactiveDomain.Foundation.Tests/when_using_read_model_property.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_read_model_property.cs
@@ -1,0 +1,149 @@
+using ReactiveDomain.Testing;
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests;
+
+// ReSharper disable once InconsistentNaming
+public sealed class when_using_read_model_property {
+
+	private sealed class RecordingObserver<T> : IObserver<T> {
+		public readonly List<T> Received = [];
+		public void OnNext(T value) {
+			lock (Received) {
+				Received.Add(value);
+			}
+		}
+		public void OnError(Exception error) { }
+		public void OnCompleted() { }
+	}
+
+	[Fact]
+	public void subscribers_receive_the_current_value_synchronously_on_subscribe() {
+		var property = new ReadModelProperty<int>(5);
+		var observer = new RecordingObserver<int>();
+
+		using var _ = property.Subscribe(observer);
+
+		// No waiting: the initial value must be delivered before Subscribe returns.
+		Assert.Equal(new[] { 5 }, observer.Received);
+	}
+
+	[Fact]
+	public void late_subscribers_receive_the_most_recent_value() {
+		var property = new ReadModelProperty<int>(0);
+		property.Update(42);
+		var observer = new RecordingObserver<int>();
+
+		using var _ = property.Subscribe(observer);
+
+		Assert.Equal(new[] { 42 }, observer.Received);
+	}
+
+	[Fact]
+	public void initial_delivery_uses_the_publish_wrapper() {
+		var wrapped = 0;
+		var property = new ReadModelProperty<int>(7, publish => {
+			wrapped++;
+			publish();
+		});
+		var observer = new RecordingObserver<int>();
+
+		using var _ = property.Subscribe(observer);
+
+		Assert.Equal(1, wrapped);
+		Assert.Equal(new[] { 7 }, observer.Received);
+
+		property.Update(8);
+
+		Assert.Equal(2, wrapped);
+		Assert.Equal(new[] { 7, 8 }, observer.Received);
+	}
+
+	[Fact]
+	public void updates_notify_all_subscribers() {
+		var property = new ReadModelProperty<int>(0);
+		var observer1 = new RecordingObserver<int>();
+		var observer2 = new RecordingObserver<int>();
+		using var _1 = property.Subscribe(observer1);
+		using var _2 = property.Subscribe(observer2);
+
+		property.Update(1);
+		property.Update(2);
+
+		Assert.Equal(new[] { 0, 1, 2 }, observer1.Received);
+		Assert.Equal(new[] { 0, 1, 2 }, observer2.Received);
+	}
+
+	[Fact]
+	public void unchanged_values_are_not_delivered_unless_forced() {
+		var property = new ReadModelProperty<int>(3);
+		var observer = new RecordingObserver<int>();
+		using var _ = property.Subscribe(observer);
+
+		property.Update(3);
+		Assert.Equal(new[] { 3 }, observer.Received);
+
+		property.Update(3, force: true);
+		Assert.Equal(new[] { 3, 3 }, observer.Received);
+	}
+
+	[Fact]
+	public void disposed_subscribers_are_not_notified() {
+		var property = new ReadModelProperty<int>(0);
+		var observer = new RecordingObserver<int>();
+		var subscription = property.Subscribe(observer);
+
+		property.Update(1);
+		subscription.Dispose();
+		property.Update(2);
+
+		Assert.Equal(new[] { 0, 1 }, observer.Received);
+	}
+
+	[Fact]
+	public void current_value_reflects_the_latest_update() {
+		var property = new ReadModelProperty<Guid>(Guid.Empty);
+		Assert.Equal(Guid.Empty, property.CurrentValue());
+
+		var id = Guid.NewGuid();
+		property.Update(id);
+		Assert.Equal(id, property.CurrentValue());
+	}
+
+	[Fact]
+	public async Task subscribers_never_observe_an_older_value_after_a_newer_one() {
+		// Regression test for GH-212: the initial delivery raced Update and could
+		// stomp a subscriber with a stale value after a newer one was delivered.
+		var property = new ReadModelProperty<long>(0);
+		const int updates = 10_000;
+		const int subscribers = 200;
+		var failures = 0;
+
+		var writer = Task.Run(() => {
+			for (long i = 1; i <= updates; i++) {
+				property.Update(i);
+			}
+		});
+
+		var readers = Task.Run(() => {
+			for (var i = 0; i < subscribers; i++) {
+				var last = long.MinValue;
+				var subscription = property.Subscribe(new AdHocObserver<long>(v => {
+					if (v < Interlocked.Read(ref last))
+						Interlocked.Increment(ref failures);
+					Interlocked.Exchange(ref last, v);
+				}));
+				subscription.Dispose();
+			}
+		});
+
+		await Task.WhenAll(writer, readers);
+		Assert.Equal(0, failures);
+	}
+
+	private sealed class AdHocObserver<T>(Action<T> onNext) : IObserver<T> {
+		public void OnNext(T value) => onNext(value);
+		public void OnError(Exception error) { }
+		public void OnCompleted() { }
+	}
+}

--- a/src/ReactiveDomain.Foundation/ReactiveDomain.Foundation.csproj
+++ b/src/ReactiveDomain.Foundation/ReactiveDomain.Foundation.csproj
@@ -8,6 +8,9 @@
     <Compile Remove="StreamStore\EventStoreMessageLogger.cs" />
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="ReactiveDomain.Testing" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>

--- a/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
@@ -41,8 +41,15 @@ public abstract class ReadModelBase :
 	/// Gets a task that completes when all streams started using a <c>StartAsync</c> overload are live.
 	/// </summary>
 	/// <remarks>The returned task represents the aggregate completion of all underlying read tasks. Awaiting
-	/// this property allows callers to determine when all read operations are complete.</remarks>
-	public Task IsLive => Task.WhenAll(_readTasks);
+	/// this property allows callers to determine when all read operations are complete. The task is a snapshot:
+	/// it does not cover streams started after the property is read.</remarks>
+	public Task IsLive {
+		get {
+			lock (_readTasks) {
+				return Task.WhenAll(_readTasks.ToArray());
+			}
+		}
+	}
 
 	/// <summary>
 	/// Creates a read model using the provided stream store connection. Reads existing events using a
@@ -68,6 +75,12 @@ public abstract class ReadModelBase :
 		lock (ReaderLock) {
 			_bus.Handle(message);
 			Version++;
+		}
+	}
+
+	private void AddReadTask(Task readTask) {
+		lock (_readTasks) {
+			_readTasks.Add(readTask);
 		}
 	}
 
@@ -126,7 +139,7 @@ public abstract class ReadModelBase :
 	/// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true.</param>
 	public void StartAsync(string stream, long? checkpoint = null, bool validateStream = false,
 		CancellationToken cancelWaitToken = default) {
-		_readTasks.Add(Task.Run(() => {
+		AddReadTask(Task.Run(() => {
 			using var reader = _getReader();
 			reader.Read(stream, () => Idle, checkpoint);
 			checkpoint = reader.Position ?? checkpoint;
@@ -169,7 +182,7 @@ public abstract class ReadModelBase :
 	/// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true.</param>
 	public void StartAsync<TAggregate>(Guid id, long? checkpoint = null, bool validateStream = false,
 		CancellationToken cancelWaitToken = default) where TAggregate : class, IEventSource {
-		_readTasks.Add(Task.Run(() => {
+		AddReadTask(Task.Run(() => {
 			using var reader = _getReader();
 			reader.Read<TAggregate>(id, () => Idle, checkpoint);
 			checkpoint = reader.Position;
@@ -210,7 +223,7 @@ public abstract class ReadModelBase :
 	/// <param name="cancelWaitToken">Cancellation token to cancel waiting if blockUntilLive is true.</param>
 	public void StartAsync<TAggregate>(long? checkpoint = null, bool validateStream = false,
 		CancellationToken cancelWaitToken = default) where TAggregate : class, IEventSource {
-		_readTasks.Add(Task.Run(() => {
+		AddReadTask(Task.Run(() => {
 			using var reader = _getReader();
 			reader.Read<TAggregate>(() => Idle, checkpoint);
 			checkpoint = reader.Position;

--- a/src/ReactiveDomain.Foundation/StreamStore/ReadModelProperty.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/ReadModelProperty.cs
@@ -1,4 +1,4 @@
-﻿using System.Reactive.Linq;
+using System.Reactive.Linq;
 
 // ReSharper disable once CheckNamespace
 namespace ReactiveDomain.Foundation;
@@ -6,11 +6,19 @@ namespace ReactiveDomain.Foundation;
 /// <summary>
 /// A wrapper for an observable provider, intended for use in transient read models.
 /// This provider is a hot observable. Includes simple semantics for appending a new
-/// item to the provider. Late subscribers are automatically provided with the most
+/// item to the provider. Late subscribers are synchronously provided with the most
 /// recent value upon subscription.
+/// <br/>
+/// All deliveries (initial and update) are serialized through a single lock, so a
+/// subscriber can never observe an older value after a newer one. Because the current
+/// value is delivered synchronously inside <see cref="Subscribe"/>, observer callbacks
+/// may re-enter this property (e.g. call <see cref="Update"/>) on the same thread, but
+/// must not block waiting on another thread that also uses this property. If a
+/// publish wrapper is provided it should enqueue rather than block for the same reason.
 /// </summary>
 /// <typeparam name="T">The type of data for the provider.</typeparam>
 public class ReadModelProperty<T> : IObservable<T> {
+	private readonly object _gate = new();
 	private readonly List<IObserver<T>> _subscribed = [];
 	private readonly IObservable<T> _observable;
 
@@ -24,13 +32,32 @@ public class ReadModelProperty<T> : IObservable<T> {
 		_lastValue = startValue;
 		_publishWrapper = publishWrapper;
 		_observable = Observable.Create<T>(o => {
-			_subscribed.Add(o);
-			return () => _subscribed.Remove(o);
+			lock (_gate) {
+				_subscribed.Add(o);
+			}
+			return () => {
+				lock (_gate) {
+					_subscribed.Remove(o);
+				}
+			};
 		});
 	}
 
 	private T _lastValue;
 	private readonly Action<Action>? _publishWrapper;
+
+	/// <summary>
+	/// The most recent value, read under the same lock that orders deliveries.
+	/// Exposed for test visibility via ReactiveDomain.Testing; production code
+	/// should subscribe rather than poll.
+	/// </summary>
+	internal T CurrentValue {
+		get {
+			lock (_gate) {
+				return _lastValue;
+			}
+		}
+	}
 
 	/// <summary>
 	/// Append an item to the provider's stream and notifies all subscribers.
@@ -41,31 +68,40 @@ public class ReadModelProperty<T> : IObservable<T> {
 	/// <param name="force">Forces notifications. If true, notifies subscribers of
 	/// the new value even if that value is the same as the previous value.</param>
 	public void Update(T val, bool force = false) {
-		var noChange = val != null && val.Equals(_lastValue) || val == null && _lastValue == null;
-		if (!force && noChange)
-			return;
-		_lastValue = val;
-		var subscribed = _subscribed.ToArray();
-		// ReSharper disable once ForCanBeConvertedToForeach - If someone throws they will be removed form the collection
-		for (var i = 0; i < subscribed.Length; i++) {
-			var subscriber = subscribed[i];
-			if (_publishWrapper != null)
-				_publishWrapper(() => subscriber.OnNext(val));
-			else
-				subscriber.OnNext(val);
+		lock (_gate) {
+			var noChange = val != null && val.Equals(_lastValue) || val == null && _lastValue == null;
+			if (!force && noChange)
+				return;
+			_lastValue = val;
+			var subscribed = _subscribed.ToArray();
+			// ReSharper disable once ForCanBeConvertedToForeach - If someone throws they will be removed form the collection
+			for (var i = 0; i < subscribed.Length; i++) {
+				Notify(subscribed[i], val);
+			}
 		}
 	}
 
 	/// <summary>
-	/// Subscribes a new observer to this observable and asynchronously notifies
-	/// that observer of the most recent value.
+	/// Subscribes a new observer to this observable and synchronously notifies
+	/// that observer of the most recent value. The initial delivery is ordered
+	/// with respect to <see cref="Update"/> notifications, so the observer can
+	/// never see an older value after a newer one.
 	/// </summary>
 	/// <param name="observer">The observer to subscribe.</param>
 	/// <returns>A reference to an interface that allows observers to stop receiving
 	/// notifications before the provider has finished sending them.</returns>
 	public IDisposable Subscribe(IObserver<T> observer) {
-		var unsubscribe = _observable.Subscribe(observer);
-		Task.Run(() => observer.OnNext(_lastValue));
-		return unsubscribe;
+		lock (_gate) {
+			var unsubscribe = _observable.Subscribe(observer);
+			Notify(observer, _lastValue);
+			return unsubscribe;
+		}
+	}
+
+	private void Notify(IObserver<T> observer, T val) {
+		if (_publishWrapper != null)
+			_publishWrapper(() => observer.OnNext(val));
+		else
+			observer.OnNext(val);
 	}
 }

--- a/src/ReactiveDomain.Testing/TestVisibilityHelpers.cs
+++ b/src/ReactiveDomain.Testing/TestVisibilityHelpers.cs
@@ -68,13 +68,14 @@ public static class TestVisibilityExtensions {
 	/// <summary>
 	/// Allows test to access the current value of a ReadModelProperty.
 	/// This leverages the fact that the current value is stored to be published to new subscribers.
+	/// The value is read under the same lock that orders deliveries, so it cannot be torn.
 	/// </summary>
 	/// <typeparam name="T">the ReadModelProperty type</typeparam>
 	/// <param name="readModelProperty">the ReadModelProperty</param>
 	/// <returns></returns>
 	public static T CurrentValue<T>(this IObservable<T> readModelProperty) {
-		return readModelProperty is ReadModelProperty<T>
-			? GetInstanceField<T>(readModelProperty, "_lastValue")
+		return readModelProperty is ReadModelProperty<T> property
+			? property.CurrentValue
 			: throw new InvalidOperationException("Observable is not a ReadModelProperty.");
 	}
 }


### PR DESCRIPTION
Fixes #212

## Problem

`ReadModelProperty<T>.Subscribe` delivered the initial value via an unsynchronized `Task.Run`, unordered with respect to `Update(...)`. A subscriber could receive a stale value **after** a newer one and stay permanently wrong until the next update (see #212 for the interleaving and downstream impact).

Auditing the surrounding surface turned up three sibling defects, all fixed here:

## Changes

**`ReadModelProperty<T>`** — all deliveries now serialize through a single gate:
- `Subscribe` delivers the current value **synchronously** inside the lock, ordered with `Update` notifications — an observer can never see an older value after a newer one. The reentrancy implications are documented on the class (observer callbacks may re-enter on the same thread; publish wrappers should enqueue, not block).
- The initial delivery now routes through `publishWrapper`. Previously only `Update` used the wrapper; the initial value was delivered raw on a thread-pool thread, violating the wrapper's thread-affinity contract (e.g. dispatcher marshalling).
- `_subscribed` (a plain `List<IObserver<T>>` mutated by subscribe/dispose while `Update` snapshots it) is now guarded by the same gate.
- `_lastValue` is only read/written under the gate, eliminating torn reads for multi-word structs (`T` is unconstrained; `Guid` is the common case).

**`TestVisibilityExtensions.CurrentValue`** — now reads a new `internal CurrentValue` property (via `InternalsVisibleTo`) instead of reflecting on `_lastValue`, so test polling reads under the same lock and cannot tear.

**`ReadModelBase`** — `_readTasks` was a plain `List<Task>` appended by the `StartAsync` overloads while `IsLive => Task.WhenAll(_readTasks)` enumerated it unsynchronized. Both sides now lock, matching the existing `_listeners` locking in the same class. `IsLive` docs note it is a snapshot that does not cover later-started streams.

## Behavioral note for consumers

Initial delivery moving from async (thread pool) to synchronous-inside-`Subscribe` is the fix, but code that accidentally depended on the async hop (e.g. subscribing while holding a lock the observer callback also takes) will see the callback inline. This matches the documented intent ("Late subscribers are automatically provided with the most recent value") and Rx `BehaviorSubject` semantics.

## Tests

New `when_using_read_model_property` suite: synchronous initial delivery, last-value semantics for late subscribers, wrapper used for initial delivery, force/no-change semantics, unsubscribe, `CurrentValue` visibility, and a GH-212 regression stress test (concurrent monotonic writer + 200 subscribe/dispose cycles asserting no observer ever sees an older value after a newer one).

`ReactiveDomain.Foundation.Tests`: 123/123 pass locally (net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)