### PR TITLE
docs: storage-update plan (test infra 0.15.2 + StreamStore port 0.16.0)

### DIFF
--- a/Docs/storage-update/streamstore-storage-port.md
+++ b/Docs/storage-update/streamstore-storage-port.md
@@ -1,0 +1,129 @@
+# StreamStore Storage Port
+
+Ship a concrete gRPC-backed `IStreamStoreConnection` over the StreamStore SQLite engine. It
+becomes both a production backend and the backing store for `ReactiveDomain.Testing`
+(replacing `MockStreamStoreConnection`). Targets **0.16.0**; the test-infrastructure
+primitives it depends on ship ahead of it in 0.15.2 — see
+[test-infrastructure-plan.md](test-infrastructure-plan.md) for the release split.
+
+Tracked in #230 (wrapper) and #235 (packaging); the ProjectedEvent tagging contract it relies
+on lands first in #228. Relates to #217 (shed transitive EventStore.ClientAPI).
+
+## Current state
+
+- `IStreamStoreConnection` lives in `ReactiveDomain.Persistence`
+  (`src/ReactiveDomain.Persistence/IStreamStoreConnection.cs`). Two implementations:
+  - `EventStoreConnectionWrapper` — production, wraps the legacy TCP client
+    (`EventStore.Client 22.0.0`, `EventStore.ClientAPI`), sync-over-async throughout. Its
+    `ConnectionHelpers` extension class is the ES⇄RD mapping seam a new backend re-implements.
+  - `MockStreamStoreConnection` — `ReactiveDomain.Testing`, in-memory, synchronous delivery.
+- The Persistence assembly ships inside the umbrella `ReactiveDomain` package, which
+  hard-depends on `EventStore.Client 22.0.0`. `IStreamStoreConnection.cs` carries a leftover
+  `using EventStore.ClientAPI;` even though the interface uses only RD types.
+
+## What StreamStore provides
+
+- **`ReactiveDomain.StreamStore`** — the `MultiDbStreams` gRPC service, the client-side
+  `PartitionInterceptor`, and the `AddStreamStoreSqliteMultiDb(dataDir, maxEventSize)` DI
+  extension.
+- **`ReactiveDomain.StreamStore.Sqlite`** — the SQLite multi-database engine.
+- The host speaks the KurrentDB/ESDB gRPC wire protocol, so the client is stock
+  **`KurrentDB.Client`** (currently 1.4.0). One wrapper therefore serves StreamStore.Host,
+  KurrentDB, and ESDB — the gRPC protocol is theirs; StreamStore adopted it.
+
+## The connection wrapper
+
+New class in `ReactiveDomain.Persistence` implementing `IStreamStoreConnection` over
+`KurrentDBClient`. StreamStore has a conformance-tested implementation
+(`ESDBConnectionWrapper`); adopt it rather than writing fresh.
+
+Construction:
+
+- `KurrentDBClientSettings` from an `esdb://…?tls=false` URI. `DefaultDeadline` of 2 minutes
+  (headroom for large multi-event transactions).
+- Interceptor list on the settings: `PartitionInterceptor(partition)` when a partition is set,
+  a bearer-token interceptor when a token is set. Connection-scoped headers must ride client
+  interceptors — per-call `UserCredentials` map to gRPC call credentials, which .NET drops on
+  insecure (tls=false) channels.
+- `settings.CreateHttpMessageHandler` accepts an optional handler factory — the seam that lets
+  tests point the client at an in-process ASP.NET TestServer with no socket.
+
+Behavior:
+
+- **ProjectedEvent tagging is required, not optional.** A delivery with `ResolvedEvent.Link`
+  non-null is a projection copy (`$ce-`/`$et-`/`$streams` link), not a distinct fact. Return:
+
+  ```csharp
+  new ProjectedEvent(
+      link.EventStreamId,                          // ProjectedStream: the $ce-/$et- stream this copy lives in
+      e.EventNumber.ToInt64(),                     // OriginalEventNumber: position in the source stream
+      e.EventStreamId,                             // source stream
+      e.EventId.ToGuid(),
+      resolvedEvent.OriginalEventNumber.ToInt64(), // EventNumber: position in the projected stream
+      e.EventType, e.Data.ToArray(), e.Metadata.ToArray(),
+      isJson, e.Created, e.Created.Ticks);
+  ```
+
+  This matches `MockStreamStoreConnection`'s tagging of its emulated projection copies.
+  `MockRepositorySpecification`'s connector bus dedups on `is ProjectedEvent`; without the tag,
+  every domain event is delivered multiple times through its link copies.
+  `EventStoreConnectionWrapper` adopts the same tagging in 0.15.2, so by the time this
+  wrapper ships the tagging is an established contract across all implementations, not a new
+  behavior.
+- Non-link deliveries map to plain `RecordedEvent` using `OriginalEventNumber` — position in
+  the stream being read, matching `EventStoreConnectionWrapper`.
+- Carry forward the null-resolved-event guards specified in
+  [../null-linkto-handling.md](../null-linkto-handling.md) (skip null link targets in
+  subscriptions and batch reads; checkpoints track link positions, so gaps are safe).
+- **Carry the source position(s) through the delivery envelope** — the envelope half of
+  #211. The wrapper defines the `RecordedEvent` mapping; deferring position carry means
+  touching the same mapping twice when read-model checkpointing (`CheckpointPosition`,
+  `WaitForPosition`) lands. On a single-store total order the `$all` position is a scalar
+  watermark.
+
+## Partition model
+
+- Routing header: **`streamstore-partition`**, stamped per-connection by
+  `PartitionInterceptor`. One SQLite database per partition value, provisioned on first use.
+  Partition ids match `^[a-z][a-z0-9_]*$`.
+- The test harness derives a fresh partition per test (e.g. `b_` + `Guid.NewGuid():N`), so
+  thousands of tests share one host with hard isolation and no port contention.
+
+## Hosting shapes
+
+Both shapes are the same composition:
+`CreateSlimBuilder` → `AddGrpc()` → `AddStreamStoreSqliteMultiDb(dataDir, maxEventSize)` →
+`MapGrpcService<MultiDbStreams>()` (resolve the service eagerly so the engine boots at start).
+
+- **In-process TestServer** — the `ReactiveDomain.Testing` default. `UseTestServer()`, backing
+  data in a temp subdirectory, and the TestServer's `CreateHandler()` fed into the wrapper's
+  handler factory. No sockets; hermetic; parallel-safe.
+- **Loopback sidecar** — integration and production. Kestrel plaintext HTTP/2 on
+  `127.0.0.1`, port 0 to pick a free port. On Windows, probe the bound port for the
+  WinNAT/Hyper-V excluded-port-range failure (`WSAEACCES` on connect despite a successful
+  bind) and rebind — retry ~10 ports. Endpoint: `esdb://127.0.0.1:{port}?tls=false`.
+
+## Packaging
+
+- The wrapper goes in `ReactiveDomain.Persistence`; the umbrella `ReactiveDomain` package
+  gains a `KurrentDB.Client` dependency.
+- The test host needs `ReactiveDomain.StreamStore`, `ReactiveDomain.StreamStore.Sqlite`, and
+  `Microsoft.AspNetCore.TestHost`. Decide whether `ReactiveDomain.Testing` absorbs those
+  dependencies or a separate `ReactiveDomain.Testing.Host` package carries them (keeps the
+  base testing package light for consumers that only want the bus/spec doubles).
+- End state: `EventStoreConnectionWrapper` and the `EventStore.Client 22.0.0` TCP dependency
+  retire once consumers are on the gRPC wrapper; the stray `using EventStore.ClientAPI;` in
+  `IStreamStoreConnection.cs` goes with them. The wrapper becomes the contract.
+
+## Verification
+
+StreamStore's conformance suite already covers the wrapper against its host. Once the test
+infrastructure plan lands, RD's own spec suite runs against the real store continuously, which
+keeps the wrapper honest from the consumer side.
+
+One case the conformance suite must include explicitly: **writes racing the catch-up→live
+transition.** The gRPC protocol makes the transition server-side (history, caught-up signal,
+live — one stream), so there is no client-side switchover to race; the case pins the
+StreamStore host's implementation of that boundary. Events committed during the transition are
+delivered exactly once, and the live signal fires only after the transition completes —
+`ReadModelBase.IsLive` (#234) is only as honest as this signal.

--- a/Docs/storage-update/test-infrastructure-plan.md
+++ b/Docs/storage-update/test-infrastructure-plan.md
@@ -1,0 +1,264 @@
+# Storage Update: Test Infrastructure Plan
+
+Replace `MockStreamStoreConnection` as the backing store for `ReactiveDomain.Testing` with
+the SQLite StreamStore, connected through the gRPC wrapper described in
+[streamstore-storage-port.md](streamstore-storage-port.md). The real store reproduces async
+delivery, so tests exercise the same timing behaviors as production instead of the mock's
+synchronous shortcut.
+
+The work splits across two releases:
+
+- **0.15.2** ships every primitive and pattern. All of it is backend-independent and (with
+  one flagged exception) purely additive, so consumers — including RD's own test suite —
+  migrate their tests incrementally against the unchanged synchronous mock.
+- **0.16.0** ships the wrapper and flips the backend. Tests already written fence-then-assert
+  keep passing; only genuinely racy stragglers surface.
+
+The designs below are proven — they run today in a consuming application's CI against the
+real store.
+
+## Tracking
+
+**0.15.2** — #223 (TestQueue signal-before-filter), #224 (AwaitEventDelivery fence),
+#225 (CatchUpConnection), #226 (FaultInjectingConfiguredConnection), #227 (CI-aware timeouts),
+#228 (ProjectedEvent tagging in EventStoreConnectionWrapper), #229 (IsLive contract docs).
+
+**0.16.0** — #230 (gRPC StreamStore wrapper — see
+[streamstore-storage-port.md](streamstore-storage-port.md)), #231 (spec-base backend swap),
+#232 (residual test migration), #233 (remove MockStreamStoreConnection), #234 (IsLive
+alignment), #235 (Testing.Host packaging — see storage-port doc).
+
+## Why async delivery forces harness changes
+
+The mock delivers synchronously through its internal `SingleThreadedBus`: when `Save`
+returns, every subscriber has already handled the event. All of RD.Testing's assertion
+contracts (`AssertNext`, `AssertEmpty`, dispatcher queue inspection) implicitly depend on
+that. On the real store, `RepositoryEvents` is fed by a live asynchronous `$all`
+subscription — "the save returned" no longer means "the event is in the queue." Every spec
+test needs an explicit delivery fence, and the harness must provide one that doesn't pollute
+assertions.
+
+---
+
+## 0.15.2 — primitives and patterns
+
+### 1. TestQueue: signal WaitForMsgId waiters before the type filter
+
+Today `TestQueue.Handle` applies the constructor's `MessageTypeFilter` before enqueueing
+**and** before signaling `_idWatchList` waiters, so a message outside the filter can never
+complete a `WaitForMsgId` wait. Change the ordering: signal id-watchers first, then apply the
+filter for enqueue.
+
+This enables an **invisible fence** — a fence message completes a `WaitForMsgId` wait without
+ever entering the queue, so it can't break a subsequent `AssertEmpty`. The only observable
+change is that waits on filtered-out message ids now complete instead of timing out — a fix.
+Everything below depends on it; land it first.
+
+While in the file: `WaitFor`/`WaitForMultiple<T>` poll a full queue snapshot per iteration
+and use `is T` at wait time versus `IsAssignableFrom` at ingest — both get hotter and more
+visible under async delivery; worth tightening in the same pass.
+
+### 2. AwaitEventDelivery: the spec-base fence
+
+With the TestQueue change in the same release, the fence ships in its invisible form
+directly:
+
+```csharp
+// Brackets a test's arrange region in $all. Plain Messages, NOT Events, so
+// RepositoryEvents (filter: typeof(Event)) never captures them — but WaitForMsgId
+// still signals (per change 1).
+public sealed record SetupStartMarker : Message;
+public sealed record DeliveryFence : Message;
+
+// A '$'-free, '-'-free stream: no $ce category link is emitted for markers, and the
+// $et link that is emitted resolves to a ProjectedEvent the connector drops.
+private const string MarkerStream = "setupMarkers";
+
+public void AwaitEventDelivery() {
+    var fence = new DeliveryFence();
+    WriteMarker(fence);
+    RepositoryEvents.WaitForMsgId(fence.MsgId, TestTimeouts.WaitFor);
+}
+
+public override void ClearQueues() {
+    AwaitEventDelivery();                // fence async $all delivery so no in-flight event lands post-clear
+    base.ClearQueues();
+    WriteMarker(new SetupStartMarker()); // open the next arrange region
+}
+
+private void WriteMarker(Message marker) =>
+    StreamStoreConnection.AppendToStream(
+        MarkerStream, ExpectedVersion.Any, credentials: null, EventSerializer.Serialize(marker));
+```
+
+Because `$all` delivers in order, the fence's arrival proves every event committed before it
+is already queued. The fence covers events committed before it — synchronous handler saves —
+not async cascades (process managers, timers); those need the read-model barrier below. The
+spec constructor writes a `SetupStartMarker` so the first arrange region is bracketed from
+the start.
+
+**On the 0.15.2 mock this is a near-no-op** — delivery is synchronous, so the fence
+completes immediately. That is the point: consumers adopt fence-then-assert against 0.15.2
+at their own pace, and the calls become load-bearing when 0.16.0 flips the backend.
+
+### 3. CatchUpConnection: the standard read-model barrier
+
+An `IConfiguredConnection` decorator providing a deterministic "all read models have
+consumed everything committed to their streams" barrier. New public class in Foundation —
+it is useful in production seeding/export paths, not just tests, and works against the mock
+and the ESDB wrapper today.
+
+```csharp
+public sealed class CatchUpConnection(IConfiguredConnection inner) : IConfiguredConnection {
+    // Delegates everything; GetListener returns a TrackedStreamListener and records it.
+    // GetQueuedListener is deliberately NOT tracked: QueuedStreamListener's queue buffers
+    // post-receipt, so tracking it would over-report delivery.
+    public void WaitForCatchUp(TimeSpan timeout, params ReadModelBase[] readModels);
+}
+```
+
+`TrackedStreamListener` (private, extends `StreamListener`) exposes
+`DeliveredThrough = max(startCheckpoint, lastDelivered)`, with `lastDelivered` recorded in a
+`GotEvent` override **after** the base publishes into the subscriber's queue. So
+`DeliveredThrough >= N` means "event N is in the read model's queue or applied," never "in
+flight." This fixes two ambiguities in the base `StreamListener.Position`: it advances at
+receipt (before the subscriber sees the event) and initializes to 0 (indistinguishable from
+"applied event 0").
+
+Barrier mechanics:
+
+1. Bound the `IsLive` wait first — `Task.WhenAll(readModels.Select(rm => rm.IsLive))` with
+   the timeout. An unbounded wait here has hung CI for hours.
+2. Loop until deadline, checking in causal order each pass: every tracked listener's
+   `DeliveredThrough` against its stream's end (re-read via `ReadStreamBackward` every pass,
+   so the target moves until the store is quiet), then every read model's
+   `Idle && MessageCount == 0`.
+3. On timeout, throw naming each laggard (`"{stream} delivered {n} of {target}"`) and each
+   busy queue (`"queue {RmType} (count {n})"`), so the failure says *what* is behind, not
+   just that something is.
+
+This replaces every heuristic wait (count-stability windows, version guessing, bare
+`IsLive`) whose failure mode is false completion under scheduler lag.
+
+### 4. FaultInjectingConfiguredConnection
+
+A save-fault injection decorator for RD.Testing; purely additive:
+
+```csharp
+// IConfiguredConnection decorator: wraps the repositories so Save throws
+// InjectedSaveException when a Func<IEventSource, bool> predicate matches;
+// reads and listeners pass through untouched.
+public sealed class FaultInjectingConfiguredConnection(IConfiguredConnection inner, Func<IEventSource, bool> shouldFail)
+```
+
+Deterministically exercises save-failure and compensation paths; RD.Testing has no
+equivalent today.
+
+### 5. CI-aware timeouts
+
+A single timeout source in RD.Testing, keyed on `GITHUB_ACTIONS`:
+
+| Purpose | Local | CI |
+|---|---|---|
+| `WaitFor` (TestQueue / RepositoryEvents waits) | 500 ms | 5 s |
+| `CommandTimeout` (Send response waits) | 500 ms | 10 s |
+| `ThrottleWaitFor` (real-time Rx operators) | 2 s | 10 s |
+
+Plus `MaxCpuCount=1` runsettings guidance (sequential assembly execution; concurrent
+in-process stores starve the thread pool) and the local repro recipe for 2-core flakes:
+launch the test runner with `start /affinity` (2 cores) and `GITHUB_ACTIONS=true`.
+
+### 6. ProjectedEvent tagging in EventStoreConnectionWrapper — the one behavior change
+
+Link-resolved deliveries from the production ESDB wrapper start arriving as `ProjectedEvent`
+instead of plain `RecordedEvent`, matching the mock's tagging of its emulated projection
+copies (field mapping in [streamstore-storage-port.md](streamstore-storage-port.md)).
+
+Since `ProjectedEvent : RecordedEvent`, consumers that don't type-check are unaffected;
+consumers with `is ProjectedEvent` dedup guards (the harness connector) start working
+correctly against real ES for the first time. Landing it here makes the connection contract
+uniform across mock and real wrapper before the port, so the 0.16.0 wrapper conforms to an
+already-published contract. Deserves the release-notes callout.
+
+### 7. IsLive: document the contract
+
+The `IsLive` **Task** completes when the subscription goes live — before any downstream
+batching cache flushes — while `IsLiveObservable` fires after. Consumers waiting on the Task
+can observe empty read models that are "live." Document this in 0.15.2; behavioral alignment
+(if any) changes consumer-visible timing and belongs in 0.16.0.
+
+### Consumer guidance for the 0.15.2 window
+
+Migrate test patterns now, while the backend is still synchronous and every change is
+verifiable as a no-op:
+
+- assert immediately after save → fence first (`AwaitEventDelivery()`)
+- `AssertEmpty` after seeding → the fenced `ClearQueues()` handles it
+- read-model state checks after command dispatch → `CatchUpConnection.WaitForCatchUp(...)`
+- raw waits/sleeps → `WaitForMsgId` or bounded `AssertEx.IsOrBecomesTrue` with CI-aware
+  timeouts
+
+RD's own `MockRepositorySpecification`-derived suite migrates in this window too — it is the
+first consumer.
+
+---
+
+## 0.16.0 — the backend flip
+
+### 1. The gRPC wrapper
+
+Per [streamstore-storage-port.md](streamstore-storage-port.md). ProjectedEvent tagging and
+null-linkto handling are already contract-uniform from 0.15.2; the wrapper conforms.
+
+### 2. Spec base backend swap
+
+`MockRepositorySpecification` keeps its API (Dispatcher, `RepositoryEvents`, `Repository`,
+listeners) and swaps the backing store underneath: each test gets a fresh partition (its own
+SQLite database) on a shared in-process TestServer host — hermetic, parallel-safe, no port
+contention (host composition in the storage-port doc).
+
+### 3. Residual test migration
+
+Tests migrated during the 0.15.2 window keep passing. What surfaces now is the genuinely
+racy remainder — tests whose assumptions no fence can paper over (ordering across
+independent subscriptions, reliance on synchronous cascade timing). Fix these individually;
+the failure diagnostics from the barrier and fences name what's behind.
+
+Downstream consumers inherit the same sequence when they upgrade; the 0.15.2 consumer
+guidance doubles as their upgrade guide.
+
+### 4. Deletions
+
+Mock-only artifacts die with the mock — delete compensations rather than migrate them:
+
+- The catch-up→live switchover gap in the mock's `SubscribeToStreamFrom` (`#mock-life`) and
+  anything compensating for it.
+- `resolveLinkTos` accepted-but-ignored; the real store and wrapper handle link resolution.
+
+### 5. IsLive: complete at the live transition, fault on drop, align with observable
+
+Three fixes, all consumer-visible timing changes (#234):
+
+- **Upstream edge**: each `StartAsync` read task calls `listener.Start(...,
+  blockUntilLive: false, ...)` and completes when the subscription is merely *started* —
+  every event between `reader.Position` and the live transition is still in flight when
+  `IsLive` completes. The read task must complete on the listener's live signal instead.
+  (The read→listen handoff itself is lossless — the listener catch-up-subscribes from
+  `reader.Position`, so transition-window events are replayed, never skipped. The defect is
+  the signal, not the handoff.)
+- **Fault on drop**: `StreamListener` sets its live gate on subscription drop and on
+  Dispose, so a dead listener reads as live and can pass liveness gates. A drop must fault
+  the read task; `blockUntilLive` waiters unblock via the fault, not a fake live.
+- **Downstream edge**: the Task vs `IsLiveObservable` divergence documented in 0.15.2 —
+  align so awaiting `IsLive` guarantees a queryable read model, or keep the two signals as
+  explicitly distinct contracts.
+
+Fixing the signal at the source shrinks every downstream compensation: gating on the
+observable instead of the Task, barrier-wrapping read models because "IsLive alone
+under-waits," and the barrier's known blindness to dropped subscriptions.
+
+### 6. Packaging
+
+The host dependency decision (fold `ReactiveDomain.StreamStore`, `.Sqlite`, and
+`Microsoft.AspNetCore.TestHost` into `ReactiveDomain.Testing` vs a separate
+`ReactiveDomain.Testing.Host` package) — see the storage-port doc.


### PR DESCRIPTION
Adds `Docs/storage-update/` with the two design docs behind replacing `MockStreamStoreConnection` with the SQLite StreamStore, so the harness reproduces real async delivery.

## Docs

- **test-infrastructure-plan.md** — the release split. **0.15.2** lands the backend-independent test primitives so consumers migrate incrementally against the unchanged synchronous mock; **0.16.0** ships the wrapper and flips the backend.
- **streamstore-storage-port.md** — the concrete gRPC `IStreamStoreConnection` over StreamStore (KurrentDB.Client wire), partition model, hosting shapes, and packaging.

## Why two releases

Everything except the wrapper and the backend swap is additive and backend-independent. Landing it in 0.15.2 lets the test-pattern migration happen against the mock (where every fence is a verifiable no-op), so 0.16.0 becomes just the wrapper plus the flip. The one behavior change in 0.15.2 is ProjectedEvent tagging on `EventStoreConnectionWrapper` (#228) — flagged for release notes.

## Tracking

- 0.15.2: #223 #224 #225 #226 #227 #228 #229
- 0.16.0: #230 #231 #232 #233 #234 #235
- Relates to #217 (shed transitive EventStore.ClientAPI).

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)