### PR TITLE
Improvements to packaging

### DIFF
--- a/package.bat
+++ b/package.bat
@@ -1,8 +1,10 @@
 del .\nupkgs\*.* /q
 del .\bld\Debug\*.* /q
 del .\bld\pub\*.* /q
+del .\bld\tools\*.* /q
 dotnet restore .\src\ReactiveDomain.sln
 dotnet build .\src\ReactiveDomain.sln -c Debug
+dotnet publish .\src\ReactiveDomain.PolicyTool\ReactiveDomain.PolicyTool.csproj -p:PublishProfile=FolderProfile --framework net8.0
 dotnet publish .\src\ReactiveDomain.PolicyTool\ReactiveDomain.PolicyTool.csproj -p:PublishProfile=FolderProfile --framework net10.0
 pwsh.exe -Command "& {.\tools\CreateDebugNuget.ps1 -local002}"
 

--- a/publish.bat
+++ b/publish.bat
@@ -1,8 +1,10 @@
 del .\*.nukpg /q
 del .\bld\Release\*.* /q
 del .\bld\pub\*.* /q
+del .\bld\tools\*.* /q
 dotnet restore .\src\ReactiveDomain.sln
 dotnet build .\src\ReactiveDomain.sln -c Release
+dotnet publish .\src\ReactiveDomain.PolicyTool\ReactiveDomain.PolicyTool.csproj -c Release -p:PublishProfile=FolderProfile --framework net8.0
 dotnet publish .\src\ReactiveDomain.PolicyTool\ReactiveDomain.PolicyTool.csproj -c Release -p:PublishProfile=FolderProfile --framework net10.0
 pwsh.exe -Command "& {.\tools\CreateNuget.ps1}"
 

--- a/src/ReactiveDomain.Core/ReactiveDomain.Core.csproj
+++ b/src/ReactiveDomain.Core/ReactiveDomain.Core.csproj
@@ -3,7 +3,8 @@
   <Import Project="../ci.build.imports" />
   <PropertyGroup>
     <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
-    <RootNamespace>ReactiveDomain</RootNamespace>   
+    <RootNamespace>ReactiveDomain</RootNamespace>
+		<IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="ReactiveDomain.Persistence" />

--- a/src/ReactiveDomain.Debug.nuspec
+++ b/src/ReactiveDomain.Debug.nuspec
@@ -1,71 +1,91 @@
 ﻿<?xml version="1.0"?>
 <package>
-  <metadata>
-    <id>ReactiveDomain</id>
-    <version>0.15.1.0</version>
-    <authors>Reactive Domain Group</authors>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">MIT</license>
-    <description>Package includes all ReactiveDomain Core assemblies</description>
-    <dependencies>
-      <group targetFramework="net8.0">
-        <dependency id="EventStore.Client" version="21.2.2" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.CSharp" version="4.7.0" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-        <dependency id="System.Reactive" version="6.0.1" exclude="Build,Analyzers"/>
-        <dependency id="System.Configuration.ConfigurationManager" version="8.0.0" exclude="Build,Analyzers" />
-        <dependency id="System.Diagnostics.PerformanceCounter" version="8.0.0" exclude="Build,Analyzers" />
-      </group>
-	  <group targetFramework="net10.0">
-		<dependency id="EventStore.Client" version="21.2.2" exclude="Build,Analyzers" />
-		<dependency id="Microsoft.CSharp" version="4.7.0" exclude="Build,Analyzers" />
-		<dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-		<dependency id="System.Reactive" version="6.0.1" exclude="Build,Analyzers"/>
-		<dependency id="System.Configuration.ConfigurationManager" version="10.0.0" exclude="Build,Analyzers" />
-		<dependency id="System.Diagnostics.PerformanceCounter" version="10.0.0" exclude="Build,Analyzers" />
-	  </group>
-    </dependencies>
-    <references>
-      <group targetFramework="net8.0">
-        <reference file="ReactiveDomain.Core.dll" />
-        <reference file="ReactiveDomain.Foundation.dll" />
-        <reference file="ReactiveDomain.Messaging.dll" />
-        <reference file="ReactiveDomain.Persistence.dll" />
-        <reference file="ReactiveDomain.Transport.dll" />
-      </group>
-	  <group targetFramework="net10.0">
-		<reference file="ReactiveDomain.Core.dll" />
-		<reference file="ReactiveDomain.Foundation.dll" />
-		<reference file="ReactiveDomain.Messaging.dll" />
-		<reference file="ReactiveDomain.Persistence.dll" />
-		<reference file="ReactiveDomain.Transport.dll" />
-	  </group>
-    </references>
-  </metadata>
-  <files>
-    <file src="..\build\ReactiveDomain.props" target="build" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Core.pdb" target="lib\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Foundation.pdb" target="lib\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Messaging.pdb" target="lib\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Persistence.pdb" target="lib\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Transport.pdb" target="lib\net8.0" />
-                               
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Core.dll" target="lib\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Foundation.dll" target="lib\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Messaging.dll" target="lib\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Persistence.dll" target="lib\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Transport.dll" target="lib\net10.0" />
-                               
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Core.dll" target="ref\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Foundation.dll" target="ref\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Messaging.dll" target="ref\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Persistence.dll" target="ref\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Transport.dll" target="ref\net8.0" />
-                               
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Core.dll" target="ref\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Foundation.dll" target="ref\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Messaging.dll" target="ref\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Persistence.dll" target="ref\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Transport.dll" target="ref\net10.0" />
-  </files>
+	<metadata>
+		<id>ReactiveDomain</id>
+		<version>0.15.1.0</version>
+		<authors>Reactive Domain Group</authors>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<license type="expression">MIT</license>
+		<description>A toolkit for implementing CQRS-ES in a reactive system. Package includes all ReactiveDomain Core assemblies.</description>
+		<readme>docs\README.md</readme>
+		<tags>CQRS ES event-sourcing messaging</tags>
+		<repository type="git" url="https://github.com/ReactiveDomain/reactive-domain" branch="master" />
+		<dependencies>
+			<group targetFramework="net8.0">
+				<dependency id="EventStore.Client" version="21.2.2" exclude="Build,Analyzers" />
+				<dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
+				<dependency id="System.Reactive" version="6.0.1" exclude="Build,Analyzers"/>
+				<dependency id="System.Configuration.ConfigurationManager" version="8.0.0" exclude="Build,Analyzers" />
+				<dependency id="System.Diagnostics.PerformanceCounter" version="8.0.0" exclude="Build,Analyzers" />
+			</group>
+			<group targetFramework="net10.0">
+				<dependency id="EventStore.Client" version="21.2.2" exclude="Build,Analyzers" />
+				<dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
+				<dependency id="System.Reactive" version="6.0.1" exclude="Build,Analyzers"/>
+				<dependency id="System.Configuration.ConfigurationManager" version="10.0.0" exclude="Build,Analyzers" />
+				<dependency id="System.Diagnostics.PerformanceCounter" version="10.0.0" exclude="Build,Analyzers" />
+			</group>
+		</dependencies>
+		<references>
+			<group targetFramework="net8.0">
+				<reference file="ReactiveDomain.Core.dll" />
+				<reference file="ReactiveDomain.Foundation.dll" />
+				<reference file="ReactiveDomain.Messaging.dll" />
+				<reference file="ReactiveDomain.Persistence.dll" />
+				<reference file="ReactiveDomain.Transport.dll" />
+			</group>
+			<group targetFramework="net10.0">
+				<reference file="ReactiveDomain.Core.dll" />
+				<reference file="ReactiveDomain.Foundation.dll" />
+				<reference file="ReactiveDomain.Messaging.dll" />
+				<reference file="ReactiveDomain.Persistence.dll" />
+				<reference file="ReactiveDomain.Transport.dll" />
+			</group>
+		</references>
+	</metadata>
+	<files>
+		<file src="..\build\ReactiveDomain.props" target="build" />
+		
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Core.pdb" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Core.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Core.dll" target="ref\net8.0" />
+
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Core.pdb" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Core.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Core.dll" target="ref\net10.0" />
+
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Foundation.pdb" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Foundation.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Foundation.dll" target="ref\net8.0" />
+
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Foundation.pdb" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Foundation.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Foundation.dll" target="ref\net10.0" />
+
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Messaging.pdb" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Messaging.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Messaging.dll" target="ref\net8.0" />
+
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Messaging.pdb" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Messaging.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Messaging.dll" target="ref\net10.0" />
+
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Persistence.pdb" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Persistence.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Persistence.dll" target="ref\net8.0" />
+
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Persistence.pdb" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Persistence.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Persistence.dll" target="ref\net10.0" />
+
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Transport.pdb" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Transport.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Transport.dll" target="ref\net8.0" />
+
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Transport.pdb" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Transport.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Transport.dll" target="ref\net10.0" />
+
+		<file src="..\README.md" target="docs\" />
+	</files>
 </package>

