### PR TITLE
Bumps version to 0.15.2

### DIFF
--- a/src/ReactiveDomain.Debug.nuspec
+++ b/src/ReactiveDomain.Debug.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>ReactiveDomain</id>
-		<version>0.15.1.0</version>
+		<version>0.15.2.0</version>
 		<authors>Reactive Domain Group</authors>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<license type="expression">MIT</license>

--- a/src/ReactiveDomain.Policy.Debug.nuspec
+++ b/src/ReactiveDomain.Policy.Debug.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>ReactiveDomain.Policy</id>
-		<version>0.15.1.0</version>
+		<version>0.15.2.0</version>
 		<authors>Reactive Domain Group</authors>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<license type="expression">MIT</license>
@@ -12,7 +12,7 @@
 		<repository type="git" url="https://github.com/ReactiveDomain/reactive-domain" branch="master" />
 		<dependencies>
 			<group targetFramework="net8.0">
-				<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
+				<dependency id="ReactiveDomain" version="0.15.2.0" exclude="Build,Analyzers" />
 				<dependency id="DynamicData" version="8.4.1" exclude="Build,Analyzers" />
 				<dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
 				<dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>
@@ -21,7 +21,7 @@
 				<dependency id="System.DirectoryServices.AccountManagement" version="8.0.0" exclude="Build,Analyzers" />
 			</group>
 			<group targetFramework="net10.0">
-				<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
+				<dependency id="ReactiveDomain" version="0.15.2.0" exclude="Build,Analyzers" />
 				<dependency id="DynamicData" version="8.4.1" exclude="Build,Analyzers" />
 				<dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
 				<dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>

--- a/src/ReactiveDomain.Policy.nuspec
+++ b/src/ReactiveDomain.Policy.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>ReactiveDomain.Policy</id>
-		<version>0.15.1.0</version>
+		<version>0.15.2.0</version>
 		<authors>Reactive Domain Group</authors>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<license type="expression">MIT</license>
@@ -13,7 +13,7 @@
 		<repository type="git" url="https://github.com/ReactiveDomain/reactive-domain" branch="master" />
 		<dependencies>
 			<group targetFramework="net8.0">
-				<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
+				<dependency id="ReactiveDomain" version="0.15.2.0" exclude="Build,Analyzers" />
 				<dependency id="DynamicData" version="8.4.1" exclude="Build,Analyzers" />
 				<dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
 				<dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>
@@ -22,7 +22,7 @@
 				<dependency id="System.DirectoryServices.AccountManagement" version="8.0.0" exclude="Build,Analyzers" />
 			</group>
 			<group targetFramework="net10.0">
-				<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
+				<dependency id="ReactiveDomain" version="0.15.2.0" exclude="Build,Analyzers" />
 				<dependency id="DynamicData" version="8.4.1" exclude="Build,Analyzers" />
 				<dependency id="IdentityModel" version="4.6.0" exclude="Build,Analyzers" />
 				<dependency id="IdentityServer4.Storage" version="4.1.2" exclude="Build,Analyzers"/>

--- a/src/ReactiveDomain.Testing.Debug.nuspec
+++ b/src/ReactiveDomain.Testing.Debug.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>ReactiveDomain.Testing</id>
-		<version>0.15.1.0</version>
+		<version>0.15.2.0</version>
 		<authors>Reactive Domain Group</authors>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<license type="expression">MIT</license>
@@ -13,13 +13,13 @@
 		<repository type="git" url="https://github.com/ReactiveDomain/reactive-domain" branch="master" />
 		<dependencies>
 			<group targetFramework="net8.0">
-				<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
+				<dependency id="ReactiveDomain" version="0.15.2.0" exclude="Build,Analyzers" />
 				<dependency id="Microsoft.NET.Test.Sdk" version="17.10.0" exclude="Build,Analyzers" />
 				<dependency id="xunit" version="2.9.0" exclude="Build,Analyzers" />
 				<dependency id="xunit.runner.console" version="2.9.0" exclude="Build,Analyzers" />
 			</group>
 			<group targetFramework="net10.0">
