### PR TITLE
Add AwaitEventDelivery delivery fence to MockRepositorySpecification

### DIFF
--- a/src/ReactiveDomain.Testing.Tests/Specifications/MockRepositoryTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/Specifications/MockRepositoryTests.cs
@@ -64,6 +64,38 @@ public sealed class MockRepositoryTests : IDisposable,
 	}
 
 	[Fact]
+	public void await_event_delivery_is_invisible_to_assertions() {
+		//the ctor marker and a bare fence never show up
+		_fixture.AwaitEventDelivery();
+		_fixture.RepositoryEvents.AssertEmpty();
+
+		//fence-then-assert round trip
+		var id = Guid.NewGuid();
+		_fixture.Repository.Save(new TestAggregate(id));
+		_fixture.AwaitEventDelivery();
+		_fixture
+			.RepositoryEvents
+			.AssertNext<TestAggregateMessages.NewAggregate>(e => e.AggregateId == id, "Aggregate Id Mismatch")
+			.AssertEmpty();
+	}
+
+	[Fact]
+	public void fenced_clear_queues_reopens_an_arrange_region() {
+		_fixture.Repository.Save(new TestAggregate(Guid.NewGuid()));
+		_fixture.ClearQueues();
+		_fixture.RepositoryEvents.AssertEmpty();
+
+		//the re-opened arrange region still fences and asserts cleanly
+		var id = Guid.NewGuid();
+		_fixture.Repository.Save(new TestAggregate(id));
+		_fixture.AwaitEventDelivery();
+		_fixture
+			.RepositoryEvents
+			.AssertNext<TestAggregateMessages.NewAggregate>(e => e.AggregateId == id, "Aggregate Id Mismatch")
+			.AssertEmpty();
+	}
+
+	[Fact]
 	public void create_mock_repository_without_a_prefix() {
 		var id = Guid.NewGuid();
 		var expectedStreamName = $"testAggregate-{id:n}";

--- a/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
+++ b/src/ReactiveDomain.Testing/Specifications/MockRepositorySpecification.cs
@@ -5,6 +5,20 @@ using ReactiveDomain.Testing.EventStore;
 
 namespace ReactiveDomain.Testing;
 
+/// <summary>
+/// Opens an arrange region in $all: written to the marker stream on construction and after every
+/// <see cref="MockRepositorySpecification.ClearQueues"/>. A plain <see cref="Message"/>, not an
+/// <see cref="Event"/>, so RepositoryEvents never captures it.
+/// </summary>
+public sealed record SetupStartMarker : Message;
+
+/// <summary>
+/// Delivery fence marker appended by <see cref="MockRepositorySpecification.AwaitEventDelivery"/>.
+/// A plain <see cref="Message"/>, not an <see cref="Event"/>, so RepositoryEvents never captures
+/// it — but its arrival still completes a WaitForMsgId wait.
+/// </summary>
+public sealed record DeliveryFence : Message;
+
 public class MockRepositorySpecification : DispatcherSpecification {
 	protected readonly IRepository MockRepository;
 	public IRepository Repository => MockRepository;
@@ -39,7 +53,35 @@ public class MockRepositorySpecification : DispatcherSpecification {
 				connectorBus.Publish(msg);
 		});
 		RepositoryEvents = new TestQueue(connectorBus, [typeof(Event)]);
+		WriteMarker(new SetupStartMarker()); // bracket the first arrange region
 	}
+
+	// A '$'-free, '-'-free stream: no $ce category link is emitted for markers, and the $et link
+	// that is emitted resolves to a ProjectedEvent the connector drops.
+	private const string MarkerStream = "setupMarkers";
+
+	/// <summary>
+	/// Delivery fence: blocks until every event committed before this call has been delivered to
+	/// <see cref="RepositoryEvents"/>. Appends a <see cref="DeliveryFence"/> marker and waits for
+	/// its id; because $all delivers in order, the fence's arrival proves every earlier commit is
+	/// already queued. The marker never appears in <see cref="RepositoryEvents"/>, so it cannot
+	/// break a later AssertEmpty. Covers events committed before the call (synchronous handler
+	/// saves), not async cascades — those need a read-model catch-up barrier.
+	/// </summary>
+	/// <remarks>
+	/// Against the synchronous mock this is a near-no-op: delivery has already happened when the
+	/// fence is called. Adopt fence-then-assert now; the calls become load-bearing when the
+	/// backing store delivers asynchronously.
+	/// </remarks>
+	public void AwaitEventDelivery() {
+		var fence = new DeliveryFence();
+		WriteMarker(fence);
+		RepositoryEvents.WaitForMsgId(fence.MsgId, TestTimeouts.WaitFor);
+	}
+
+	private void WriteMarker(Message marker) =>
+		StreamStoreConnection.AppendToStream(
+			MarkerStream, ExpectedVersion.Any, credentials: null, EventSerializer.Serialize(marker));
 
 	/// <summary>
 	/// Creates a mock repository with a prefix.
@@ -54,8 +96,10 @@ public class MockRepositorySpecification : DispatcherSpecification {
 	public MockRepositorySpecification(IStreamStoreConnection dataStore) : this(dataStore.ConnectionName, dataStore) { }
 
 	public override void ClearQueues() {
+		AwaitEventDelivery(); // fence async $all delivery so no in-flight event lands post-clear
 		RepositoryEvents.Clear();
 		base.ClearQueues();
+		WriteMarker(new SetupStartMarker()); // open the next arrange region
 	}
 
 	public IListener GetListener(string name) =>


### PR DESCRIPTION
## Summary

`AwaitEventDelivery()` appends a `DeliveryFence` marker to an isolated marker stream and blocks on `RepositoryEvents.WaitForMsgId(...)`. Because `$all` delivers in order, the fence's arrival proves every event committed before it is already queued.

Invisibility mechanics:
- Markers are plain `Message`s, not `Event`s, so the `RepositoryEvents` type filter (`typeof(Event)`) never enqueues them — but the seen-id registry from #223 still completes the wait.
- The marker stream (`setupMarkers`) is `$`-free and `-`-free: no `$ce` category link is emitted, and the `$et` link resolves to a `ProjectedEvent` the connector drops.
- `ClearQueues()` fences before clearing (no in-flight event lands post-clear) and writes a `SetupStartMarker` after, re-opening the arrange region; the constructor brackets the first region the same way.

On the synchronous mock the fence is a **near-no-op by design** — consumers adopt fence-then-assert against 0.15.2 at their own pace, and the calls become load-bearing when 0.16.0 flips the backend to the real store.

Stacked on #239 (uses `TestTimeouts.WaitFor`), which stacks on #238 (needs the seen-id registry — without it the fence deterministically times out on the sync mock, since delivery completes inside the marker append before the wait registers).

## Tests

- `await_event_delivery_is_invisible_to_assertions` — bare fence leaves `RepositoryEvents` empty; fence-then-assert round trip works.
- `fenced_clear_queues_reopens_an_arrange_region` — post-clear `AssertEmpty` passes and the next arrange region fences cleanly.
- Downstream suites against the changed spec base: Testing.Tests 90/90, Foundation.Tests 151/151, Policy.Tests, PolicyStorage.Tests — all green on net8.0 + net10.0.

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)