--- a/src/ReactiveDomain.Foundation.Tests/ReactiveDomain.Foundation.Tests.csproj
+++ b/src/ReactiveDomain.Foundation.Tests/ReactiveDomain.Foundation.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="../ci.build.imports" />
   <PropertyGroup>
     <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
+	  <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>

--- a/src/ReactiveDomain.IdentityStorage.Tests/ReactiveDomain.IdentityStorage.Tests.csproj
+++ b/src/ReactiveDomain.IdentityStorage.Tests/ReactiveDomain.IdentityStorage.Tests.csproj
@@ -1,30 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="../ci.build.imports" />
-    <PropertyGroup>
-     <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
-    <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
-    <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-      <PackageReference Include="xunit" Version="2.9.3" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-      <PackageReference Include="xunit.runner.console" Version="2.9.3">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    </ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />
-      <ProjectReference Include="..\ReactiveDomain.Policy\ReactiveDomain.Policy.csproj" />
-      <ProjectReference Include="..\ReactiveDomain.IdentityStorage\ReactiveDomain.IdentityStorage.csproj" />
-      <ProjectReference Include="..\ReactiveDomain.Core\ReactiveDomain.Core.csproj" />
-      <ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
-      <ProjectReference Include="..\ReactiveDomain.Persistence\ReactiveDomain.Persistence.csproj" />
-      <ProjectReference Include="..\ReactiveDomain.Testing\ReactiveDomain.Testing.csproj" />
-    </ItemGroup>   
-  </Project>
+	<Import Project="../ci.build.imports" />
+	<PropertyGroup>
+		<TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="xunit.runner.console" Version="2.9.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Policy\ReactiveDomain.Policy.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.IdentityStorage\ReactiveDomain.IdentityStorage.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Core\ReactiveDomain.Core.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Persistence\ReactiveDomain.Persistence.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Testing\ReactiveDomain.Testing.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/ReactiveDomain.IdentityStorage/ReactiveDomain.IdentityStorage.csproj
+++ b/src/ReactiveDomain.IdentityStorage/ReactiveDomain.IdentityStorage.csproj
@@ -2,7 +2,7 @@
   <Import Project="../ci.build.imports" />
   <PropertyGroup>
     <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
-    <IsPackable>true</IsPackable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
    <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/src/ReactiveDomain.Messaging.Tests/ReactiveDomain.Messaging.Tests.csproj
+++ b/src/ReactiveDomain.Messaging.Tests/ReactiveDomain.Messaging.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="../ci.build.imports" />
   <PropertyGroup>
     <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
+	  <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
@@ -9,7 +10,7 @@
     <PackageReference Include="System.CodeDom" Version="10.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.runner.console" Version="2.9.3">

--- a/src/ReactiveDomain.Messaging/ReactiveDomain.Messaging.csproj
+++ b/src/ReactiveDomain.Messaging/ReactiveDomain.Messaging.csproj
@@ -1,18 +1,19 @@
-﻿<Project Sdk="Microsoft.NET.Sdk"> 
-  <Import Project="../ci.build.imports" />
-  <PropertyGroup>
-    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.9" />
-    <PackageReference Include="System.Reactive" Version="6.1.0" />
-    <ProjectReference Include="..\ReactiveDomain.Core\ReactiveDomain.Core.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Reactive">
-      <HintPath>..\..\dependencies\system.reactive\6.0.1\lib\net6.0\System.Reactive.dll</HintPath>
-    </Reference>
-  </ItemGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<Import Project="../ci.build.imports" />
+	<PropertyGroup>
+		<TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" PrivateAssets="all" />
+		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.9" />
+		<PackageReference Include="System.Reactive" Version="6.1.0" />
+		<ProjectReference Include="..\ReactiveDomain.Core\ReactiveDomain.Core.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<Reference Include="System.Reactive">
+			<HintPath>..\..\dependencies\system.reactive\6.0.1\lib\net6.0\System.Reactive.dll</HintPath>
+		</Reference>
+	</ItemGroup>
 </Project>

--- a/src/ReactiveDomain.Persistence/ReactiveDomain.Persistence.csproj
+++ b/src/ReactiveDomain.Persistence/ReactiveDomain.Persistence.csproj
@@ -1,21 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../ci.build.imports" />
-  <PropertyGroup>
-    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
-    <RootNamespace>ReactiveDomain</RootNamespace>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Remove="EventStoreCatchUpSubscription.cs" />
-    <Compile Remove="EventStoreStreamCatchUpSubscription.cs" />
-    <Compile Remove="StreamSubscription.cs" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="EventStore.Client" Version="22.0.0" Condition="" />   
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\ReactiveDomain.Core\ReactiveDomain.Core.csproj" />
-    <ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
-  </ItemGroup>
+	<Import Project="../ci.build.imports" />
+	<PropertyGroup>
+		<TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
+		<RootNamespace>ReactiveDomain</RootNamespace>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+	<ItemGroup>
+		<Compile Remove="EventStoreCatchUpSubscription.cs" />
+		<Compile Remove="EventStoreStreamCatchUpSubscription.cs" />
+		<Compile Remove="StreamSubscription.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="EventStore.Client" Version="22.0.0" Condition="" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ReactiveDomain.Core\ReactiveDomain.Core.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/ReactiveDomain.Policy.Debug.nuspec
+++ b/src/ReactiveDomain.Policy.Debug.nuspec
@@ -1,75 +1,82 @@
 ﻿<?xml version="1.0"?>
 <package>
