### PR TITLE
Add FaultInjectingConfiguredConnection to ReactiveDomain.Testing

### DIFF
--- a/src/ReactiveDomain.Testing.Tests/ReactiveDomain.Testing.Tests.csproj
+++ b/src/ReactiveDomain.Testing.Tests/ReactiveDomain.Testing.Tests.csproj
@@ -9,6 +9,10 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ReactiveDomain.Testing.Tests/Specifications/FaultInjectingConfiguredConnectionTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/Specifications/FaultInjectingConfiguredConnectionTests.cs
@@ -1,0 +1,61 @@
+using ReactiveDomain.Foundation;
+using ReactiveDomain.Testing.EventStore;
+using Xunit;
+
+namespace ReactiveDomain.Testing.Tests.Specifications;
+
+public sealed class FaultInjectingConfiguredConnectionTests : IDisposable {
+	private readonly MockStreamStoreConnection _conn = new(nameof(FaultInjectingConfiguredConnectionTests));
+	private readonly IConfiguredConnection _inner;
+	private readonly Guid _poisonId = Guid.NewGuid();
+	private readonly FaultInjectingConfiguredConnection _faulting;
+
+	public FaultInjectingConfiguredConnectionTests() {
+		_conn.Connect();
+		_inner = new ConfiguredConnection(
+			_conn,
+			new PrefixedCamelCaseStreamNameBuilder(nameof(FaultInjectingConfiguredConnectionTests)),
+			new JsonMessageSerializer());
+		_faulting = new FaultInjectingConfiguredConnection(_inner, es => es.Id == _poisonId);
+	}
+
+	[Fact]
+	public void save_throws_exactly_when_the_predicate_matches() {
+		var repo = _faulting.GetRepository();
+
+		var goodId = Guid.NewGuid();
+		repo.Save(new TestAggregate(goodId));
+		Assert.True(repo.TryGetById<TestAggregate>(goodId, out _));
+
+		var poison = new TestAggregate(_poisonId);
+		var ex = Assert.Throws<InjectedSaveException>(() => repo.Save(poison));
+		Assert.Same(poison, ex.Aggregate);
+		Assert.False(repo.TryGetById<TestAggregate>(_poisonId, out _)); // nothing was persisted
+	}
+
+	[Fact]
+	public void correlated_repository_saves_fault_too() {
+		var correlated = _faulting.GetCorrelatedRepository();
+		Assert.Throws<InjectedSaveException>(() => correlated.Save(new TestAggregate(_poisonId)));
+	}
+
+	[Fact]
+	public void reads_listeners_and_readers_pass_through() {
+		//seed through the unwrapped connection
+		_inner.GetRepository().Save(new TestAggregate(_poisonId));
+
+		//reads are untouched: the poison aggregate loads fine
+		Assert.True(_faulting.GetRepository().TryGetById<TestAggregate>(_poisonId, out var loaded));
+		Assert.Equal(_poisonId, loaded!.Id);
+
+		//listeners and readers come straight from the inner connection
+		using var listener = _faulting.GetListener("passThrough") as StreamListener;
+		Assert.NotNull(listener);
+		var reader = _faulting.GetReader("passThrough", _ => { });
+		Assert.NotNull(reader);
+	}
+
+	public void Dispose() {
+		_conn.Dispose();
+	}
+}

