### PR TITLE
Moves unit tests out of RD.Testing

### DIFF
--- a/src/ReactiveDomain.Foundation.Tests/EmbeddedStreamStoreConnectionCollection.cs
+++ b/src/ReactiveDomain.Foundation.Tests/EmbeddedStreamStoreConnectionCollection.cs
@@ -4,8 +4,8 @@ using Xunit;
 namespace ReactiveDomain.Foundation.Tests;
 
 // n.b a copy of this marker class must be in the assembly with the test classes
-// copy and place in the local namespace to avoid collisions. This is not currently used,
-// but is useful for the "Common" tests if we want to use StreamStoreConnectionFixture
-// in LIVE_ES_CONNECTION mode.
+// copy and place in the local namespace to avoid collisions. This is currently
+// used for only one test class, but is useful for the "StreamListenerTests.Common"
+// tests if we want to use StreamStoreConnectionFixture in LIVE_ES_CONNECTION mode.
 [CollectionDefinition(nameof(EmbeddedStreamStoreConnectionCollection))]
 public class EmbeddedStreamStoreConnectionCollection : ICollectionFixture<StreamStoreConnectionFixture>;

--- a/src/ReactiveDomain.Foundation.Tests/ReactiveDomain.Foundation.Tests.csproj
+++ b/src/ReactiveDomain.Foundation.Tests/ReactiveDomain.Foundation.Tests.csproj
@@ -32,6 +32,7 @@
     <ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />
     <ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
     <ProjectReference Include="..\ReactiveDomain.Persistence\ReactiveDomain.Persistence.csproj" />
+    <ProjectReference Include="..\ReactiveDomain.Testing.Tests\ReactiveDomain.Testing.Tests.csproj" />
     <ProjectReference Include="..\ReactiveDomain.Testing\ReactiveDomain.Testing.csproj" />
   </ItemGroup> 
 </Project>

--- a/src/ReactiveDomain.Foundation.Tests/StreamReaderTests.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamReaderTests.cs
@@ -1,13 +1,13 @@
-﻿using ReactiveDomain.Foundation;
-using ReactiveDomain.Messaging;
+﻿using ReactiveDomain.Messaging;
 using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using ReactiveDomain.Testing.EventStore;
 using Xunit;
 using Xunit.Abstractions;
-using StreamReader = ReactiveDomain.Foundation.StreamReader;
 
 // ReSharper disable UnusedParameter.Local
 
