### PR TITLE
Add CatchUpConnection read-model catch-up barrier

### DIFF
--- a/src/ReactiveDomain.Foundation.Tests/when_using_catch_up_connection.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_catch_up_connection.cs
@@ -8,9 +8,9 @@ namespace ReactiveDomain.Foundation.Tests;
 
 // ReSharper disable once InconsistentNaming
 public sealed class when_using_catch_up_connection : IDisposable {
-	private static readonly IEventSerializer Serializer = new JsonMessageSerializer();
-	private static readonly IStreamNameBuilder Namer =
-		new PrefixedCamelCaseStreamNameBuilder(nameof(when_using_catch_up_connection));
+	private static readonly JsonMessageSerializer Serializer = new();
+	private static readonly PrefixedCamelCaseStreamNameBuilder Namer =
+		new(nameof(when_using_catch_up_connection));
 
 	private readonly MockStreamStoreConnection _conn = new(nameof(when_using_catch_up_connection));
 	private readonly CatchUpConnection _catchUp;
@@ -33,11 +33,11 @@ public sealed class when_using_catch_up_connection : IDisposable {
 		using var rm = new SumReadModel(_catchUp);
 		rm.StartAsync(_stream);
 
-		_catchUp.WaitForCatchUp(TimeSpan.FromSeconds(10), rm);
+		_catchUp.WaitForCatchUp(TestTimeouts.WaitFor, rm);
 		Assert.Equal(20, rm.Sum); // deterministic: no IsOrBecomesTrue needed after the barrier
 
 		AppendEvents(10, 5);
-		_catchUp.WaitForCatchUp(TimeSpan.FromSeconds(10), rm);
+		_catchUp.WaitForCatchUp(TestTimeouts.WaitFor, rm);
 		Assert.Equal(70, rm.Sum);
 	}
 
@@ -46,7 +46,7 @@ public sealed class when_using_catch_up_connection : IDisposable {
 		AppendEvents(1, 1);
 		var listener = _catchUp.GetListener("laggard");
 		listener.Start(_stream);
-		_catchUp.WaitForCatchUp(TimeSpan.FromSeconds(10));
+		_catchUp.WaitForCatchUp(TestTimeouts.WaitFor);
 
 		// a dead listener must read as a laggard, not as caught up
 		listener.Dispose();
@@ -65,7 +65,7 @@ public sealed class when_using_catch_up_connection : IDisposable {
 		queued.Start(_stream);
 
 		// the queued listener does not feed the barrier, so no laggard is reported for it
-		_catchUp.WaitForCatchUp(TimeSpan.FromSeconds(10));
+		_catchUp.WaitForCatchUp(TestTimeouts.WaitFor);
 		queued.Dispose();
 	}
 

--- a/src/ReactiveDomain.Foundation.Tests/when_using_catch_up_connection.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_catch_up_connection.cs
@@ -1,0 +1,93 @@
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using ReactiveDomain.Testing.EventStore;
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests;
+
+// ReSharper disable once InconsistentNaming
+public sealed class when_using_catch_up_connection : IDisposable {
+	private static readonly IEventSerializer Serializer = new JsonMessageSerializer();
+	private static readonly IStreamNameBuilder Namer =
+		new PrefixedCamelCaseStreamNameBuilder(nameof(when_using_catch_up_connection));
+
+	private readonly MockStreamStoreConnection _conn = new(nameof(when_using_catch_up_connection));
+	private readonly CatchUpConnection _catchUp;
+	private readonly string _stream = $"catchUpTest{Guid.NewGuid():N}";
+
+	public when_using_catch_up_connection() {
+		_conn.Connect();
+		_catchUp = new CatchUpConnection(new ConfiguredConnection(_conn, Namer, Serializer));
+	}
+
+	private void AppendEvents(int count, int value) {
+		for (var i = 0; i < count; i++) {
+			_conn.AppendToStream(_stream, ExpectedVersion.Any, null, Serializer.Serialize(new CatchUpTestEvent(value)));
+		}
+	}
+
+	[Fact]
+	public void wait_for_catch_up_returns_when_everything_is_delivered_and_applied() {
+		AppendEvents(10, 2);
+		using var rm = new SumReadModel(_catchUp);
+		rm.StartAsync(_stream);
+
+		_catchUp.WaitForCatchUp(TimeSpan.FromSeconds(10), rm);
+		Assert.Equal(20, rm.Sum); // deterministic: no IsOrBecomesTrue needed after the barrier
+
+		AppendEvents(10, 5);
+		_catchUp.WaitForCatchUp(TimeSpan.FromSeconds(10), rm);
+		Assert.Equal(70, rm.Sum);
+	}
+
+	[Fact]
+	public void timeout_names_the_lagging_stream() {
+		AppendEvents(1, 1);
+		var listener = _catchUp.GetListener("laggard");
+		listener.Start(_stream);
+		_catchUp.WaitForCatchUp(TimeSpan.FromSeconds(10));
+
+		// a dead listener must read as a laggard, not as caught up
+		listener.Dispose();
+		AppendEvents(2, 1);
+
+		var ex = Assert.Throws<TimeoutException>(() => _catchUp.WaitForCatchUp(TimeSpan.FromMilliseconds(200)));
+		Assert.Contains(_stream, ex.Message);
+		Assert.Contains("delivered 0 of 2", ex.Message);
+	}
+
+	[Fact]
+	public void queued_listeners_are_not_tracked() {
+		AppendEvents(5, 3);
+		var queued = _catchUp.GetQueuedListener("queued");
+		Assert.IsType<QueuedStreamListener>(queued);
+		queued.Start(_stream);
+
+		// the queued listener does not feed the barrier, so no laggard is reported for it
+		_catchUp.WaitForCatchUp(TimeSpan.FromSeconds(10));
+		queued.Dispose();
+	}
+
+	public void Dispose() {
+		_conn.Dispose();
+	}
+
+	public record CatchUpTestEvent(int Value) : Event;
+
+	private sealed class SumReadModel :
+		ReadModelBase,
+		IHandle<CatchUpTestEvent> {
+		public long Sum { get; private set; }
+
+		public SumReadModel(IConfiguredConnection connection)
+			: base(nameof(SumReadModel), connection) {
+			// ReSharper disable once RedundantTypeArgumentsOfMethod
+			EventStream.Subscribe<CatchUpTestEvent>(this);
+		}
+
+		void IHandle<CatchUpTestEvent>.Handle(CatchUpTestEvent @event) {
+			Sum += @event.Value;
+		}
+	}
+}

--- a/src/ReactiveDomain.Foundation/CatchUpConnection.cs
+++ b/src/ReactiveDomain.Foundation/CatchUpConnection.cs
@@ -1,0 +1,138 @@
+using ReactiveDomain.Messaging;
+
+namespace ReactiveDomain.Foundation;
+
+/// <summary>
+/// An <see cref="IConfiguredConnection"/> decorator providing a deterministic "all read models
+/// have consumed everything committed to their streams" barrier. Listeners handed out by
+/// <see cref="GetListener"/> are tracked; <see cref="WaitForCatchUp"/> blocks until every tracked
+/// listener has delivered through its stream's current end and every supplied read model is idle
+/// with an empty queue. Replaces heuristic waits (count-stability windows, version guessing, bare
+/// IsLive) whose failure mode is false completion under scheduler lag. Useful in production
+/// seeding and export paths as well as tests.
+/// </summary>
+public sealed class CatchUpConnection(IConfiguredConnection inner) : IConfiguredConnection {
+	private readonly List<TrackedStreamListener> _tracked = [];
+
+	public IStreamStoreConnection Connection => inner.Connection;
+	public IStreamNameBuilder StreamNamer => inner.StreamNamer;
+	public IEventSerializer Serializer => inner.Serializer;
+
+	/// <summary>
+	/// Returns a listener whose delivered-through position feeds <see cref="WaitForCatchUp"/>.
+	/// </summary>
+	public IListener GetListener(string name) {
+		var listener = new TrackedStreamListener(name, inner.Connection, inner.StreamNamer, inner.Serializer);
+		lock (_tracked) { _tracked.Add(listener); }
+		return listener;
+	}
+
+	/// <summary>
+	/// Deliberately NOT tracked: <see cref="QueuedStreamListener"/>'s internal queue
+	/// buffers events after receipt, so a tracked position would over-report delivery —
+	/// "received by the listener" is not "handed to the subscriber". Do not "fix" this by
+	/// tracking it.
+	/// </summary>
+	public IListener GetQueuedListener(string name) => inner.GetQueuedListener(name);
+
+	public IStreamReader GetReader(string name, Action<IMessage> handle) => inner.GetReader(name, handle);
+
+	public IRepository GetRepository(bool caching = false, Func<Guid>? currentPolicyUserId = null) =>
+		inner.GetRepository(caching, currentPolicyUserId);
+
+	public ICorrelatedRepository GetCorrelatedRepository(
+		IRepository? baseRepository = null, bool caching = false, Func<Guid>? currentPolicyUserId = null) =>
+		inner.GetCorrelatedRepository(baseRepository, caching, currentPolicyUserId);
+
+	/// <summary>
+	/// Blocks until every listener handed out by <see cref="GetListener"/> has delivered through
+	/// its stream's current end and every read model in <paramref name="readModels"/> is idle
+	/// with an empty queue. The stream-end target is re-read every pass, so it keeps moving until
+	/// the store is quiet. Throws a <see cref="TimeoutException"/> naming each lagging stream and
+	/// each busy read-model queue.
+	/// </summary>
+	/// <param name="timeout">Overall deadline for the barrier, including the IsLive wait.</param>
+	/// <param name="readModels">The read models whose queues must drain.</param>
+	public void WaitForCatchUp(TimeSpan timeout, params ReadModelBase[] readModels) {
+		var deadline = DateTime.UtcNow + timeout;
+
+		// Bound the IsLive wait: an unbounded wait here has hung CI for hours.
+		var isLive = Task.WhenAll(readModels.Select(rm => rm.IsLive).ToArray());
+		try {
+			if (!isLive.Wait(timeout)) {
+				throw new TimeoutException($"Read models did not go live within {timeout}.");
+			}
+		} catch (AggregateException ex) {
+			throw new TimeoutException("A read model faulted before going live.", ex);
+		}
+
+		while (true) {
+			var laggards = ListLaggards(readModels);
+			if (laggards.Count == 0) { return; }
+			if (DateTime.UtcNow > deadline) {
+				throw new TimeoutException($"Catch-up incomplete after {timeout}: {string.Join("; ", laggards)}");
+			}
+			Thread.Sleep(10);
+		}
+	}
+
+	// Checked in causal order each pass: store delivery first, then read-model queues.
+	private List<string> ListLaggards(ReadModelBase[] readModels) {
+		var laggards = new List<string>();
+		TrackedStreamListener[] tracked;
+		lock (_tracked) { tracked = _tracked.ToArray(); }
+		foreach (var listener in tracked) {
+			if (string.IsNullOrEmpty(listener.StreamName)) { continue; } // not started yet
+			var slice = inner.Connection.ReadStreamBackward(listener.StreamName, -1, 1);
+			if (slice is null or StreamNotFoundSlice || slice.Events.Length == 0) { continue; }
+			var target = slice.LastEventNumber;
+			var delivered = listener.DeliveredThrough;
+			if (delivered < target) {
+				laggards.Add($"{listener.StreamName} delivered {delivered} of {target}");
+			}
+		}
+		if (laggards.Count > 0) { return laggards; }
+		foreach (var rm in readModels) {
+			if (!rm.Idle || rm.MessageCount != 0) {
+				laggards.Add($"queue {rm.GetType().Name} (count {rm.MessageCount})");
+			}
+		}
+		return laggards;
+	}
+
+	/// <summary>
+	/// Exposes DeliveredThrough = max(startCheckpoint, lastDelivered), with lastDelivered
+	/// recorded after the base publishes into the subscriber's queue — so DeliveredThrough >= N
+	/// means "event N is in the read model's queue or applied", never "in flight". This fixes two
+	/// ambiguities in the base <see cref="StreamListener.Position"/>: it advances at receipt
+	/// (before the subscriber sees the event) and initializes to 0 (indistinguishable from
+	/// "applied event 0").
+	/// </summary>
+	private sealed class TrackedStreamListener(
+		string listenerName,
+		IStreamStoreConnection connection,
+		IStreamNameBuilder streamNameBuilder,
+		IEventSerializer serializer)
+		: StreamListener(listenerName, connection, streamNameBuilder, serializer) {
+		private long _startCheckpoint = -1;
+		private long _lastDelivered = -1;
+
+		public long DeliveredThrough =>
+			Math.Max(Interlocked.Read(ref _startCheckpoint), Interlocked.Read(ref _lastDelivered));
+
+		public override void Start(
+			string streamName,
+			long? checkpoint = null,
+			bool blockUntilLive = false,
+			bool validateStream = false,
+			CancellationToken cancelWaitToken = default) {
+			Interlocked.Exchange(ref _startCheckpoint, checkpoint ?? -1);
+			base.Start(streamName, checkpoint, blockUntilLive, validateStream, cancelWaitToken);
+		}
+
+		protected override void GotEvent(RecordedEvent recordedEvent) {
+			base.GotEvent(recordedEvent); // deliver first, then record
+			Interlocked.Exchange(ref _lastDelivered, recordedEvent.EventNumber);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`CatchUpConnection` is an `IConfiguredConnection` decorator providing a deterministic "all read models have consumed everything committed to their streams" barrier:

```csharp
public void WaitForCatchUp(TimeSpan timeout, params ReadModelBase[] readModels);
```

- `GetListener` returns a private `TrackedStreamListener` with `DeliveredThrough = max(startCheckpoint, lastDelivered)`; `lastDelivered` is recorded in a `GotEvent` override **after** the base publishes, so `DeliveredThrough >= N` means "queued or applied", never "in flight". This fixes the base `StreamListener.Position` ambiguities (advances at receipt; initializes to 0, indistinguishable from "applied event 0").
- `GetQueuedListener` is deliberately **not** tracked — `QueuedStreamListener`'s queue buffers post-receipt, so tracking it would over-report delivery. XML-doc'd so nobody "fixes" it.
- Barrier mechanics: bound the `IsLive` wait first (an unbounded wait here has hung CI for hours), then loop to deadline checking in causal order — each tracked listener's `DeliveredThrough` against its stream end (re-read via `ReadStreamBackward` every pass, so the target moves until the store is quiet), then each read model's `Idle && MessageCount == 0`. On timeout, throws naming each laggard (`"{stream} delivered {n} of {target}"`) and each busy queue.

Lands in Foundation (not Testing) because it serves production seeding/export paths too. Replaces heuristic waits (count-stability windows, version guessing, bare `IsLive`) whose failure mode is false completion under scheduler lag.

## Tests

Even against the synchronous mock the barrier is load-bearing — `ReadModelBase` pumps through a `QueuedHandler` thread, so the queue-drain check is real:

- `wait_for_catch_up_returns_when_everything_is_delivered_and_applied` — asserts exact state after the barrier, no `IsOrBecomesTrue`.
- `timeout_names_the_lagging_stream` — a dead listener reads as a laggard; the exception names the stream and `delivered {n} of {target}`.
- `queued_listeners_are_not_tracked` — a queued listener does not feed the barrier.

Full Foundation.Tests: 154/154 on net8.0 + net10.0.

Design: `Docs/storage-update/test-infrastructure-plan.md` § 0.15.2/3.

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)