### PR TITLE
Add CI-aware TestTimeouts and 2-core CI guidance

### DIFF
--- a/Docs/ci-test-guidance.md
+++ b/Docs/ci-test-guidance.md
@@ -1,0 +1,57 @@
+# CI Test Guidance
+
+CI runners (GitHub Actions: 2 cores) starve the scheduler in ways local machines don't.
+Timing-sensitive tests that pass locally fail on CI with spurious timeouts, and the failures
+don't reproduce on a developer box at default settings. Three practices keep the suite honest.
+
+## 1. Use `TestTimeouts`, not literal timeouts
+
+`ReactiveDomain.Testing.TestTimeouts` is the single timeout source, keyed on the
+`GITHUB_ACTIONS` environment variable:
+
+| Purpose | Property | Local | CI |
+|---|---|---|---|
+| TestQueue / RepositoryEvents waits | `WaitFor` | 500 ms | 5 s |
+| Command Send response waits | `CommandTimeout` | 500 ms | 10 s |
+| Real-time Rx operators (Throttle, Buffer, Sample) | `ThrottleWaitFor` | 2 s | 10 s |
+
+Don't copy timeout constants into test projects; reference these. A wait that needs more than
+the CI value is a design problem (an unbounded dependency or a heuristic wait), not a reason
+for a bigger number.
+
+## 2. Run test assemblies sequentially (`MaxCpuCount=1`)
+
+Concurrent test assemblies each hosting an in-process store starve the thread pool on small
+runners. Force sequential assembly execution:
+
+```xml
+<!-- ci.runsettings -->
+<RunSettings>
+  <RunConfiguration>
+    <MaxCpuCount>1</MaxCpuCount>
+  </RunConfiguration>
+</RunSettings>
+```
+
+```
+dotnet test --settings ci.runsettings
+```
+
+Test parallelism *within* an assembly is governed separately (xUnit
+`ParallelizeTestCollections`; this repo's CI passes `-p:ParallelizeTestCollections=false`).
+
+## 3. Reproduce 2-core CI flakes locally
+
+Restrict the runner to two cores and set the CI flag — most "CI-only" failures reproduce in
+seconds:
+
+```cmd
+set GITHUB_ACTIONS=true
+start /affinity 3 dotnet test src/SomeProject.Tests
+```
+
+(`/affinity 3` = cores 0–1. PowerShell: start the process, then
+`(Get-Process -Id $pid).ProcessorAffinity = 3`.)
+
+Setting `GITHUB_ACTIONS=true` also switches `TestTimeouts` to CI values, so the repro
+exercises the same waits CI does.

--- a/Docs/storage-update/test-infrastructure-plan.md
+++ b/Docs/storage-update/test-infrastructure-plan.md
@@ -28,6 +28,44 @@ real store.
 #232 (residual test migration), #233 (remove MockStreamStoreConnection), #234 (IsLive
 alignment), #235 (Testing.Host packaging — see storage-port doc).
 