-namespace ReactiveDomain.Testing.EventStore;
+namespace ReactiveDomain.Foundation.Tests;
 
 public class StreamReaderTests : IClassFixture<StreamStoreConnectionFixture>, IHandle<Event> {
 	private readonly List<IStreamStoreConnection> _stores = [];

--- a/src/ReactiveDomain.Foundation.Tests/StreamStoreRepositoryIntegrationTests.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamStoreRepositoryIntegrationTests.cs
@@ -1,14 +1,13 @@
-﻿using ReactiveDomain.Foundation;
+﻿using ReactiveDomain.Testing;
 using Xunit;
 
-// ReSharper disable once CheckNamespace
-namespace ReactiveDomain.Testing;
+namespace ReactiveDomain.Foundation.Tests;
 
 /// <summary>
 /// Integration tests for the GetEventStoreRepository. 
 /// </summary>
 [Collection(nameof(EmbeddedStreamStoreConnectionCollection))]
-public class EventStoreRepositoryIntegrationTests {
+public class StreamStoreRepositoryIntegrationTests {
 	private const string DomainPrefix = "UnitTest";
 
 	private static Guid SaveTestAggregateWithoutCustomHeaders(IRepository repository, int numberOfEvents) {
@@ -22,11 +21,12 @@ public class EventStoreRepositoryIntegrationTests {
 	private readonly IStreamStoreConnection _connection;
 	private readonly IStreamNameBuilder _streamNameBuilder;
 
-	public EventStoreRepositoryIntegrationTests(StreamStoreConnectionFixture fixture) {
+	public StreamStoreRepositoryIntegrationTests(StreamStoreConnectionFixture fixture) {
 		_connection = fixture.Connection;
 		_streamNameBuilder = new PrefixedCamelCaseStreamNameBuilder(DomainPrefix);
 		_repo = new StreamStoreRepository(_streamNameBuilder, _connection, new JsonMessageSerializer());
 	}
+
 	[Fact]
 	public void CanGetLatestVersionById() {
 		var savedId = SaveTestAggregateWithoutCustomHeaders(_repo, 3000 /* excludes TestAggregateCreated */);
@@ -56,7 +56,8 @@ public class EventStoreRepositoryIntegrationTests {
 	public void CanHandleLargeNumberOfEventsInOneTransaction() {
 		const int numberOfEvents = 50000;
 
-		var aggregateId = SaveTestAggregateWithoutCustomHeaders(_repo, numberOfEvents /* excludes TestAggregateCreated */);
+		var aggregateId =
+			SaveTestAggregateWithoutCustomHeaders(_repo, numberOfEvents /* excludes TestAggregateCreated */);
 
 		var saved = _repo.GetById<TestWoftamAggregate>(aggregateId);
 		Assert.Equal(numberOfEvents, saved.AppliedEventCount);

--- a/src/ReactiveDomain.Foundation/ReactiveDomain.Foundation.csproj
+++ b/src/ReactiveDomain.Foundation/ReactiveDomain.Foundation.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="ReactiveDomain.Testing" />
+    <InternalsVisibleTo Include="ReactiveDomain.Testing.Tests" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/src/ReactiveDomain.Messaging.Tests/MessageHierarchyTests.cs
+++ b/src/ReactiveDomain.Messaging.Tests/MessageHierarchyTests.cs
@@ -1,8 +1,7 @@
-﻿using ReactiveDomain.Messaging;
+﻿using ReactiveDomain.Testing;
 using Xunit;
 
-// ReSharper disable once CheckNamespace
-namespace ReactiveDomain.Testing;
+namespace ReactiveDomain.Messaging.Tests;
 
 public class MessageHierarchyTests {
 	[Fact]

--- a/src/ReactiveDomain.Testing.Tests/Messaging/CapturingBusTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/Messaging/CapturingBusTests.cs
@@ -1,7 +1,8 @@
 ﻿using ReactiveDomain.Messaging;
+using ReactiveDomain.Testing.Messaging;
 using Xunit;
 
-namespace ReactiveDomain.Testing.Messaging;
+namespace ReactiveDomain.Testing.Tests.Messaging;
 
 public sealed class CapturingBusTests {
 	private readonly CapturingBus _sut = new();

--- a/src/ReactiveDomain.Testing.Tests/Messaging/CapturingSubscribableBusTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/Messaging/CapturingSubscribableBusTests.cs
@@ -3,9 +3,10 @@ using System.Reactive.Disposables.Fluent;
 using ReactiveDomain.Foundation;
 using ReactiveDomain.Messaging;
 using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing.Messaging;
 using Xunit;
 
-namespace ReactiveDomain.Testing.Messaging;
+namespace ReactiveDomain.Testing.Tests.Messaging;
 
 public sealed class CapturingSubscribableBusTests : IDisposable {
 	private readonly CapturingSubscribableBus _sut = new();

--- a/src/ReactiveDomain.Testing.Tests/ReactiveDomain.Testing.Tests.csproj
+++ b/src/ReactiveDomain.Testing.Tests/ReactiveDomain.Testing.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<Import Project="../ci.build.imports" />
+	<PropertyGroup>
+	  <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />
+    <ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
+    <ProjectReference Include="..\ReactiveDomain.Testing\ReactiveDomain.Testing.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/ReactiveDomain.Testing.Tests/Specifications/MessageListExtensionsTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/Specifications/MessageListExtensionsTests.cs
@@ -2,7 +2,7 @@
 using Xunit;
 using Xunit.Sdk;
 
-namespace ReactiveDomain.Testing;
+namespace ReactiveDomain.Testing.Tests.Specifications;
 
 public sealed class MessageListExtensionsTests : DispatcherSpecification {
 	[Fact]

--- a/src/ReactiveDomain.Testing.Tests/Specifications/MockRepositoryTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/Specifications/MockRepositoryTests.cs
@@ -3,7 +3,7 @@ using ReactiveDomain.Messaging.Bus;
 using ReactiveDomain.Testing.EventStore;
 using Xunit;
 
-namespace ReactiveDomain.Testing;
+namespace ReactiveDomain.Testing.Tests.Specifications;
 
 public sealed class MockRepositoryTests : IDisposable,
 	IHandleCommand<TestCommands.Command1> {

--- a/src/ReactiveDomain.Testing.Tests/Specifications/TestQueueTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/Specifications/TestQueueTests.cs
@@ -1,9 +1,10 @@
 ﻿using ReactiveDomain.Messaging;
 using ReactiveDomain.Messaging.Bus;
 using Xunit;
+
 // ReSharper disable AccessToDisposedClosure
 
-namespace ReactiveDomain.Testing;
+namespace ReactiveDomain.Testing.Tests.Specifications;
 
 public sealed class TestQueueTests :
 	IHandleCommand<TestCommands.Command1>,

--- a/src/ReactiveDomain.Testing.Tests/StreamStore/MockStreamStoreConnectionTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/StreamStore/MockStreamStoreConnectionTests.cs
@@ -3,8 +3,7 @@ using ReactiveDomain.Messaging;
 using ReactiveDomain.Testing.EventStore;
 using Xunit;
 
-// ReSharper disable once CheckNamespace
-namespace ReactiveDomain.Testing;
+namespace ReactiveDomain.Testing.Tests.StreamStore;
 
 // todo: separate stream connection tests and repo tests
 // ReSharper disable InconsistentNaming

--- a/src/ReactiveDomain.Testing.Tests/StreamStore/StreamStoreReadTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/StreamStore/StreamStoreReadTests.cs
@@ -1,8 +1,9 @@
 ﻿using ReactiveDomain.Foundation;
 using ReactiveDomain.Messaging;
+using ReactiveDomain.Testing.EventStore;
 using Xunit;
 
-namespace ReactiveDomain.Testing.EventStore;
+namespace ReactiveDomain.Testing.Tests.StreamStore;
 
 public class StreamStoreReadTests : IClassFixture<StreamStoreConnectionFixture> {
 	private readonly List<IStreamStoreConnection> _stores = [];

--- a/src/ReactiveDomain.Testing.Tests/StreamStore/StreamStoreSubscriptionTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/StreamStore/StreamStoreSubscriptionTests.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections.Concurrent;
 using ReactiveDomain.Foundation;
 using ReactiveDomain.Messaging;
+using ReactiveDomain.Testing.EventStore;
 using Xunit;
 
-namespace ReactiveDomain.Testing.EventStore;
+namespace ReactiveDomain.Testing.Tests.StreamStore;
 
 public class StreamStoreSubscriptionTests : IClassFixture<StreamStoreConnectionFixture> {
 	private readonly List<IStreamStoreConnection> _stores = [];

--- a/src/ReactiveDomain.Testing/EventStore/EmbeddedStreamStoreConnectionCollection.cs
+++ b/src/ReactiveDomain.Testing/EventStore/EmbeddedStreamStoreConnectionCollection.cs
@@ -1,9 +1,0 @@
-using Xunit;
-
-// ReSharper disable once CheckNamespace
-namespace ReactiveDomain.Testing;
-
-//n.b a copy of this marker class must be in the assembly with the test classes
-//copy and place in the local namespace to avoid collisions
-[CollectionDefinition(nameof(EmbeddedStreamStoreConnectionCollection))]
-public class EmbeddedStreamStoreConnectionCollection : ICollectionFixture<StreamStoreConnectionFixture>;

--- a/src/ReactiveDomain.Testing/ReactiveDomain.Testing.csproj
+++ b/src/ReactiveDomain.Testing/ReactiveDomain.Testing.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
     <IsPackable>True</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Domain\**" />
@@ -11,17 +10,11 @@
     <None Remove="Domain\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.9.3" />
+	  <InternalsVisibleTo Include="ReactiveDomain.Testing.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+	  <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />

--- a/src/ReactiveDomain.sln
+++ b/src/ReactiveDomain.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.4.11612.150 stable
+VisualStudioVersion = 18.4.11612.150
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveDomain.Messaging", "ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj", "{3BAF7404-334D-4FD3-97A5-4D15F3049334}"
 EndProject
@@ -54,6 +54,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveDomain.IdentityStorage.Tests", "ReactiveDomain.IdentityStorage.Tests\ReactiveDomain.IdentityStorage.Tests.csproj", "{46F5E314-9AAF-419D-A261-940D55CD0FC9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveDomain.PolicyTool", "ReactiveDomain.PolicyTool\ReactiveDomain.PolicyTool.csproj", "{44879F67-D0AD-4D81-B680-CB01FBC5B75F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReactiveDomain.Testing.Tests", "ReactiveDomain.Testing.Tests\ReactiveDomain.Testing.Tests.csproj", "{C6DF94CA-6BAC-4A08-A593-D8404CF3D55B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -123,6 +125,10 @@ Global
 		{46F5E314-9AAF-419D-A261-940D55CD0FC9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{44879F67-D0AD-4D81-B680-CB01FBC5B75F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{44879F67-D0AD-4D81-B680-CB01FBC5B75F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6DF94CA-6BAC-4A08-A593-D8404CF3D55B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6DF94CA-6BAC-4A08-A593-D8404CF3D55B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6DF94CA-6BAC-4A08-A593-D8404CF3D55B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6DF94CA-6BAC-4A08-A593-D8404CF3D55B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Since `ReactiveDomain.Testing` is published as a NuGet package, it should only contain what's necessary for that package. The unit tests that were in that project have been moved to different locations depending on what they're testing: some were moved to `Messaging.Tests` or `Foundation.Tests`, while those testing the classes in RD.Testing were placed in their own project, `ReactiveDomain.Testing.Tests`.