-				<dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
+				<dependency id="ReactiveDomain" version="0.15.2.0" exclude="Build,Analyzers" />
 				<dependency id="Microsoft.NET.Test.Sdk" version="17.10.0" exclude="Build,Analyzers" />
 				<dependency id="xunit" version="2.9.0" exclude="Build,Analyzers" />
 				<dependency id="xunit.runner.console" version="2.9.0" exclude="Build,Analyzers" />

--- a/src/ReactiveDomain.Testing.nuspec
+++ b/src/ReactiveDomain.Testing.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain.Testing</id>
-    <version>0.15.1.0</version>
+    <version>0.15.2.0</version>
     <authors>Reactive Domain Group</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
@@ -13,13 +13,13 @@
     <repository type="git" url="https://github.com/ReactiveDomain/reactive-domain" branch="master" />
     <dependencies>
       <group targetFramework="net8.0">
-        <dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.15.2.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.NET.Test.Sdk" version="18.7.0" exclude="Build,Analyzers" />
         <dependency id="xunit" version="2.9.0" exclude="Build,Analyzers" />
         <dependency id="xunit.runner.console" version="2.9.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net10.0">
-        <dependency id="ReactiveDomain" version="0.15.1.0" exclude="Build,Analyzers" />
+        <dependency id="ReactiveDomain" version="0.15.2.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.NET.Test.Sdk" version="18.7.0" exclude="Build,Analyzers" />
         <dependency id="xunit" version="2.9.0" exclude="Build,Analyzers" />
         <dependency id="xunit.runner.console" version="2.9.0" exclude="Build,Analyzers" />

--- a/src/ReactiveDomain.nuspec
+++ b/src/ReactiveDomain.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ReactiveDomain</id>
-    <version>0.15.1.0</version>
+    <version>0.15.2.0</version>
     <authors>Reactive Domain Group</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>

--- a/src/build.props
+++ b/src/build.props
@@ -12,7 +12,7 @@
     <DeployPackages Condition="$(CI) == 'true' and $(MSBuildRuntimeType) != 'Full' And $(OS) == 'WINDOWS_NT'">false</DeployPackages>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageVersionPrefix>0.15.1</PackageVersionPrefix>
+    <PackageVersionPrefix>0.15.2</PackageVersionPrefix>
     <PackageVersionSuffix Condition="$(IsCIBuild) == false">-dev</PackageVersionSuffix>
     <PackageVersionSuffix Condition="$(IsCIBuild) == true">-build</PackageVersionSuffix>
     <PackageOutputPath>$(MSBuildThisFileDirectory)..\packages\</PackageOutputPath>
@@ -24,8 +24,8 @@
     <Authors>Reactive Domain Group</Authors>
     <Copyright>Copyright © 2026 Reactive Domain Group</Copyright>
     <Description />
-    <AssemblyVersion>0.15.1.0</AssemblyVersion>
-    <FileVersion>0.15.1.0</FileVersion>
+    <AssemblyVersion>0.15.2.0</AssemblyVersion>
+    <FileVersion>0.15.2.0</FileVersion>
     <NeutralLanguage />
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Bumps the package version **0.15.1 → 0.15.2** to cut the 0.15.2 release. Mirrors the 0.15.1 bump (#215): `src/build.props` (`PackageVersionPrefix`, `AssemblyVersion`, `FileVersion`) plus the `<version>` and `ReactiveDomain` self-dependency in all six nuspecs. Version metadata only — no code changes; CRLF line endings preserved.

## What 0.15.2 ships (merged since 0.15.1)
- #221 dispose-ordering / queue-thread race fixes
- #237 packaging improvements
- #238 TestQueue: signal WaitForMsgId before the type filter
- #239 CI-aware TestTimeouts
- #240 AwaitEventDelivery delivery fence
- #241 CatchUpConnection read-model catch-up barrier
- #242 FaultInjectingConfiguredConnection
- #243 ProjectedEvent tagging in EventStoreConnectionWrapper
- #244 IsLive timing-contract docs

## Publishing
Publishing is manual (no release workflow — only `pr-checks.yml`). After this merges to `master`, run the package/publish scripts to push `ReactiveDomain`, `ReactiveDomain.Testing`, and `ReactiveDomain.Policy` 0.15.2 to nuget.org.

Downstream Shoebox consumer bump is staged and waiting on the publish.