+### Implementation checklist — 0.15.2
+
+Sequential, one PR per issue against `master`, in this order (fence depends on the TestQueue
+change and the timeout source). Each PR ticks its box here, adds targeted tests in the
+matching test project, and closes its issue (`Closes #NNN`); CI is the full gate. No version
+bump, no publishing.
+
+- [ ] **#223 TestQueue** — signal `_idWatchList` waiters before the type filter, **and**
+  record ids that arrive with no watcher registered (insert an already-set wait handle) —
+  without this the fence deterministically times out on the synchronous mock (see § 0.15.2/1).
+  Same pass: `WaitForMultiple<T>` full-queue re-snapshot per iteration, `is T` (wait) vs
+  `IsAssignableFrom` (ingest), unsynchronized `_handledTypes`.
+- [ ] **#227 TestTimeouts** — static source keyed on `GITHUB_ACTIONS` (WaitFor 500 ms/5 s,
+  CommandTimeout 500 ms/10 s, ThrottleWaitFor 2 s/10 s) plus `MaxCpuCount=1` runsettings and
+  `start /affinity` + `GITHUB_ACTIONS=true` repro guidance. Before #224 — the fence uses
+  `TestTimeouts.WaitFor`.
+- [ ] **#224 AwaitEventDelivery fence** — `SetupStartMarker`/`DeliveryFence` derive from
+  `Message` (a record), not `Event`; stream `setupMarkers`; ctor writes the first
+  `SetupStartMarker`; `ClearQueues()` = fence → clear → base → new `SetupStartMarker`;
+  markers never visible to `RepositoryEvents` assertions.
+- [ ] **#225 CatchUpConnection** (Foundation) — `GetQueuedListener` untracked by design
+  (XML-doc why); `lastDelivered` set *after* `base.GotEvent`; bounded `IsLive` wait first;
+  re-read stream ends via `ReadStreamBackward` every pass; timeout names laggards and busy
+  queues.
+- [ ] **#226 FaultInjectingConfiguredConnection** + `InjectedSaveException` — only repository
+  `Save` faults; `GetCorrelatedRepository` composes over the faulting repo; reads, readers,
+  listeners pass through.
+- [ ] **#228 ProjectedEvent tagging** — `SubscribeToAll`/`SubscribeToAllFrom` only:
+  `ProjectedStream = Link.EventStreamId`, `OriginalEventNumber = Event.EventNumber`,
+  `EventNumber = Link.EventNumber`; stream subscriptions and batch reads unchanged; keep the
+  `evt.Event != null` null-linkto guard; verify via mapping-parity test against the mock (no
+  live-ESDB test project exists). **Release-notes callout.**
+- [ ] **#229 IsLive XML docs** — document the contract as amended in § 0.15.2/7 (Task
+  completes at listener *start*, not live; a "live" model can be empty/stale; point to
+  `WaitForCatchUp`); `IsLiveObservable` is consumer-side, not an RD member — reconcile the
+  issue wording, don't invent the member.
+- [ ] **Milestone** — create the 0.15.2 milestone and assign #223–#229.
+
 ## Why async delivery forces harness changes
 
 The mock delivers synchronously through its internal `SingleThreadedBus`: when `Save`
@@ -48,6 +86,13 @@ Today `TestQueue.Handle` applies the constructor's `MessageTypeFilter` before en
 **and** before signaling `_idWatchList` waiters, so a message outside the filter can never
 complete a `WaitForMsgId` wait. Change the ordering: signal id-watchers first, then apply the
 filter for enqueue.
+
+Signal order alone is not enough: `Handle` must also record ids that arrive with **no watcher
+registered** — insert an already-set wait handle into `_idWatchList` so a `WaitForMsgId` that
+starts after delivery completes immediately (`WaitForMsgId` already short-circuits on a set
+handle). On the synchronous mock this is the *only* working path: delivery completes inside
+the marker append, before the fence's wait registers, and the filtered marker never enters
+the queue for the late-arrival scan. Growth is bounded by `Clear()`, same as the queue.
 
 This enables an **invisible fence** — a fence message completes a `WaitForMsgId` wait without
 ever entering the queue, so it can't break a subsequent `AssertEmpty`. The only observable
@@ -182,10 +227,12 @@ already-published contract. Deserves the release-notes callout.
 
 ### 7. IsLive: document the contract
 
-The `IsLive` **Task** completes when the subscription goes live — before any downstream
-batching cache flushes — while `IsLiveObservable` fires after. Consumers waiting on the Task
-can observe empty read models that are "live." Document this in 0.15.2; behavioral alignment
-(if any) changes consumer-visible timing and belongs in 0.16.0.
+The `IsLive` **Task** completes when each `StartAsync` read task has read history and merely
+*started* its listener (`blockUntilLive: false`) — before catch-up completes, and before any
+downstream batching cache flushes (see 0.16.0 § 5). Consumers waiting on the Task can observe
+read models that are "live" but empty or stale. (`IsLiveObservable` is a consumer-side
+construct, not an RD member; post-flush signals fire after the Task.) Document this in
+0.15.2; behavioral alignment changes consumer-visible timing and belongs in 0.16.0 (#234).
 
 ### Consumer guidance for the 0.15.2 window
 

--- a/src/ReactiveDomain.Testing.Tests/ReactiveDomain.Testing.Tests.csproj
+++ b/src/ReactiveDomain.Testing.Tests/ReactiveDomain.Testing.Tests.csproj
@@ -9,6 +9,10 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ReactiveDomain.Testing.Tests/Specifications/TestQueueTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/Specifications/TestQueueTests.cs
@@ -197,6 +197,36 @@ public sealed class TestQueueTests :
 	}
 
 	[Fact]