-  <metadata>
-    <id>ReactiveDomain.Policy</id>
-    <version>0.15.1.0</version>
-    <authors>Reactive Domain Group</authors>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">MIT</license>
-    <description>Package includes all ReactiveDomain Identity and Policy assemblies</description>       
-    <dependencies>
-      <group targetFramework="net8.0">
-        <dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
-        <dependency id="DynamicData" version="8.4.1" exclude="Build,Analyzers" />
-        <dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
-        <dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>
-        <dependency id="Microsoft.CSharp" version="4.7.0" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-        <dependency id="System.DirectoryServices" version="8.0.0" exclude="Build,Analyzers"/>
-        <dependency id="System.DirectoryServices.AccountManagement" version="8.0.0" exclude="Build,Analyzers" />
-      </group>
-	  <group targetFramework="net10.0">
-		<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
-		<dependency id="DynamicData" version="8.4.1" exclude="Build,Analyzers" />
-		<dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
-		<dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>
-		<dependency id="Microsoft.CSharp" version="4.7.0" exclude="Build,Analyzers" />
-		<dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-		<dependency id="System.DirectoryServices" version="10.0.0" exclude="Build,Analyzers"/>
-		<dependency id="System.DirectoryServices.AccountManagement" version="10.0.0" exclude="Build,Analyzers" />
-	  </group>
-    </dependencies>
-    <references>
-      <group targetFramework="net8.0">
-        <reference file="ReactiveDomain.Policy.dll" />
-        <reference file="ReactiveDomain.PolicyStorage.dll" />
-        <reference file="ReactiveDomain.IdentityStorage.dll" />
-      </group>
-	  <group targetFramework="net10.0">
-		<reference file="ReactiveDomain.Policy.dll" />
-		<reference file="ReactiveDomain.PolicyStorage.dll" />
-		<reference file="ReactiveDomain.IdentityStorage.dll" />
-	  </group>
-    </references>    
-  </metadata>
-  <files>
-    <file src="..\build\ReactiveDomain.Policy.props" target="build" />
-    <file src="ReactiveDomain.Policy.targets" target="build" />
-    <file src="..\bld\tools\ReactiveDomain.PolicyTool.exe" target="build\PolicyTool.exe" />
-    <file src="..\bld\tools\es_settings.json" target="build\es_settings.json" />
-    
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Policy.pdb" target="lib\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Policy.dll" target="lib\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Policy.dll" target="ref\net8.0" />
+	<metadata>
+		<id>ReactiveDomain.Policy</id>
+		<version>0.15.1.0</version>
+		<authors>Reactive Domain Group</authors>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<license type="expression">MIT</license>
+		<description>ReactiveDomain Identity and Policy assemblies.</description>
+		<readme>docs\README.md</readme>
+		<tags>CQRS ES event-sourcing messaging identity policy</tags>
+		<repository type="git" url="https://github.com/ReactiveDomain/reactive-domain" branch="master" />
+		<dependencies>
+			<group targetFramework="net8.0">
+				<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
+				<dependency id="DynamicData" version="8.4.1" exclude="Build,Analyzers" />
+				<dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
+				<dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>
+				<dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
+				<dependency id="System.DirectoryServices" version="8.0.0" exclude="Build,Analyzers"/>
+				<dependency id="System.DirectoryServices.AccountManagement" version="8.0.0" exclude="Build,Analyzers" />
+			</group>
+			<group targetFramework="net10.0">
+				<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
+				<dependency id="DynamicData" version="8.4.1" exclude="Build,Analyzers" />
+				<dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
+				<dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>
+				<dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
+				<dependency id="System.DirectoryServices" version="10.0.0" exclude="Build,Analyzers"/>
+				<dependency id="System.DirectoryServices.AccountManagement" version="10.0.0" exclude="Build,Analyzers" />
+			</group>
+		</dependencies>
+		<references>
+			<group targetFramework="net8.0">
+				<reference file="ReactiveDomain.Policy.dll" />
+				<reference file="ReactiveDomain.PolicyStorage.dll" />
+				<reference file="ReactiveDomain.IdentityStorage.dll" />
+			</group>
+			<group targetFramework="net10.0">
+				<reference file="ReactiveDomain.Policy.dll" />
+				<reference file="ReactiveDomain.PolicyStorage.dll" />
+				<reference file="ReactiveDomain.IdentityStorage.dll" />
+			</group>
+		</references>
+	</metadata>
+	<files>
+		<file src="..\build\ReactiveDomain.Policy.props" target="build" />
+		<file src="ReactiveDomain.Policy.targets" target="build" />
+		
+		<file src="..\bld\tools\net8.0\ReactiveDomain.PolicyTool.exe" target="build\net8.0\PolicyTool.exe" />
+		<file src="..\bld\tools\net8.0\es_settings.json" target="build\net8.0\es_settings.json" />
+		
+		<file src="..\bld\tools\net10.0\ReactiveDomain.PolicyTool.exe" target="build\net10.0\PolicyTool.exe" />
+		<file src="..\bld\tools\net10.0\es_settings.json" target="build\net10.0\es_settings.json" />
 
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Policy.pdb" target="lib\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Policy.dll" target="lib\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Policy.dll" target="ref\net10.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Policy.pdb" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Policy.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Policy.dll" target="ref\net8.0" />
 
-	<file src="..\bld\Debug\net8.0\ReactiveDomain.PolicyStorage.pdb" target="lib\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.PolicyStorage.dll" target="lib\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.PolicyStorage.dll" target="ref\net8.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Policy.pdb" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Policy.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Policy.dll" target="ref\net10.0" />
 
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.PolicyStorage.pdb" target="lib\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.PolicyStorage.dll" target="lib\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.PolicyStorage.dll" target="ref\net10.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.PolicyStorage.pdb" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.PolicyStorage.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.PolicyStorage.dll" target="ref\net8.0" />
 
-	<file src="..\bld\Debug\net8.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.IdentityStorage.dll" target="lib\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.IdentityStorage.dll" target="ref\net8.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.PolicyStorage.pdb" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.PolicyStorage.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.PolicyStorage.dll" target="ref\net10.0" />
 
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.IdentityStorage.dll" target="lib\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.IdentityStorage.dll" target="ref\net10.0" />
-  </files>
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.IdentityStorage.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.IdentityStorage.dll" target="ref\net8.0" />
+
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.IdentityStorage.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.IdentityStorage.dll" target="ref\net10.0" />
+
+		<file src="..\README.md" target="docs\" />
+	</files>
 </package>

--- a/src/ReactiveDomain.Policy.Tests/ReactiveDomain.Policy.Tests.csproj
+++ b/src/ReactiveDomain.Policy.Tests/ReactiveDomain.Policy.Tests.csproj
@@ -1,29 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="../ci.build.imports" />
-    <PropertyGroup>
-      <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
-      <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
-    <ItemGroup>
-      <Compile Remove="PolicyMapTest.cs" />
-    </ItemGroup>
-  
-    <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-      <PackageReference Include="xunit" Version="2.9.3" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-      <PackageReference Include="xunit.runner.console" Version="2.9.3">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    </ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\ReactiveDomain.Policy\ReactiveDomain.Policy.csproj" />     
-      <ProjectReference Include="..\ReactiveDomain.Testing\ReactiveDomain.Testing.csproj" />
-    </ItemGroup>   
-  </Project>
+	<Import Project="../ci.build.imports" />
+	<PropertyGroup>
+		<TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+	<ItemGroup>
+		<Compile Remove="PolicyMapTest.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="xunit.runner.console" Version="2.9.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ReactiveDomain.Policy\ReactiveDomain.Policy.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Testing\ReactiveDomain.Testing.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/ReactiveDomain.Policy.nuspec
+++ b/src/ReactiveDomain.Policy.nuspec
@@ -1,76 +1,83 @@
 <?xml version="1.0"?>
 <package>