--- a/src/ReactiveDomain.Testing/Specifications/FaultInjectingConfiguredConnection.cs
+++ b/src/ReactiveDomain.Testing/Specifications/FaultInjectingConfiguredConnection.cs
@@ -1,0 +1,58 @@
+using System.Diagnostics.CodeAnalysis;
+using ReactiveDomain.Foundation;
+using ReactiveDomain.Messaging;
+
+namespace ReactiveDomain.Testing;
+
+/// <summary>
+/// Thrown by repositories handed out by <see cref="FaultInjectingConfiguredConnection"/> when the
+/// fault predicate matches a <see cref="IEventSource"/> being saved.
+/// </summary>
+public sealed class InjectedSaveException(IEventSource aggregate)
+	: Exception($"Injected save failure for {aggregate.GetType().Name} {aggregate.Id}") {
+	public IEventSource Aggregate { get; } = aggregate;
+}
+
+/// <summary>
+/// An <see cref="IConfiguredConnection"/> decorator for deterministically exercising save-failure
+/// and compensation paths: repositories it hands out throw <see cref="InjectedSaveException"/>
+/// from Save when <paramref name="shouldFail"/> returns true for the aggregate being saved.
+/// Reads, listeners, and readers pass through untouched.
+/// </summary>
+public sealed class FaultInjectingConfiguredConnection(
+	IConfiguredConnection inner,
+	Func<IEventSource, bool> shouldFail) : IConfiguredConnection {
+	public IStreamStoreConnection Connection => inner.Connection;
+	public IStreamNameBuilder StreamNamer => inner.StreamNamer;
+	public IEventSerializer Serializer => inner.Serializer;
+
+	public IListener GetListener(string name) => inner.GetListener(name);
+	public IListener GetQueuedListener(string name) => inner.GetQueuedListener(name);
+	public IStreamReader GetReader(string name, Action<IMessage> handle) => inner.GetReader(name, handle);
+
+	public IRepository GetRepository(bool caching = false, Func<Guid>? currentPolicyUserId = null) =>
+		new FaultInjectingRepository(inner.GetRepository(caching, currentPolicyUserId), shouldFail);
+
+	public ICorrelatedRepository GetCorrelatedRepository(
+		IRepository? baseRepository = null, bool caching = false, Func<Guid>? currentPolicyUserId = null) =>
+		inner.GetCorrelatedRepository(baseRepository ?? GetRepository(caching, currentPolicyUserId));
+
+	private sealed class FaultInjectingRepository(IRepository inner, Func<IEventSource, bool> shouldFail) : IRepository {
+		public bool TryGetById<TAggregate>(Guid id, [NotNullWhen(true)] out TAggregate? aggregate, int version = int.MaxValue)
+			where TAggregate : class, IEventSource => inner.TryGetById(id, out aggregate, version);
+
+		public TAggregate GetById<TAggregate>(Guid id, int version = int.MaxValue)
+			where TAggregate : class, IEventSource => inner.GetById<TAggregate>(id, version);
+
+		public void Update<TAggregate>(ref TAggregate aggregate, int version = int.MaxValue)
+			where TAggregate : class, IEventSource => inner.Update(ref aggregate, version);
+
+		public void Save(IEventSource aggregate) {
+			if (shouldFail(aggregate)) { throw new InjectedSaveException(aggregate); }
+			inner.Save(aggregate);
+		}
+
+		public void Delete(IEventSource aggregate) => inner.Delete(aggregate);
+		public void HardDelete(IEventSource aggregate) => inner.HardDelete(aggregate);
+	}
+}


### PR DESCRIPTION
## Summary

Adds `FaultInjectingConfiguredConnection` — an `IConfiguredConnection` decorator that wraps the repositories so `Save` throws `InjectedSaveException` when a `Func<IEventSource, bool>` predicate matches; reads, listeners, and readers pass through untouched. `GetCorrelatedRepository` composes over the faulting repository (`CorrelatedStreamStoreRepository.Save` delegates to its base repo), so correlated saves fault through the same predicate.

Deterministically exercises save-failure and compensation paths. Purely additive and backend-independent — no dependency on the storage port. The exception carries the rejected aggregate for assertion convenience.

Also carries the `xunit.runner.visualstudio` reference for `ReactiveDomain.Testing.Tests` (the same hunk as #238) so the new tests are discovered on CI regardless of merge order; the identical change merges cleanly whichever lands first.

## Tests

- `save_throws_exactly_when_the_predicate_matches` — non-matching saves persist and read back; matching saves throw and persist nothing.
- `correlated_repository_saves_fault_too`
- `reads_listeners_and_readers_pass_through`

Design: `Docs/storage-update/test-infrastructure-plan.md` § 0.15.2/4.

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)