+	public void can_wait_by_id_for_a_message_excluded_by_the_type_filter() {
+		using var tq = new TestQueue(_dispatcher, [typeof(Command)]);
+		var evt = new TestEvent();
+		//arrival before the wait starts (the synchronous-delivery fence case)
+		_dispatcher.Publish(evt);
+		tq.WaitForMsgId(evt.MsgId, TimeSpan.FromMilliseconds(200));
+
+		//arrival after the wait starts
+		var evt2 = new TestEvent();
+		var t = Task.Run(() => tq.WaitForMsgId(evt2.MsgId, TimeSpan.FromMilliseconds(1000)));
+		AssertEx.EnsureRunning(t);
+		_dispatcher.Publish(evt2);
+		AssertEx.EnsureComplete(t);
+
+		//neither filtered message entered the queue
+		tq.AssertEmpty();
+	}
+
+	[Fact]
+	public void clear_forgets_previously_seen_ids() {
+		using var tq = new TestQueue(_dispatcher);
+		var evt = new TestEvent();
+		_dispatcher.Publish(evt);
+		tq.WaitForMsgId(evt.MsgId, TimeSpan.FromMilliseconds(200));
+		tq.Clear();
+		Assert.Throws<TimeoutException>(() => tq.WaitForMsgId(evt.MsgId, TimeSpan.FromMilliseconds(50)));
+		tq.AssertEmpty();
+	}
+
+	[Fact]
 	public void can_wait_for_multiple_messages_of_a_type() {
 		using var tq = new TestQueue(_dispatcher);
 		var evt = new TestEvent();

--- a/src/ReactiveDomain.Testing.Tests/TestTimeoutsTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/TestTimeoutsTests.cs
@@ -1,0 +1,22 @@
+using Xunit;
+
+namespace ReactiveDomain.Testing.Tests;
+
+public sealed class TestTimeoutsTests {
+	[Fact]
+	public void values_match_the_environment() {
+		var isCi = string.Equals(
+			Environment.GetEnvironmentVariable("GITHUB_ACTIONS"), "true", StringComparison.OrdinalIgnoreCase);
+
+		Assert.Equal(isCi, TestTimeouts.IsCi);
+		if (isCi) {
+			Assert.Equal(TimeSpan.FromSeconds(5), TestTimeouts.WaitFor);
+			Assert.Equal(TimeSpan.FromSeconds(10), TestTimeouts.CommandTimeout);
+			Assert.Equal(TimeSpan.FromSeconds(10), TestTimeouts.ThrottleWaitFor);
+		} else {
+			Assert.Equal(TimeSpan.FromMilliseconds(500), TestTimeouts.WaitFor);
+			Assert.Equal(TimeSpan.FromMilliseconds(500), TestTimeouts.CommandTimeout);
+			Assert.Equal(TimeSpan.FromSeconds(2), TestTimeouts.ThrottleWaitFor);
+		}
+	}
+}

--- a/src/ReactiveDomain.Testing/Specifications/TestQueue.cs
+++ b/src/ReactiveDomain.Testing/Specifications/TestQueue.cs
@@ -10,14 +10,21 @@ public sealed class TestQueue : IHandle<IMessage>, IDisposable {
 	/// <summary>
 	/// The types of messages to subscribe to. Child types are included.
 	/// </summary>
-	public Type[] MessageTypeFilter => (Type[])field.Clone();
+	public Type[] MessageTypeFilter => (Type[])_messageTypeFilter.Clone();
+	private readonly Type[] _messageTypeFilter;
 
 	private readonly bool _isFiltered;
 	/// <summary>
 	/// Contains the list of the Types of messages processed since last time TestQueue was cleared.
 	/// If Type tracking is disabled, returns an empty list.
 	/// </summary>
-	public Type[] HandledTypes => _handledTypes.ToArray();
+	public Type[] HandledTypes {
+		get {
+			lock (_handledTypes) {
+				return _handledTypes.ToArray();
+			}
+		}
+	}
 	private readonly HashSet<Type> _handledTypes = [];
 	private readonly bool _trackTypes;
 	private readonly Dictionary<Guid, ManualResetEventSlim> _idWatchList = new();
@@ -41,7 +48,7 @@ public sealed class TestQueue : IHandle<IMessage>, IDisposable {
 		Type[]? messageTypeFilter = null,
 		bool trackTypes = true) {
 		_isFiltered = messageTypeFilter != null;
-		MessageTypeFilter = messageTypeFilter ?? [];
+		_messageTypeFilter = messageTypeFilter ?? [];
 
 		_trackTypes = trackTypes;
 
@@ -68,15 +75,25 @@ public sealed class TestQueue : IHandle<IMessage>, IDisposable {
 	public void Handle(IMessage message) {
 		EnsureReady();
 		var msgType = message.GetType();
-		if (_isFiltered && !MessageTypeFilter.Any(t => t.IsAssignableFrom(msgType))) { return; }
 
-		Messages.Enqueue(message);
-
-		if (_trackTypes) { _handledTypes.Add(msgType); }
+		// Record the id before the type filter so WaitForMsgId completes even for messages the
+		// filter excludes (e.g. delivery-fence markers that must stay invisible to queue
+		// assertions). Unwatched ids get a pre-set handle so a wait that starts after delivery
+		// completes immediately; Clear() bounds the growth.
 		lock (_idWatchList) {
 			if (_idWatchList.TryGetValue(message.MsgId, out var resetEvent)) {
 				resetEvent.Set();
+			} else {
+				_idWatchList.Add(message.MsgId, new ManualResetEventSlim(true));
 			}
+		}
+
+		if (_isFiltered && !_messageTypeFilter.Any(t => t.IsAssignableFrom(msgType))) { return; }
+
+		Messages.Enqueue(message);
+
+		if (_trackTypes) {
+			lock (_handledTypes) { _handledTypes.Add(msgType); }
 		}
 	}
 
@@ -89,7 +106,9 @@ public sealed class TestQueue : IHandle<IMessage>, IDisposable {
 			Interlocked.Exchange(ref _cleaning, 1); //It's ok to clean an extra message on the race condition
 			while (!Messages.IsEmpty)
 				Messages.TryDequeue(out _);
-			_handledTypes.Clear();
+			lock (_handledTypes) {
+				_handledTypes.Clear();
+			}
 			lock (_idWatchList) {
 				_idWatchList.Clear();
 			}
@@ -122,10 +141,9 @@ public sealed class TestQueue : IHandle<IMessage>, IDisposable {
 		var endTime = startTime + (int)timeout.TotalMilliseconds;
 
 		var delay = 1;
-		//Evaluating the entire queue is a bit heavy, but is required to support waiting on base types, interfaces, etc. 
-		//calling ToList allows the concurrent queue to handle grabbing a snapshot of the collection
-		// ReSharper disable once RemoveToList.2
-		while (Messages.ToList().Count(x => x is T) < num) {
+		//Evaluating the entire queue is required to support waiting on base types, interfaces, etc.
+		//ConcurrentQueue enumeration is a moment-in-time snapshot, so no materialization is needed.
+		while (Messages.Count(x => x is T) < num) {
 			ObjectDisposedException.ThrowIf(_disposed, this);
 			if (Interlocked.Read(ref _queueVersion) != version) { throw new InvalidOperationException("Test queue Cleared!"); }
 			var now = Environment.TickCount;
@@ -146,23 +164,16 @@ public sealed class TestQueue : IHandle<IMessage>, IDisposable {
 		var version = Interlocked.Read(ref _queueVersion);
 		var deadline = DateTime.Now + timeout;
 
-		//set up a watch
+		//set up a watch; Handle records every id it has seen since the last Clear, so an
+		//already-handled message (queued or filtered out) is an already-set handle here
 		ManualResetEventSlim? waitHandle;
 		lock (_idWatchList) {
-			if (_idWatchList.TryGetValue(id, out waitHandle)) {
-				if (waitHandle.IsSet) { return; }
-			} else {
+			if (!_idWatchList.TryGetValue(id, out waitHandle)) {
 				waitHandle = new ManualResetEventSlim(false);
 				_idWatchList.Add(id, waitHandle);
 			}
 		}
-		//check to see if the message was handled before we got the watch setup
-		if (Messages.ToArray().Any(m => m.MsgId == id)) {
-			lock (_idWatchList) {
-				_idWatchList[id].Set();
-			}
-			return;
-		}
+		if (waitHandle.IsSet) { return; }
 		//wait here to see if the message handler triggers the wait handle we added
 		while (!waitHandle.Wait(10)) {
 			if (DateTime.Now > deadline) { throw new TimeoutException($"Msg with ID {id} failed to arrive within {timeout}."); }

--- a/src/ReactiveDomain.Testing/TestTimeouts.cs
+++ b/src/ReactiveDomain.Testing/TestTimeouts.cs
@@ -1,0 +1,42 @@
+namespace ReactiveDomain.Testing;
+
+/// <summary>
+/// CI-aware timeout source for test waits, keyed on the <c>GITHUB_ACTIONS</c> environment
+/// variable. CI runners (typically 2 cores) suffer scheduler starvation that surfaces as
+/// spurious timeouts when tests use locally-tuned values, so waits get generous CI values
+/// while staying fast for the local edit-test loop.
+/// </summary>
+/// <remarks>
+/// To reproduce CI-only timing failures locally, launch the test runner restricted to two
+/// cores with the CI flag set, e.g. from cmd:
+/// <c>set GITHUB_ACTIONS=true &amp;&amp; start /affinity 3 dotnet test ...</c>.
+/// Run test assemblies sequentially (<c>MaxCpuCount=1</c> in a .runsettings file or
+/// <c>-maxcpucount:1</c>) — concurrent in-process stores starve the thread pool.
+/// See Docs/ci-test-guidance.md.
+/// </remarks>
+public static class TestTimeouts {
+	/// <summary>
+	/// True when running under GitHub Actions (<c>GITHUB_ACTIONS</c> = "true"), or under the
+	/// local repro recipe that sets the same variable.
+	/// </summary>
+	public static bool IsCi { get; } =
+		string.Equals(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"), "true", StringComparison.OrdinalIgnoreCase);
+
+	/// <summary>
+	/// Timeout for message-arrival waits: <see cref="TestQueue.WaitFor{T}"/>,
+	/// <see cref="TestQueue.WaitForMsgId"/>, and RepositoryEvents waits.
+	/// 500 ms locally, 5 s on CI.
+	/// </summary>
+	public static TimeSpan WaitFor { get; } = IsCi ? TimeSpan.FromSeconds(5) : TimeSpan.FromMilliseconds(500);
+
+	/// <summary>
+	/// Timeout for command-response waits (dispatcher Send). 500 ms locally, 10 s on CI.
+	/// </summary>
+	public static TimeSpan CommandTimeout { get; } = IsCi ? TimeSpan.FromSeconds(10) : TimeSpan.FromMilliseconds(500);
+
+	/// <summary>
+	/// Timeout for waits on real-time Rx operators (Throttle, Buffer, Sample) whose timers
+	/// run on wall-clock schedulers. 2 s locally, 10 s on CI.
+	/// </summary>
+	public static TimeSpan ThrottleWaitFor { get; } = IsCi ? TimeSpan.FromSeconds(10) : TimeSpan.FromSeconds(2);
+}


### PR DESCRIPTION
## Summary

Adds `TestTimeouts` to `ReactiveDomain.Testing` — the single timeout source for test waits, keyed on `GITHUB_ACTIONS`:

| Purpose | Local | CI |
|---|---|---|
| `WaitFor` (TestQueue / RepositoryEvents waits) | 500 ms | 5 s |
| `CommandTimeout` (Send response waits) | 500 ms | 10 s |
| `ThrottleWaitFor` (real-time Rx operators) | 2 s | 10 s |

Consolidates the timeout constants consumers currently copy-paste, and gives CI runners generous values so 2-core scheduler starvation does not surface as flakes.

`Docs/ci-test-guidance.md` documents the `MaxCpuCount=1` runsettings guidance (concurrent in-process stores starve the thread pool) and the local repro recipe for CI-only timing failures: `start /affinity` (2 cores) + `GITHUB_ACTIONS=true`, which also flips `TestTimeouts` to CI values so the repro exercises the same waits CI does.

Stacked on #238 (base: `fix/223-testqueue-signal-before-filter`); the fence PR for #224 builds on both.

## Tests

`TestTimeoutsTests.values_match_the_environment` verifies the local/CI value split against the actual environment — it exercises the CI branch on GitHub Actions and the local branch on dev machines.

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)