-  <metadata>
-    <id>ReactiveDomain.Policy</id>
-    <version>0.15.1.0</version>
-    <authors>Reactive Domain Group</authors>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">MIT</license>
-    <description>Package includes all ReactiveDomain Identity and Policy assemblies</description>
-    <copyright>Copyright © 2026 Reactive Domain Group</copyright>
-    <dependencies>
-      <group targetFramework="net8.0">
-        <dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
-        <dependency id="DynamicData" version="8.4.1" exclude="Build,Analyzers" />
-        <dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
-        <dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>
-        <dependency id="Microsoft.CSharp" version="4.7.0" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-        <dependency id="System.DirectoryServices" version="8.0.0" exclude="Build,Analyzers"/>
-        <dependency id="System.DirectoryServices.AccountManagement" version="8.0.0" exclude="Build,Analyzers" />
-      </group>
-	  <group targetFramework="net10.0">
-		<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
-		<dependency id="DynamicData" version="8.4.1" exclude="Build,Analyzers" />
-		<dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
-		<dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>
-		<dependency id="Microsoft.CSharp" version="4.7.0" exclude="Build,Analyzers" />
-		<dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-		<dependency id="System.DirectoryServices" version="10.0.0" exclude="Build,Analyzers"/>
-		<dependency id="System.DirectoryServices.AccountManagement" version="10.0.0" exclude="Build,Analyzers" />
-	  </group>
-    </dependencies>
-    <references>
-      <group targetFramework="net8.0">
-        <reference file="ReactiveDomain.Policy.dll" />
-        <reference file="ReactiveDomain.PolicyStorage.dll" />
-        <reference file="ReactiveDomain.IdentityStorage.dll" />
-      </group>
-	  <group targetFramework="net10.0">
-		<reference file="ReactiveDomain.Policy.dll" />
-		<reference file="ReactiveDomain.PolicyStorage.dll" />
-		<reference file="ReactiveDomain.IdentityStorage.dll" />
-	  </group>
-    </references>    
-  </metadata>
-  <files>
-    <file src="..\build\ReactiveDomain.Policy.props" target="build" />
-    <file src="ReactiveDomain.Policy.targets" target="build" />
-    <file src="..\bld\tools\ReactiveDomain.PolicyTool.exe" target="build\PolicyTool.exe" />
-    <file src="..\bld\tools\es_settings.json" target="build\es_settings.json" />
+	<metadata>
+		<id>ReactiveDomain.Policy</id>
+		<version>0.15.1.0</version>
+		<authors>Reactive Domain Group</authors>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<license type="expression">MIT</license>
+		<description>ReactiveDomain Identity and Policy assemblies.</description>
+		<copyright>Copyright © 2026 Reactive Domain Group</copyright>
+		<readme>docs\README.md</readme>
+		<tags>CQRS ES event-sourcing messaging identity policy</tags>
+		<repository type="git" url="https://github.com/ReactiveDomain/reactive-domain" branch="master" />
+		<dependencies>
+			<group targetFramework="net8.0">
+				<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
+				<dependency id="DynamicData" version="8.4.1" exclude="Build,Analyzers" />
+				<dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
+				<dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>
+				<dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
+				<dependency id="System.DirectoryServices" version="8.0.0" exclude="Build,Analyzers"/>
+				<dependency id="System.DirectoryServices.AccountManagement" version="8.0.0" exclude="Build,Analyzers" />
+			</group>
+			<group targetFramework="net10.0">
+				<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
+				<dependency id="DynamicData" version="8.4.1" exclude="Build,Analyzers" />
+				<dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
+				<dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>
+				<dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
+				<dependency id="System.DirectoryServices" version="10.0.0" exclude="Build,Analyzers"/>
+				<dependency id="System.DirectoryServices.AccountManagement" version="10.0.0" exclude="Build,Analyzers" />
+			</group>
+		</dependencies>
+		<references>
+			<group targetFramework="net8.0">
+				<reference file="ReactiveDomain.Policy.dll" />
+				<reference file="ReactiveDomain.PolicyStorage.dll" />
+				<reference file="ReactiveDomain.IdentityStorage.dll" />
+			</group>
+			<group targetFramework="net10.0">
+				<reference file="ReactiveDomain.Policy.dll" />
+				<reference file="ReactiveDomain.PolicyStorage.dll" />
+				<reference file="ReactiveDomain.IdentityStorage.dll" />
+			</group>
+		</references>
+	</metadata>
+	<files>
+		<file src="..\build\ReactiveDomain.Policy.props" target="build" />
+		<file src="ReactiveDomain.Policy.targets" target="build" />
+		
+		<file src="..\bld\tools\net8.0\ReactiveDomain.PolicyTool.exe" target="build\net8.0\PolicyTool.exe" />
+		<file src="..\bld\tools\net8.0\es_settings.json" target="build\net8.0\es_settings.json" />
+		
+		<file src="..\bld\tools\net10.0\ReactiveDomain.PolicyTool.exe" target="build\net10.0\PolicyTool.exe" />
+		<file src="..\bld\tools\net10.0\es_settings.json" target="build\net10.0\es_settings.json" />
 
-    <file src="..\bld\Release\net8.0\ReactiveDomain.Policy.pdb" target="lib\net8.0" />
-    <file src="..\bld\Release\net8.0\ReactiveDomain.Policy.dll" target="lib\net8.0" />
-    <file src="..\bld\Release\net8.0\ReactiveDomain.Policy.dll" target="ref\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Policy.pdb" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Policy.dll" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Policy.dll" target="ref\net8.0" />
 
-    <file src="..\bld\Release\net10.0\ReactiveDomain.Policy.pdb" target="lib\net10.0" />
-    <file src="..\bld\Release\net10.0\ReactiveDomain.Policy.dll" target="lib\net10.0" />
-    <file src="..\bld\Release\net10.0\ReactiveDomain.Policy.dll" target="ref\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Policy.pdb" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Policy.dll" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Policy.dll" target="ref\net10.0" />
 
-	<file src="..\bld\Release\net8.0\ReactiveDomain.PolicyStorage.pdb" target="lib\net8.0" />
-    <file src="..\bld\Release\net8.0\ReactiveDomain.PolicyStorage.dll" target="lib\net8.0" />
-    <file src="..\bld\Release\net8.0\ReactiveDomain.PolicyStorage.dll" target="ref\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.PolicyStorage.pdb" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.PolicyStorage.dll" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.PolicyStorage.dll" target="ref\net8.0" />
 
-    <file src="..\bld\Release\net10.0\ReactiveDomain.PolicyStorage.pdb" target="lib\net10.0" />
-    <file src="..\bld\Release\net10.0\ReactiveDomain.PolicyStorage.dll" target="lib\net10.0" />
-    <file src="..\bld\Release\net10.0\ReactiveDomain.PolicyStorage.dll" target="ref\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.PolicyStorage.pdb" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.PolicyStorage.dll" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.PolicyStorage.dll" target="ref\net10.0" />
 
-	<file src="..\bld\Release\net8.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net8.0" />
-    <file src="..\bld\Release\net8.0\ReactiveDomain.IdentityStorage.dll" target="lib\net8.0" />
-    <file src="..\bld\Release\net8.0\ReactiveDomain.IdentityStorage.dll" target="ref\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.IdentityStorage.dll" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.IdentityStorage.dll" target="ref\net8.0" />
 
