### PR TITLE
CapturingSubscribableBus: match command responses by CommandId

### DIFF
--- a/src/ReactiveDomain.Testing/Messaging/CapturingSubscribableBus.cs
+++ b/src/ReactiveDomain.Testing/Messaging/CapturingSubscribableBus.cs
@@ -91,16 +91,8 @@ public sealed class CapturingSubscribableBus : IDispatcher {
 			// using IHandle<T> and will not handle synchronously. In those cases we publish on the internal bus, and
 			// then wait for a CommandResponse to be published onto that bus.
 			if (_bus.HasSubscriberFor(command.GetType())) {
-				CommandResponse? response = null;
-				using var d = _bus.Subscribe(new AdHocHandler<CommandResponse>(r => response = r));
-				_bus.Publish(command);
-				var startTime = Environment.TickCount; //returns MS since machine start
-				var endTime = startTime + (int)responseTimeout.Value.TotalMilliseconds;
-				while (response is null) {
-					var now = Environment.TickCount;
-					if (endTime - now <= 0)
-						throw new CommandTimedOutException(command);
-				}
+				var response = AwaitResponse(command, responseTimeout.Value)
+							   ?? throw new CommandTimedOutException(command);
 				if (response is Fail f)
 					throw new CommandException("Command failed", f.Exception, command);
 			} else
@@ -112,7 +104,27 @@ public sealed class CapturingSubscribableBus : IDispatcher {
 				throw new CommandException("Command failed", ex.InnerException, command);
 			}
 		}
