### PR TITLE
Tag link-resolved deliveries as ProjectedEvent in EventStoreConnectionWrapper

### DIFF
--- a/src/ReactiveDomain.Persistence/EventStore/EventStoreConnectionWrapper.cs
+++ b/src/ReactiveDomain.Persistence/EventStore/EventStoreConnectionWrapper.cs
@@ -276,8 +276,9 @@ public static class ConnectionHelpers {
 	/// deliveries as <see cref="ProjectedEvent"/>. A delivery whose resolved event carries a
 	/// non-null link is a projection copy (a $ce-/$et-/$streams link), not a distinct fact;
 	/// <see cref="ProjectedEvent.ProjectedStream"/> and
-	/// <see cref="ProjectedEvent.OriginalEventNumber"/> let consumers dedup it. This matches
-	/// MockStreamStoreConnection's tagging of its emulated projection copies. Returns null for
+	/// <see cref="ProjectedEvent.OriginalEventNumber"/> let consumers dedup it.
+	/// MockStreamStoreConnection emulates this tagging so its in-memory projection
+	/// copies present the same contract as the real store. Returns null for
 	/// link events whose target was deleted or scavenged (see Docs/null-linkto-handling.md);
 	/// stream positions are immutable, so skipping them leaves checkpoints valid.
 	/// </summary>

--- a/src/ReactiveDomain.Persistence/EventStore/EventStoreConnectionWrapper.cs
+++ b/src/ReactiveDomain.Persistence/EventStore/EventStoreConnectionWrapper.cs
@@ -171,8 +171,9 @@ public class EventStoreConnectionWrapper : IStreamStoreConnection {
 		var sub = EsConnection.SubscribeToAllAsync(
 			resolveLinkTos,
 			async (_, evt) => {
-				if (evt.Event != null)
-					eventAppeared(evt.Event.ToRecordedEvent());
+				var delivered = evt.ToDeliveredEvent();
+				if (delivered != null)
+					eventAppeared(delivered);
 				await Task.FromResult(Unit.Default);
 			},
 			(_, reason, ex) => subscriptionDropped?.Invoke((SubscriptionDropReason)(int)reason, ex),
@@ -197,8 +198,9 @@ public class EventStoreConnectionWrapper : IStreamStoreConnection {
 			new ES.Position(from.CommitPosition, from.PreparePosition),
 			settings?.ToCatchUpSubscriptionSettings(),
 			async (_, evt) => {
-				if (evt.Event != null)
-					eventAppeared(evt.Event.ToRecordedEvent());
+				var delivered = evt.ToDeliveredEvent();
+				if (delivered != null)
+					eventAppeared(delivered);
 				await Task.FromResult(Unit.Default);
 			},
 			_ => { liveProcessingStarted?.Invoke(); },
@@ -267,6 +269,35 @@ public static class ConnectionHelpers {
 			events.Add(evt.ToRecordedEvent(resolvedEvents[i].OriginalEvent.EventNumber));
 		}
 		return events.ToArray();
+	}
+
+	/// <summary>
+	/// Maps a $all subscription delivery to a ReactiveDomain RecordedEvent, tagging link-resolved
+	/// deliveries as <see cref="ProjectedEvent"/>. A delivery whose resolved event carries a
+	/// non-null link is a projection copy (a $ce-/$et-/$streams link), not a distinct fact;
+	/// <see cref="ProjectedEvent.ProjectedStream"/> and
+	/// <see cref="ProjectedEvent.OriginalEventNumber"/> let consumers dedup it. This matches
+	/// MockStreamStoreConnection's tagging of its emulated projection copies. Returns null for
+	/// link events whose target was deleted or scavenged (see Docs/null-linkto-handling.md);
+	/// stream positions are immutable, so skipping them leaves checkpoints valid.
+	/// </summary>
+	public static RecordedEvent? ToDeliveredEvent(this ES.ResolvedEvent resolvedEvent) {
+		var evt = resolvedEvent.Event;
+		if (evt == null) { return null; }
+		var link = resolvedEvent.Link;
+		if (link == null) { return evt.ToRecordedEvent(); }
+		return new ProjectedEvent(
+			link.EventStreamId,   // the $ce-/$et-/$streams stream this copy lives in
+			evt.EventNumber,      // position in the source stream
+			evt.EventStreamId,
+			evt.EventId,
+			link.EventNumber,     // position in the projected stream
+			evt.EventType,
+			evt.Data,
+			evt.Metadata,
+			evt.IsJson,
+			evt.Created,
+			evt.CreatedEpoch);
 	}
 
 	public static RecordedEvent ToRecordedEvent(this ES.RecordedEvent recordedEvent, long? eventNumber = null) {

--- a/src/ReactiveDomain.Testing.Tests/ReactiveDomain.Testing.Tests.csproj
+++ b/src/ReactiveDomain.Testing.Tests/ReactiveDomain.Testing.Tests.csproj
@@ -9,6 +9,10 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ReactiveDomain.Testing.Tests/StreamStore/ProjectedEventTaggingTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/StreamStore/ProjectedEventTaggingTests.cs
@@ -1,0 +1,79 @@
+using System.Runtime.CompilerServices;
+using ReactiveDomain.EventStore;
+using Xunit;
+using ES = EventStore.ClientAPI;
+
+namespace ReactiveDomain.Testing.Tests.StreamStore;
+
+/// <summary>
+/// Pins the $all delivery mapping of EventStoreConnectionWrapper: link-resolved deliveries are
+/// tagged ProjectedEvent with the same field semantics as MockStreamStoreConnection's emulated
+/// projection copies. ClientAPI's RecordedEvent/ResolvedEvent have internal constructors, so the
+/// inputs are built via reflection.
+/// </summary>
+public sealed class ProjectedEventTaggingTests {
+	private static ES.RecordedEvent MakeEsEvent(string stream, long number, string type, Guid id) {
+		var evt = (ES.RecordedEvent)RuntimeHelpers.GetUninitializedObject(typeof(ES.RecordedEvent));
+		Set(evt, nameof(ES.RecordedEvent.EventStreamId), stream);
+		Set(evt, nameof(ES.RecordedEvent.EventId), id);
+		Set(evt, nameof(ES.RecordedEvent.EventNumber), number);
+		Set(evt, nameof(ES.RecordedEvent.EventType), type);
+		Set(evt, nameof(ES.RecordedEvent.Data), new byte[] { 1, 2, 3 });
+		Set(evt, nameof(ES.RecordedEvent.Metadata), new byte[] { 4, 5 });
+		Set(evt, nameof(ES.RecordedEvent.IsJson), true);
+		Set(evt, nameof(ES.RecordedEvent.Created), new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc));
+		Set(evt, nameof(ES.RecordedEvent.CreatedEpoch), 1767323045000L);
+		return evt;
+
+		static void Set(object target, string field, object value) =>
+			typeof(ES.RecordedEvent).GetField(field)!.SetValue(target, value);
+	}
+
+	private static ES.ResolvedEvent MakeResolved(ES.RecordedEvent? evt, ES.RecordedEvent? link) {
+		object boxed = RuntimeHelpers.GetUninitializedObject(typeof(ES.ResolvedEvent));
+		typeof(ES.ResolvedEvent).GetField(nameof(ES.ResolvedEvent.Event))!.SetValue(boxed, evt);
+		typeof(ES.ResolvedEvent).GetField(nameof(ES.ResolvedEvent.Link))!.SetValue(boxed, link);
+		return (ES.ResolvedEvent)boxed;
+	}
+
+	[Fact]
+	public void link_resolved_deliveries_are_tagged_as_projected_events() {
+		var id = Guid.NewGuid();
+		var source = MakeEsEvent("account-123", 7, "CreditApplied", id);
+		var link = MakeEsEvent("$ce-account", 42, "$>", Guid.NewGuid());
+
+		var delivered = MakeResolved(source, link).ToDeliveredEvent();
+
+		var projected = Assert.IsType<ProjectedEvent>(delivered);
+		Assert.Equal("$ce-account", projected.ProjectedStream);   // the stream this copy lives in
+		Assert.Equal(7, projected.OriginalEventNumber);           // position in the source stream
+		Assert.Equal(42, projected.EventNumber);                  // position in the projected stream
+		Assert.Equal("account-123", projected.EventStreamId);     // source stream, not the link's
+		Assert.Equal(id, projected.EventId);
+		Assert.Equal("CreditApplied", projected.EventType);
+		Assert.Equal(new byte[] { 1, 2, 3 }, projected.Data);
+		Assert.Equal(new byte[] { 4, 5 }, projected.Metadata);
+		Assert.True(projected.IsJson);
+	}
+
+	[Fact]
+	public void non_link_deliveries_stay_plain_recorded_events() {
+		var id = Guid.NewGuid();
+		var source = MakeEsEvent("account-123", 7, "CreditApplied", id);
+
+		var delivered = MakeResolved(source, link: null).ToDeliveredEvent();
+
+		Assert.NotNull(delivered);
+		Assert.IsNotType<ProjectedEvent>(delivered);
+		Assert.Equal("account-123", delivered!.EventStreamId);
+		Assert.Equal(7, delivered.EventNumber);
+		Assert.Equal(id, delivered.EventId);
+	}
+
+	[Fact]
+	public void null_link_targets_are_skipped() {
+		// a link whose target was deleted or scavenged resolves with Event == null
+		var link = MakeEsEvent("$et-CreditApplied", 3, "$>", Guid.NewGuid());
+		Assert.Null(MakeResolved(evt: null, link).ToDeliveredEvent());
+	}
+}


### PR DESCRIPTION
## Summary

A `$all` delivery whose resolved event carries a non-null link is a projection copy (`$ce-`/`$et-`/`$streams`), not a distinct fact. `SubscribeToAll`/`SubscribeToAllFrom` now map such deliveries via a new `ConnectionHelpers.ToDeliveredEvent` to `ProjectedEvent`:

- `ProjectedStream` = the link's stream (the `$ce-`/`$et-` stream the copy lives in)
- `OriginalEventNumber` = position in the source stream
- `EventNumber` = position in the projected stream

matching `MockStreamStoreConnection`'s tagging of its emulated projection copies (field-for-field). Since `ProjectedEvent : RecordedEvent`, consumers that don't type-check are unaffected; consumers with `is ProjectedEvent` dedup guards (the harness connector bus) start working correctly against real ES for the first time. This makes the connection contract uniform across mock and wrapper ahead of the 0.16.0 gRPC wrapper, which then conforms to an already-published contract.

Deliberately unchanged: `SubscribeToStream(From)` and batch reads — their positions are positions in the stream being read, which listeners depend on. Null link targets (deleted/scavenged streams) are still skipped per `Docs/null-linkto-handling.md`; checkpoints track link positions, so gaps stay safe.

**⚠️ Release-notes callout: this is the one consumer-visible behavior change in 0.15.2.**

## Tests

No live-ESDB harness exists in-repo, so `ProjectedEventTaggingTests` pins the mapping directly — ClientAPI's `RecordedEvent`/`ResolvedEvent` have internal constructors, so inputs are built via reflection (the legacy TCP client is pinned at 22.0.0 and retires in 0.16.0, so this is stable):

- link-resolved delivery → `ProjectedEvent` with the exact mock-parity field mapping
- non-link delivery → plain `RecordedEvent`, source positions
- null link target → skipped

Also carries the `xunit.runner.visualstudio` reference for `ReactiveDomain.Testing.Tests` (same hunk as #238) so these tests are discovered on CI regardless of merge order.

Design: `Docs/storage-update/test-infrastructure-plan.md` § 0.15.2/6 and `Docs/storage-update/streamstore-storage-port.md` (ProjectedEvent tagging).

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)