-    <file src="..\bld\Release\net10.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net10.0" />
-    <file src="..\bld\Release\net10.0\ReactiveDomain.IdentityStorage.dll" target="lib\net10.0" />
-    <file src="..\bld\Release\net10.0\ReactiveDomain.IdentityStorage.dll" target="ref\net10.0" />
-  </files>
+		<file src="..\bld\Release\net10.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.IdentityStorage.dll" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.IdentityStorage.dll" target="ref\net10.0" />
+
+		<file src="..\README.md" target="docs\" />
+	</files>
 </package>

--- a/src/ReactiveDomain.Policy/ReactiveDomain.Policy.csproj
+++ b/src/ReactiveDomain.Policy/ReactiveDomain.Policy.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../ci.build.imports" />
-  <PropertyGroup>
-    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />
-    <ProjectReference Include="..\ReactiveDomain.IdentityStorage\ReactiveDomain.IdentityStorage.csproj" />
-    <ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
-  </ItemGroup></Project>
+	<Import Project="../ci.build.imports" />
+	<PropertyGroup>
+		<TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.IdentityStorage\ReactiveDomain.IdentityStorage.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/ReactiveDomain.PolicyStorage.Tests/ReactiveDomain.PolicyStorage.Tests.csproj
+++ b/src/ReactiveDomain.PolicyStorage.Tests/ReactiveDomain.PolicyStorage.Tests.csproj
@@ -1,39 +1,40 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="../ci.build.imports" />
-    <PropertyGroup>
-      <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
-      <IsTestProject>true</IsTestProject>
-      <RootNamespace>ReactiveDomain.Policy.Tests</RootNamespace>
-    </PropertyGroup>
-    <ItemGroup>
-      <Compile Remove="ApplicationAggregateTests.cs" />
-      <Compile Remove="ApplicationServiceTests.cs" />
-      <Compile Remove="ExternalProviderAggregateTests.cs" />
-      <Compile Remove="RoleAggregateTests.cs" />
-      <Compile Remove="RoleServiceTests.cs" />
-      <Compile Remove="UserEntitlementRMTests.cs" />
-    </ItemGroup>   
-    <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-      <PackageReference Include="xunit" Version="2.9.3" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-      <PackageReference Include="xunit.runner.console" Version="2.9.3">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    </ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\ReactiveDomain.PolicyStorage\ReactiveDomain.PolicyStorage.csproj" />
-      <ProjectReference Include="..\ReactiveDomain.Policy\ReactiveDomain.Policy.csproj" />
-      <ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />
-      <ProjectReference Include="..\ReactiveDomain.Core\ReactiveDomain.Core.csproj" />
-      <ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
-      <ProjectReference Include="..\ReactiveDomain.Persistence\ReactiveDomain.Persistence.csproj" />
-      <ProjectReference Include="..\ReactiveDomain.Testing\ReactiveDomain.Testing.csproj" />
-    </ItemGroup>   
-  </Project>
+	<Import Project="../ci.build.imports" />
+	<PropertyGroup>
+		<TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<RootNamespace>ReactiveDomain.Policy.Tests</RootNamespace>
+	</PropertyGroup>
+	<ItemGroup>
+		<Compile Remove="ApplicationAggregateTests.cs" />
+		<Compile Remove="ApplicationServiceTests.cs" />
+		<Compile Remove="ExternalProviderAggregateTests.cs" />
+		<Compile Remove="RoleAggregateTests.cs" />
+		<Compile Remove="RoleServiceTests.cs" />
+		<Compile Remove="UserEntitlementRMTests.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="xunit.runner.console" Version="2.9.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ReactiveDomain.PolicyStorage\ReactiveDomain.PolicyStorage.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Policy\ReactiveDomain.Policy.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Core\ReactiveDomain.Core.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Persistence\ReactiveDomain.Persistence.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Testing\ReactiveDomain.Testing.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/ReactiveDomain.PolicyStorage/ReactiveDomain.PolicyStorage.csproj
+++ b/src/ReactiveDomain.PolicyStorage/ReactiveDomain.PolicyStorage.csproj
@@ -1,23 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="../ci.build.imports" />
-  <PropertyGroup>
-    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
-    <IsPackable>true</IsPackable>
-    <RootNamespace>ReactiveDomain.Policy</RootNamespace>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="DynamicData" Version="9.4.33" />
-    <PackageReference Include="IdentityModel" Version="4.6.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.DirectoryServices" Version="10.0.9" />
-    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.9" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="10.0.9" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />
-    <ProjectReference Include="..\ReactiveDomain.Policy\ReactiveDomain.Policy.csproj" />
-    <ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
-    <ProjectReference Include="..\ReactiveDomain.Persistence\ReactiveDomain.Persistence.csproj" />
-  </ItemGroup>
+	<Import Project="../ci.build.imports" />
+	<PropertyGroup>
+		<TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+		<RootNamespace>ReactiveDomain.Policy</RootNamespace>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="DynamicData" Version="9.4.33" />
+		<PackageReference Include="IdentityModel" Version="4.6.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="System.DirectoryServices" Version="10.0.9" />
+		<PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.9" />
+		<PackageReference Include="System.Text.Encodings.Web" Version="10.0.9" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Policy\ReactiveDomain.Policy.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Persistence\ReactiveDomain.Persistence.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/ReactiveDomain.PolicyTool/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/src/ReactiveDomain.PolicyTool/Properties/PublishProfiles/FolderProfile.pubxml
@@ -3,16 +3,16 @@
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project>
-  <PropertyGroup>
-    <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
-    <PublishDir>..\..\bld\tools\</PublishDir>
-    <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net8.0</TargetFramework>
-    <SelfContained>true</SelfContained>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <PublishSingleFile>true</PublishSingleFile>
-    <PublishReadyToRun>true</PublishReadyToRun>
-    <PublishTrimmed>false</PublishTrimmed>
-  </PropertyGroup>
+	<PropertyGroup>
+		<Configuration>Release</Configuration>
+		<Platform>Any CPU</Platform>
+		<PublishDir>..\..\bld\tools\$(TargetFramework)</PublishDir>
+		<PublishProtocol>FileSystem</PublishProtocol>
+		<TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
+		<SelfContained>true</SelfContained>
+		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
+		<PublishSingleFile>true</PublishSingleFile>
+		<PublishReadyToRun>true</PublishReadyToRun>
+		<PublishTrimmed>false</PublishTrimmed>
+	</PropertyGroup>
 </Project>

