### PR TITLE
Fix CheckAssemblyVersion parse broken by 'nuget list' deprecation warning

### DIFF
--- a/tools/CheckAssemblyVersion.ps1
+++ b/tools/CheckAssemblyVersion.ps1
@@ -32,19 +32,23 @@ $RDVersion = $props.SelectSingleNode("//Project/PropertyGroup/AssemblyVersion")
 
 Write-Host ("Local Assembly Version node is " + $RDVersion.InnerText ) 
 
-$major = $RDVersion.InnerText.Split('.')[0]
-$minor = $RDVersion.InnerText.Split('.')[1]
-$build = $RDVersion.InnerText.Split('.')[2]
-$revision = $RDVersion.InnerText.Split('.')[3]
+$major = [int]$RDVersion.InnerText.Split('.')[0]
+$minor = [int]$RDVersion.InnerText.Split('.')[1]
+$build = [int]$RDVersion.InnerText.Split('.')[2]
+$revision = [int]$RDVersion.InnerText.Split('.')[3]
 
-&$nuget list packageid:ReactiveDomain -source https://api.nuget.org/v3/index.json | Tee-Object -Variable rdPackage
-$masterRDversion = ($rdPackage.Split(" "))[1]
+$rdPackages = &$nuget list packageid:ReactiveDomain -source https://api.nuget.org/v3/index.json
+# 'nuget list' is deprecated and prints a warning line ahead of the results, so the raw output is
+# multi-line. Select the exact 'ReactiveDomain <version>' entry — not the warning, and not the
+# ReactiveDomain.Testing/.Policy rows — then take the version token.
+$masterLine = $rdPackages | Where-Object { $_ -match '^ReactiveDomain\s+\d' } | Select-Object -First 1
+$masterRDversion = ($masterLine -split '\s+')[1]
 Write-Host "Latest ReactiveDomain nuget version is: " $masterRDversion
 
-$masterMajor = $masterRDversion.Split('.')[0]
-$masterMinor = $masterRDversion.Split('.')[1]
-$masterBuild = $masterRDversion.Split('.')[2]
-$masterRevision = $masterRDversion.Split('.')[3]
+$masterMajor = [int]$masterRDversion.Split('.')[0]
+$masterMinor = [int]$masterRDversion.Split('.')[1]
+$masterBuild = [int]$masterRDversion.Split('.')[2]
+$masterRevision = [int]$masterRDversion.Split('.')[3]
 
 # Verify the assembly has been incremented from the assembly version on master branch
 if ($masterMajor -gt $major)


### PR DESCRIPTION
## Problem
Every stable release run of `tools/CheckAssemblyVersion.ps1` now fails with a bogus **"Invalid Assembly Version!!!"** even when the version was correctly bumped (seen this release: local `0.15.2.0` vs published `0.15.1`).

`nuget list` is deprecated and prints a warning line ahead of its results:
```
WARNING: 'NuGet list' is deprecated. Use 'NuGet search' instead.
ReactiveDomain 0.15.1
```
The captured output is therefore multi-line, and `($rdPackage.Split(" "))[1]` picked the **second token of the warning line** (`'NuGet`) instead of the version. The script then compared `0.15.2` against the string `'NuGet`, tripping the failure branch. Observed output: `Latest ReactiveDomain nuget version is: 'NuGet`.

## Fix
- Select the exact `ReactiveDomain <version>` row (`-match '^ReactiveDomain\s+\d'`) — skips the warning line and the `ReactiveDomain.Testing`/`.Policy` rows — then take the version token.
- Cast the version segments to `[int]` so comparisons are numeric; the string compare would misorder at digit rollovers (e.g. `"10" -lt "9"`).

## Verified
Against live nuget.org output, the new parse yields `0.15.1`, and `0.15.2.0` vs `0.15.1` now passes ("Assembly version updated correctly").

Surfaced while cutting the 0.15.2 release. The check is an independent pre-flight (not called by `CreateNuget.ps1`), so it didn't block this release, but it fails every release until fixed.