-		command.Succeed();
+	}
+
+	/// <summary>
+	/// Publishes the command and waits for THIS command's response, or null on timeout.
+	/// The watcher must filter by <see cref="CommandResponse.CommandId"/>: with queued
+	/// subscribers a handler can still be running (and can send nested commands) after its
+	/// caller's wait begins, so an unfiltered watcher is completed by whichever response
+	/// happens to be published first — including a straggler from a previous command —
+	/// manufacturing phantom results for commands that were never even dequeued.
+	/// </summary>
+	private CommandResponse? AwaitResponse(ICommand command, TimeSpan responseTimeout) {
+		CommandResponse? response = null;
+		using var d = _bus.Subscribe(new AdHocHandler<CommandResponse>(r => {
+			if (r.CommandId == command.MsgId)
+				Volatile.Write(ref response, r);
+		}));
+		_bus.Publish(command);
+		// SpinUntil yields/sleeps between probes (the previous loop hot-spun a full core, which
+		// on a 2-core CI runner starved the very handler thread it was waiting on).
+		SpinWait.SpinUntil(() => Volatile.Read(ref response) is not null, responseTimeout);
+		return Volatile.Read(ref response);
 	}
 
 	public bool TrySend(ICommand command, out CommandResponse response, TimeSpan? responseTimeout = null,
@@ -125,24 +137,17 @@ public sealed class CapturingSubscribableBus : IDispatcher {
 			// using IHandle<T> and will not handle synchronously. In those cases we publish on the internal bus, and
 			// then wait for a CommandResponse to be published onto that bus.
 			if (_bus.HasSubscriberFor(command.GetType())) {
-				CommandResponse? resp = null;
-				using var d = _bus.Subscribe(new AdHocHandler<CommandResponse>(r => resp = r));
-				_bus.Publish(command);
-				var startTime = Environment.TickCount; //returns MS since machine start
-				var endTime = startTime + (int)responseTimeout.Value.TotalMilliseconds;
-				while (resp is null) {
-					var now = Environment.TickCount;
-					if (endTime - now <= 0) {
-						response = command.Fail(new CommandTimedOutException(command));
-						return false;
-					}
+				var resp = AwaitResponse(command, responseTimeout.Value);
+				if (resp is null) {
+					response = command.Fail(new CommandTimedOutException(command));
+					return false;
 				}
 				if (resp is Fail f) {
 					response = command.Fail(f.Exception);
 					return false;
 				}
 
-				response = command.Succeed();
+				response = resp;
 				return true;
 			}
 
@@ -165,17 +170,8 @@ public sealed class CapturingSubscribableBus : IDispatcher {
 		_allMessages.Add(command);
 		responseTimeout ??= TimeSpan.FromSeconds(5); // Default timeout long enough for heavy load on slow test machines
 		if (!_handlerWrappers.TryGetValue(command.GetType(), out var handler)) {
-			CommandResponse? response = null;
-			using var d = _bus.Subscribe(new AdHocHandler<CommandResponse>(r => response = r));
-			_bus.Publish(command);
-			var startTime = Environment.TickCount; //returns MS since machine start
-			var endTime = startTime + (int)responseTimeout.Value.TotalMilliseconds;
-			while (response is null) {
-				var now = Environment.TickCount;
-				if (endTime - now <= 0)
-					return false;
-			}
-			return response is not Fail;
+			var response = AwaitResponse(command, responseTimeout.Value);
+			return response is not (null or Fail);
 		}
 		try {
 			handler.GetType().GetMethod("Handle")?.Invoke(handler, [command]);

--- a/src/ReactiveDomain.Testing/Messaging/CapturingSubscribableBusTests.cs
+++ b/src/ReactiveDomain.Testing/Messaging/CapturingSubscribableBusTests.cs
@@ -248,6 +248,38 @@ public sealed class CapturingSubscribableBusTests : IDisposable {
 		Assert.Empty(_sut.AllMessages);
 	}
 
+	[Fact]
+	public void QueuedSendIgnoresResponsesForOtherCommands() {
+		// A straggler response from an earlier, still-draining command must not complete a
+		// later Send's wait: the watcher must match on CommandId. An unfiltered watcher
+		// reports a phantom result for the later command before its handler even runs.
+		using var subscriber = new StragglingCommandSubscriber(_sut);
+		subscriber.StragglerToPublish = new TestCommands.Command2();
+
+		var ex = Assert.Throws<CommandException>(() => _sut.Send(new TestCommands.Command2()));
+		Assert.IsType<InvalidOperationException>(ex.InnerException);
+	}
+
+	private class StragglingCommandSubscriber : QueuedSubscriber, IHandleCommand<TestCommands.Command2> {
+		private readonly IDispatcher _bus;
+		public ICommand? StragglerToPublish { get; set; }
+
+		public StragglingCommandSubscriber(IDispatcher bus) : base(bus) {
+			_bus = bus;
+			// ReSharper disable once RedundantTypeArgumentsOfMethod
+			Subscribe<TestCommands.Command2>(this);
+		}
+
+		public CommandResponse Handle(TestCommands.Command2 command) {
+			// Simulates a response from a previous command landing on the bus while the
+			// current command's sender is already waiting.
+			if (StragglerToPublish is not null)
+				_bus.Publish(StragglerToPublish.Succeed());
+			Thread.Sleep(20);
+			throw new InvalidOperationException("the real outcome");
+		}
+	}
+
 	private class DisposingCommandSubscriber : IHandleCommand<TestCommands.Command2>, IDisposable {
 		private readonly CompositeDisposable _disposables = [];
 		public DisposingCommandSubscriber(IDispatcher bus) {


### PR DESCRIPTION
## Bug

The queued-subscriber `Send`/`TrySend`/`TrySendAsync` paths in `CapturingSubscribableBus` wait for the **first `CommandResponse` published on the bus, with no filter**:

```csharp
CommandResponse? response = null;
using var d = _bus.Subscribe(new AdHocHandler<CommandResponse>(r => response = r));
```

With queued subscribers (`QueuedSubscriber`), a handler can still be running — and can send nested commands — after its caller's wait has begun. The watcher is completed by whichever response is published first, including a straggler from a *previous* command, manufacturing phantom results for commands that were never even dequeued.

**Observed downstream** (event-systems/Shoebox#92): a test whose command must fail reported success on 2-core CI runners. `Send(create)` returned on the create's inner nested-command response while `Handle(create)` was still running; the straggler `create.Succeed()` published afterward instantly satisfied the next `Send(change)`'s unfiltered watcher — before `change` was dequeued. Diagnosed with path counters + a response dump under a 2-core-pinned repro loop (`sameInstance=True`, handler `Entered=0`).

## Fix

- Extracted `AwaitResponse(command, timeout)`: watcher filtered on `CommandResponse.CommandId == command.MsgId`, publish, wait.
- Replaced the hot `Environment.TickCount` spin — which pinned a full core and, on a 2-core runner, starved the very handler thread it was waiting on — with `SpinWait.SpinUntil`, plus `Volatile` read/write on the shared slot (the old loop read a plain captured variable with no memory barrier).
- `TrySend` now returns the handler's **actual** response instead of manufacturing `command.Succeed()`; `Send` drops its discarded trailing `Succeed()` call.

## Regression test

`QueuedSendIgnoresResponsesForOtherCommands` — a queued handler publishes a straggler response for a different command, then fails. **Mutation-checked**: red against the old code (phantom success, 13 ms), green with the fix.

## Verification

ReactiveDomain.Testing: **112/112** green (net10.0), including all existing `CapturingSubscribableBus` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)