--- a/src/ReactiveDomain.PolicyTool/ReactiveDomain.PolicyTool.csproj
+++ b/src/ReactiveDomain.PolicyTool/ReactiveDomain.PolicyTool.csproj
@@ -1,28 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../ci.build.imports" />
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-	<TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
-    <IsPackable>true</IsPackable>  
-    <StartupObject>PolicyTool.Program</StartupObject>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>    
-  </PropertyGroup>  
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageReference Include="EventStore.Client" Version="22.0.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.9" />
-  </ItemGroup>  
-  <ItemGroup>
-    <ProjectReference Include="..\ReactiveDomain.IdentityStorage\ReactiveDomain.IdentityStorage.csproj" />
-    <ProjectReference Include="..\ReactiveDomain.PolicyStorage\ReactiveDomain.PolicyStorage.csproj" />
-    <ProjectReference Include="..\ReactiveDomain.Policy\ReactiveDomain.Policy.csproj" />
- </ItemGroup>
-  
-  <ItemGroup>
-    <None Update="es_settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<Import Project="../ci.build.imports" />
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
+		<IsPackable>true</IsPackable>
+		<StartupObject>PolicyTool.Program</StartupObject>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+		<PackageReference Include="EventStore.Client" Version="22.0.0" />
+		<PackageReference Include="System.CommandLine" Version="2.0.9" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ReactiveDomain.IdentityStorage\ReactiveDomain.IdentityStorage.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.PolicyStorage\ReactiveDomain.PolicyStorage.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Policy\ReactiveDomain.Policy.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="es_settings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 </Project>

--- a/src/ReactiveDomain.Testing.Debug.nuspec
+++ b/src/ReactiveDomain.Testing.Debug.nuspec
@@ -1,44 +1,50 @@
 <?xml version="1.0"?>
 <package>
-  <metadata>
-    <id>ReactiveDomain.Testing</id>
-    <version>0.15.1.0</version>
-    <authors>Reactive Domain Group</authors>
-    <owners>Reactive Domain Group</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">MIT</license>
-    <description>Package includes ReactiveDomain assemblies needed for unit testing</description>
-    <copyright>Copyright © 2026 Reactive Domain Group</copyright>
-    <dependencies>
-      <group targetFramework="net8.0">
-        <dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.NET.Test.Sdk" version="17.10.0" exclude="Build,Analyzers" />
-        <dependency id="xunit" version="2.9.0" exclude="Build,Analyzers" />
-        <dependency id="xunit.runner.console" version="2.9.0" exclude="Build,Analyzers" />
-      </group>
-	  <group targetFramework="net10.0">
-		<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
-		<dependency id="Microsoft.NET.Test.Sdk" version="17.10.0" exclude="Build,Analyzers" />
-		<dependency id="xunit" version="2.9.0" exclude="Build,Analyzers" />
-		<dependency id="xunit.runner.console" version="2.9.0" exclude="Build,Analyzers" />
-	  </group>
-    </dependencies>
-    <references>
-      <group targetFramework="net8.0">
-        <reference file="ReactiveDomain.Testing.dll" />
-      </group>
-	  <group targetFramework="net10.0">
-		<reference file="ReactiveDomain.Testing.dll" />
-	  </group>
-    </references>
-  </metadata>
-  <files>
-    <file src="..\build\ReactiveDomain.Testing.props" target="build" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Testing.pdb" target="lib\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Testing.dll" target="lib\net8.0" />
-    <file src="..\bld\Debug\net8.0\ReactiveDomain.Testing.dll" target="ref\net8.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Testing.pdb" target="lib\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Testing.dll" target="lib\net10.0" />
-    <file src="..\bld\Debug\net10.0\ReactiveDomain.Testing.dll" target="ref\net10.0" />
-  </files>
+	<metadata>
+		<id>ReactiveDomain.Testing</id>
+		<version>0.15.1.0</version>
+		<authors>Reactive Domain Group</authors>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<license type="expression">MIT</license>
+		<description>Unit testing fixtures and extensions for use with ReactiveDomain.</description>
+		<copyright>Copyright © 2026 Reactive Domain Group</copyright>
+		<readme>docs\README.md</readme>
+		<tags>CQRS ES event-sourcing messaging unit-tests xunit</tags>
+		<repository type="git" url="https://github.com/ReactiveDomain/reactive-domain" branch="master" />
+		<dependencies>
+			<group targetFramework="net8.0">
+				<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
+				<dependency id="Microsoft.NET.Test.Sdk" version="17.10.0" exclude="Build,Analyzers" />
+				<dependency id="xunit" version="2.9.0" exclude="Build,Analyzers" />
+				<dependency id="xunit.runner.console" version="2.9.0" exclude="Build,Analyzers" />
+			</group>
+			<group targetFramework="net10.0">
+				<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
+				<dependency id="Microsoft.NET.Test.Sdk" version="17.10.0" exclude="Build,Analyzers" />
+				<dependency id="xunit" version="2.9.0" exclude="Build,Analyzers" />
+				<dependency id="xunit.runner.console" version="2.9.0" exclude="Build,Analyzers" />
+			</group>
+		</dependencies>
+		<references>
+			<group targetFramework="net8.0">
+				<reference file="ReactiveDomain.Testing.dll" />
+			</group>
+			<group targetFramework="net10.0">
+				<reference file="ReactiveDomain.Testing.dll" />
+			</group>
+		</references>
+	</metadata>
+	<files>
+		<file src="..\build\ReactiveDomain.Testing.props" target="build" />
+		
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Testing.pdb" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Testing.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Testing.dll" target="ref\net8.0" />
+		
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Testing.pdb" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Testing.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Testing.dll" target="ref\net10.0" />
+
+		<file src="..\README.md" target="docs\" />
+	</files>
 </package>

--- a/src/ReactiveDomain.Testing.Tests/ReactiveDomain.Testing.Tests.csproj
+++ b/src/ReactiveDomain.Testing.Tests/ReactiveDomain.Testing.Tests.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="../ci.build.imports" />
 	<PropertyGroup>
-	  <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
-    <IsPackable>false</IsPackable>
+		<TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
+		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-  </PropertyGroup>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />
-    <ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
-    <ProjectReference Include="..\ReactiveDomain.Testing\ReactiveDomain.Testing.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Testing\ReactiveDomain.Testing.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/ReactiveDomain.Testing.nuspec
+++ b/src/ReactiveDomain.Testing.nuspec
@@ -4,21 +4,23 @@
     <id>ReactiveDomain.Testing</id>
     <version>0.15.1.0</version>
     <authors>Reactive Domain Group</authors>
-    <owners>Reactive Domain Group</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
-    <description>Package includes ReactiveDomain assemblies needed for unit testing</description>
+    <description>Unit testing fixtures and extensions for use with ReactiveDomain.</description>
     <copyright>Copyright © 2026 Reactive Domain Group</copyright>
+    <readme>docs\README.md</readme>
+    <tags>CQRS ES event-sourcing messaging unit-tests xunit</tags>
+    <repository type="git" url="https://github.com/ReactiveDomain/reactive-domain" branch="master" />
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.NET.Test.Sdk" version="17.10.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.NET.Test.Sdk" version="18.7.0" exclude="Build,Analyzers" />
         <dependency id="xunit" version="2.9.0" exclude="Build,Analyzers" />
         <dependency id="xunit.runner.console" version="2.9.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net10.0">
         <dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.NET.Test.Sdk" version="17.10.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.NET.Test.Sdk" version="18.7.0" exclude="Build,Analyzers" />
         <dependency id="xunit" version="2.9.0" exclude="Build,Analyzers" />
         <dependency id="xunit.runner.console" version="2.9.0" exclude="Build,Analyzers" />
       </group>
@@ -27,7 +29,7 @@
       <group targetFramework="net8.0">
         <reference file="ReactiveDomain.Testing.dll" />
       </group>
-      <group targetFramework="net8.0">
+      <group targetFramework="net10.0">
         <reference file="ReactiveDomain.Testing.dll" />
       </group>
     </references>
@@ -40,5 +42,6 @@
     <file src="..\bld\Release\net10.0\ReactiveDomain.Testing.pdb" target="lib\net10.0" />
     <file src="..\bld\Release\net10.0\ReactiveDomain.Testing.dll" target="lib\net10.0" />
     <file src="..\bld\Release\net10.0\ReactiveDomain.Testing.dll" target="ref\net10.0" />
+    <file src="..\README.md" target="docs\" />
   </files>
 </package>

--- a/src/ReactiveDomain.Transport.Tests/ReactiveDomain.Transport.Tests.csproj
+++ b/src/ReactiveDomain.Transport.Tests/ReactiveDomain.Transport.Tests.csproj
@@ -1,25 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../ci.build.imports" />
-  <PropertyGroup>
-    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
-    <IsTestProject>true</IsTestProject>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
-    <ProjectReference Include="..\ReactiveDomain.Testing\ReactiveDomain.Testing.csproj" />
-    <ProjectReference Include="..\ReactiveDomain.Transport\ReactiveDomain.Transport.csproj" />
-  </ItemGroup>
+	<Import Project="../ci.build.imports" />
+	<PropertyGroup>
+		<TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="xunit.runner.console" Version="2.9.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Testing\ReactiveDomain.Testing.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Transport\ReactiveDomain.Transport.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/ReactiveDomain.Transport/ReactiveDomain.Transport.csproj
+++ b/src/ReactiveDomain.Transport/ReactiveDomain.Transport.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">  
-  <Import Project="../ci.build.imports" />
-  <PropertyGroup>
-    <TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\ReactiveDomain.Core\ReactiveDomain.Core.csproj" />
-    <ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
-  </ItemGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<Import Project="../ci.build.imports" />
+	<PropertyGroup>
+		<TargetFrameworks>$(LibTargetFrameworks)</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ReactiveDomain.Core\ReactiveDomain.Core.csproj" />
+		<ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/ReactiveDomain.nuspec
+++ b/src/ReactiveDomain.nuspec
@@ -6,25 +6,26 @@
     <authors>Reactive Domain Group</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
-    <description>Package includes all ReactiveDomain Core assemblies</description>
+    <description>A toolkit for implementing CQRS-ES in a reactive system. Package includes all ReactiveDomain Core assemblies.</description>
     <copyright>Copyright © 2026 Reactive Domain Group</copyright>
+    <readme>docs\README.md</readme>
+    <tags>CQRS ES event-sourcing messaging</tags>
+    <repository type="git" url="https://github.com/ReactiveDomain/reactive-domain" branch="master" />
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="EventStore.Client" version="22.0.0" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.CSharp" version="4.7.0" exclude="Build,Analyzers" />
-        <dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-        <dependency id="System.Reactive" version="6.0.1" exclude="Build,Analyzers" />
-        <dependency id="System.Configuration.ConfigurationManager" version="8.0.0" exclude="Build,Analyzers" />
-        <dependency id="System.Diagnostics.PerformanceCounter" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="13.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Reactive" version="6.1.0" exclude="Build,Analyzers" />
+        <dependency id="System.Configuration.ConfigurationManager" version="10.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Diagnostics.PerformanceCounter" version="10.0.0" exclude="Build,Analyzers" />
       </group>
-	  <group targetFramework="net10.0">
-		<dependency id="EventStore.Client" version="22.0.0" exclude="Build,Analyzers" />
-		<dependency id="Microsoft.CSharp" version="4.7.0" exclude="Build,Analyzers" />
-		<dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
-		<dependency id="System.Reactive" version="6.0.1" exclude="Build,Analyzers" />
-		<dependency id="System.Configuration.ConfigurationManager" version="10.0.0" exclude="Build,Analyzers" />
-		<dependency id="System.Diagnostics.PerformanceCounter" version="10.0.0" exclude="Build,Analyzers" />
-	  </group>
+      <group targetFramework="net10.0">
+        <dependency id="EventStore.Client" version="22.0.0" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="13.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Reactive" version="6.1.0" exclude="Build,Analyzers" />
+        <dependency id="System.Configuration.ConfigurationManager" version="10.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Diagnostics.PerformanceCounter" version="10.0.0" exclude="Build,Analyzers" />
+      </group>
     </dependencies>
     <references>
       <group targetFramework="net8.0">
@@ -34,39 +35,47 @@
         <reference file="ReactiveDomain.Persistence.dll" />
         <reference file="ReactiveDomain.Transport.dll" />
       </group>
-	  <group targetFramework="net10.0">
-		<reference file="ReactiveDomain.Core.dll" />
-		<reference file="ReactiveDomain.Foundation.dll" />
-		<reference file="ReactiveDomain.Messaging.dll" />
-		<reference file="ReactiveDomain.Persistence.dll" />
-		<reference file="ReactiveDomain.Transport.dll" />
-	  </group>
+      <group targetFramework="net10.0">
+        <reference file="ReactiveDomain.Core.dll" />
+        <reference file="ReactiveDomain.Foundation.dll" />
+        <reference file="ReactiveDomain.Messaging.dll" />
+        <reference file="ReactiveDomain.Persistence.dll" />
+        <reference file="ReactiveDomain.Transport.dll" />
+      </group>
     </references>
   </metadata>
   <files>
     <file src="..\build\ReactiveDomain.props" target="build" />
     <file src="..\bld\Release\net8.0\ReactiveDomain.Core.pdb" target="lib\net8.0" />
-    <file src="..\bld\Release\net8.0\ReactiveDomain.Foundation.pdb" target="lib\net8.0" />
-    <file src="..\bld\Release\net8.0\ReactiveDomain.Messaging.pdb" target="lib\net8.0" />
-    <file src="..\bld\Release\net8.0\ReactiveDomain.Persistence.pdb" target="lib\net8.0" />
-    <file src="..\bld\Release\net8.0\ReactiveDomain.Transport.pdb" target="lib\net8.0" />
-	  
-    <file src="..\bld\Release\net10.0\ReactiveDomain.Core.dll" target="lib\net10.0" />
-    <file src="..\bld\Release\net10.0\ReactiveDomain.Foundation.dll" target="lib\net10.0" />
-    <file src="..\bld\Release\net10.0\ReactiveDomain.Messaging.dll" target="lib\net10.0" />
-    <file src="..\bld\Release\net10.0\ReactiveDomain.Persistence.dll" target="lib\net10.0" />
-    <file src="..\bld\Release\net10.0\ReactiveDomain.Transport.dll" target="lib\net10.0" />
-	  
+    <file src="..\bld\Release\net8.0\ReactiveDomain.Core.dll" target="lib\net8.0" />
     <file src="..\bld\Release\net8.0\ReactiveDomain.Core.dll" target="ref\net8.0" />
-    <file src="..\bld\Release\net8.0\ReactiveDomain.Foundation.dll" target="ref\net8.0" />
-    <file src="..\bld\Release\net8.0\ReactiveDomain.Messaging.dll" target="ref\net8.0" />
-    <file src="..\bld\Release\net8.0\ReactiveDomain.Persistence.dll" target="ref\net8.0" />
-    <file src="..\bld\Release\net8.0\ReactiveDomain.Transport.dll" target="ref\net8.0" />
-
+    <file src="..\bld\Release\net10.0\ReactiveDomain.Core.pdb" target="lib\net10.0" />
+    <file src="..\bld\Release\net10.0\ReactiveDomain.Core.dll" target="lib\net10.0" />
     <file src="..\bld\Release\net10.0\ReactiveDomain.Core.dll" target="ref\net10.0" />
+    <file src="..\bld\Release\net8.0\ReactiveDomain.Foundation.pdb" target="lib\net8.0" />
+    <file src="..\bld\Release\net8.0\ReactiveDomain.Foundation.dll" target="lib\net8.0" />
+    <file src="..\bld\Release\net8.0\ReactiveDomain.Foundation.dll" target="ref\net8.0" />
+    <file src="..\bld\Release\net10.0\ReactiveDomain.Foundation.pdb" target="lib\net10.0" />
+    <file src="..\bld\Release\net10.0\ReactiveDomain.Foundation.dll" target="lib\net10.0" />
     <file src="..\bld\Release\net10.0\ReactiveDomain.Foundation.dll" target="ref\net10.0" />
+    <file src="..\bld\Release\net8.0\ReactiveDomain.Messaging.pdb" target="lib\net8.0" />
+    <file src="..\bld\Release\net8.0\ReactiveDomain.Messaging.dll" target="lib\net8.0" />
+    <file src="..\bld\Release\net8.0\ReactiveDomain.Messaging.dll" target="ref\net8.0" />
+    <file src="..\bld\Release\net10.0\ReactiveDomain.Messaging.pdb" target="lib\net10.0" />
+    <file src="..\bld\Release\net10.0\ReactiveDomain.Messaging.dll" target="lib\net10.0" />
     <file src="..\bld\Release\net10.0\ReactiveDomain.Messaging.dll" target="ref\net10.0" />
+    <file src="..\bld\Release\net8.0\ReactiveDomain.Persistence.pdb" target="lib\net8.0" />
+    <file src="..\bld\Release\net8.0\ReactiveDomain.Persistence.dll" target="lib\net8.0" />
+    <file src="..\bld\Release\net8.0\ReactiveDomain.Persistence.dll" target="ref\net8.0" />
+    <file src="..\bld\Release\net10.0\ReactiveDomain.Persistence.pdb" target="lib\net10.0" />
+    <file src="..\bld\Release\net10.0\ReactiveDomain.Persistence.dll" target="lib\net10.0" />
     <file src="..\bld\Release\net10.0\ReactiveDomain.Persistence.dll" target="ref\net10.0" />
+    <file src="..\bld\Release\net8.0\ReactiveDomain.Transport.pdb" target="lib\net8.0" />
+    <file src="..\bld\Release\net8.0\ReactiveDomain.Transport.dll" target="lib\net8.0" />
+    <file src="..\bld\Release\net8.0\ReactiveDomain.Transport.dll" target="ref\net8.0" />
+    <file src="..\bld\Release\net10.0\ReactiveDomain.Transport.pdb" target="lib\net10.0" />
+    <file src="..\bld\Release\net10.0\ReactiveDomain.Transport.dll" target="lib\net10.0" />
     <file src="..\bld\Release\net10.0\ReactiveDomain.Transport.dll" target="ref\net10.0" />
+    <file src="..\README.md" target="docs\" />
   </files>
 </package>

--- a/tools/CreateDebugNuget.ps1
+++ b/tools/CreateDebugNuget.ps1
@@ -35,12 +35,15 @@ $TempDir = Join-Path $env:temp $TempNum.ToString()
 $buildDir = Join-Path $ReactiveDomainRepo "bld"
 $propsDir = Join-Path $ReactiveDomainRepo "build"
 $sourceDir = Join-Path $ReactiveDomainRepo "src"
+$readme = Join-Path $ReactiveDomainRepo "README.md"
 $tempBuildDir = Join-Path $TempDir "bld"
 $tempPropsDir = Join-Path $TempDir "build"
 $tempSourceDir = Join-Path $TempDir "src"
+$tempReadme = Join-Path $TempDir "README.md"
 New-Item -ItemType "directory" -Path $tempSourceDir
 Copy-Item -Path $buildDir -Destination $tempBuildDir -Recurse
 Copy-Item -Path $propsDir -Destination $tempPropsDir -Recurse
+Copy-Item -Path $readme -Destination $tempReadme
 
 #source nuspec file paths
 $sourceRDNuspec = Join-Path $sourceDir "ReactiveDomain.Debug.nuspec"
@@ -112,7 +115,7 @@ class PackagRef
 #     Helper function to get a specific PackageRef from a .csproj file
 #     Parses and returns a PackagRef object (defined above) that contains:
 #         Version - (version of the package)
-#         ConditionOperator - (the equality operator for a framework, == or !=)
+#         $ComparisonOperator - (the equality operator for a framework, == or !=)
 #         Framework - The framework this Packageref applies to: (net8.0, net10.0)
 #
 function GetPackageRefFromProject([string]$Id, [string]$CsProj, [string]$Framework)
@@ -127,9 +130,8 @@ function GetPackageRefFromProject([string]$Id, [string]$CsProj, [string]$Framewo
     $currentVersion = ""
 
     # There may be duplicates of the same package when there are different versions
-    # for different frameworks (i.e. ReactiveUI). Therefore if our search
-    # returns more than one node, then we take the one that matches 
-    # the Framework in its Condition
+    # for different frameworks. Therefore if our search returns more than one node,
+    # then we take the one that matches the Framework in its Condition
 
     if ($targetPackage.Node.Count -gt 1)
     {

--- a/tools/CreateNuget.ps1
+++ b/tools/CreateNuget.ps1
@@ -80,7 +80,7 @@ class PackagRef
 #     Helper function to get a specific PackageRef from a .csproj file
 #     Parses and returns a PackagRef object (defined above) that contains:
 #         Version - (version of the package)
-#         ConditionOperator - (the equality operator for a framework, == or !=)
+#         $ComparisonOperator - (the equality operator for a framework, == or !=)
 #         Framework - The framework this Packageref applies to: (net8.0, net10.0)
 #
 function GetPackageRefFromProject([string]$Id, [string]$CsProj, [string]$Framework)
@@ -95,9 +95,8 @@ function GetPackageRefFromProject([string]$Id, [string]$CsProj, [string]$Framewo
     $currentVersion = ""
 
     # There may be duplicates of the same package when there are different versions
-    # for different frameworks (i.e. ReactiveUI). Therefore if our search
-    # returns more than one node, then we take the one that matches 
-    # the Framework in its Condition
+    # for different frameworks. Therefore if our search returns more than one node,
+    # then we take the one that matches the Framework in its Condition
 
     if ($targetPackage.Node.Count -gt 1)
     {
@@ -176,8 +175,8 @@ function UpdateDependencyVersions([string]$Nuspec, [string]$CsProj)
             ($pRef.version -ne ""))
         {
             $refnode.version = $pRef.Version
-        }      
-    }
+        }
+    }      
 	
 	$net10 = $xml | Select-XML -XPath "//package/metadata/dependencies/group[@targetFramework='net10.0']"
     $net10Nodes = $net10.Node.ChildNodes


### PR DESCRIPTION
- Adds explicit `IsPackable` tag to all csproj files.
- Adds `PrivateAssets` attribute to appropriate `PackageReference` tags.
- Adds the repo README to all nuspec files.
- Adds tags and repository info to all nuspec files.
- Refines the descriptions in nuspec files
- Removes unnecessary references from nuspec files
- Builds PolicyTool against both .NET 8 & 10, and includes both in the package.