### PR TITLE
Fix intermittent CI timing flakes in Foundation.Tests catch-up family (#248)

### DIFF
--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/Common/CommonHelpers.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/Common/CommonHelpers.cs
@@ -13,7 +13,7 @@ internal static class CommonHelpers {
 					return false;
 				}
 			},
-			2000,
+			TestTimeouts.ThrottleWaitFor,
 			$"Stream '{streamName}' not created");
 	}
 }

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_aggregate_and_guid.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_aggregate_and_guid.cs
@@ -45,7 +45,7 @@ public sealed class when_using_listener_start_with_aggregate_and_guid : IClassFi
 	private long _testEventCount;
 	[Fact]
 	public void can_get_events_from_aggregate_id_stream() {
-		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _testEventCount) == 1, 3000);
+		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _testEventCount) == 1, TestTimeouts.ThrottleWaitFor);
 	}
 
 	private void Handle(IMessage message) {

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_category_aggregate.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_category_aggregate.cs
@@ -42,7 +42,7 @@ public sealed class when_using_listener_start_with_category_aggregate : IClassFi
 	private long _testEventCount;
 	[Fact]
 	public void can_get_events_from_category_projection() {
-		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _testEventCount) == 1, 4000);
+		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _testEventCount) == 1, TestTimeouts.ThrottleWaitFor);
 	}
 
 	private void Handle(IMessage message) {

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_custom_stream_not_synced.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_custom_stream_not_synced.cs
@@ -42,7 +42,7 @@ public sealed class when_using_listener_start_with_custom_stream_not_synced : IC
 
 	[Fact]
 	public void can_get_events_from_custom_stream() {
-		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _testEventCount) == 1, 3000);
+		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _testEventCount) == 1, TestTimeouts.ThrottleWaitFor);
 	}
 
 	private void Handle(IMessage message) {

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_custom_stream_synced.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_custom_stream_synced.cs
@@ -41,7 +41,7 @@ public sealed class when_using_listener_start_with_custom_stream_synced : IClass
 
 	[Fact]
 	public void can_get_events_from_custom_stream() {
-		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _testEventCount) == 1, 3000);
+		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _testEventCount) == 1, TestTimeouts.ThrottleWaitFor);
 	}
 
 	private void Handle(IMessage message) {

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_custom_stream_synced_bus.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_custom_stream_synced_bus.cs
@@ -50,8 +50,8 @@ public sealed class when_using_listener_start_with_custom_stream_synced_bus : IC
 	}
 	[Fact]
 	public void can_get_events_from_custom_stream() {
-		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _testEventCount) == 1, 3000);
-		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _gotLiveStarted) == 1);
+		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _testEventCount) == 1, TestTimeouts.ThrottleWaitFor);
+		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _gotLiveStarted) == 1, TestTimeouts.ThrottleWaitFor);
 	}
 
 	private void Handle(IMessage message) {

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_event_type.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_event_type.cs
@@ -49,7 +49,7 @@ public sealed class when_using_listener_start_with_event_type : IClassFixture<St
 	private long _testEventCount;
 	[Fact]
 	public void can_get_events_from_event_type_stream() {
-		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _testEventCount) == 1, 4000, "Event Not Received");
+		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _testEventCount) == 1, TestTimeouts.ThrottleWaitFor, "Event Not Received");
 	}
 
 	private void Handle(IMessage message) {

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_future_stream.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_using_listener_start_with_future_stream.cs
@@ -63,7 +63,7 @@ public sealed class when_using_listener_start_with_future_stream : IClassFixture
 
 		// Wait for the stream to be written
 		CommonHelpers.WaitForStream(_connection, _originStreamName);
-		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _testEventCount) == 1, 3000);
+		AssertEx.IsOrBecomesTrue(() => Interlocked.Read(ref _testEventCount) == 1, TestTimeouts.ThrottleWaitFor);
 	}
 
 	private void Handle(IMessage message) {

--- a/src/ReactiveDomain.Foundation.Tests/when_using_catch_up_connection.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_catch_up_connection.cs
@@ -33,11 +33,11 @@ public sealed class when_using_catch_up_connection : IDisposable {
 		using var rm = new SumReadModel(_catchUp);
 		rm.StartAsync(_stream);
 
-		_catchUp.WaitForCatchUp(TestTimeouts.WaitFor, rm);
+		_catchUp.WaitForCatchUp(TestTimeouts.ThrottleWaitFor, rm);
 		Assert.Equal(20, rm.Sum); // deterministic: no IsOrBecomesTrue needed after the barrier
 
 		AppendEvents(10, 5);
-		_catchUp.WaitForCatchUp(TestTimeouts.WaitFor, rm);
+		_catchUp.WaitForCatchUp(TestTimeouts.ThrottleWaitFor, rm);
 		Assert.Equal(70, rm.Sum);
 	}
 
@@ -46,7 +46,7 @@ public sealed class when_using_catch_up_connection : IDisposable {
 		AppendEvents(1, 1);
 		var listener = _catchUp.GetListener("laggard");
 		listener.Start(_stream);
-		_catchUp.WaitForCatchUp(TestTimeouts.WaitFor);
+		_catchUp.WaitForCatchUp(TestTimeouts.ThrottleWaitFor);
 
 		// a dead listener must read as a laggard, not as caught up
 		listener.Dispose();
@@ -65,7 +65,7 @@ public sealed class when_using_catch_up_connection : IDisposable {
 		queued.Start(_stream);
 
 		// the queued listener does not feed the barrier, so no laggard is reported for it
-		_catchUp.WaitForCatchUp(TestTimeouts.WaitFor);
+		_catchUp.WaitForCatchUp(TestTimeouts.ThrottleWaitFor);
 		queued.Dispose();
 	}
 

--- a/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base.cs
@@ -54,8 +54,8 @@ public sealed class when_using_read_model_base :
 		var s1 = _namer.GenerateForAggregate(typeof(TestAggregate), aggId);
 		AppendEvents(1, _conn, s1, 7);
 		Start<TestAggregate>(aggId);
-		AssertEx.AtLeastModelVersion(this, 2, msg: $"Expected 2 got {Version}"); // 1 message + CatchupSubscriptionBecameLive
-		AssertEx.IsOrBecomesTrue(() => Sum == 7);
+		AssertEx.AtLeastModelVersion(this, 2, TestTimeouts.ThrottleWaitFor, msg: $"Expected 2 got {Version}"); // 1 message + CatchupSubscriptionBecameLive
+		AssertEx.IsOrBecomesTrue(() => Sum == 7, TestTimeouts.ThrottleWaitFor);
 	}
 	[Fact]
 	public void can_start_streams_by_aggregate_category() {
@@ -66,14 +66,14 @@ public sealed class when_using_read_model_base :
 		AppendEvents(1, _conn, s2, 5);
 		Start<ReadModelTestCategoryAggregate>(null, true);
 
-		AssertEx.AtLeastModelVersion(this, 3, msg: $"Expected 3 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 12);
+		AssertEx.AtLeastModelVersion(this, 3, TestTimeouts.ThrottleWaitFor, msg: $"Expected 3 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 12, TestTimeouts.ThrottleWaitFor);
 	}
 	[Fact]
 	public void can_read_one_stream() {
 		Start(_stream1);
-		AssertEx.AtLeastModelVersion(this, 11, msg: $"Expected 11 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 20);
+		AssertEx.AtLeastModelVersion(this, 11, TestTimeouts.ThrottleWaitFor, msg: $"Expected 11 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 20, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
 		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
 		Assert.Equal(9, GetCheckpoint()[0].Item2);
@@ -82,8 +82,8 @@ public sealed class when_using_read_model_base :
 	public void can_read_two_streams() {
 		Start(_stream1);
 		Start(_stream2);
-		AssertEx.AtLeastModelVersion(this, 22, msg: $"Expected 22 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 50);
+		AssertEx.AtLeastModelVersion(this, 22, TestTimeouts.ThrottleWaitFor, msg: $"Expected 22 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 50, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
 		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
 		Assert.Equal(9, GetCheckpoint()[0].Item2);
@@ -93,28 +93,28 @@ public sealed class when_using_read_model_base :
 	[Fact]
 	public void can_wait_for_one_stream_to_go_live() {
 		Start(_stream1, null, true);
-		AssertEx.AtLeastModelVersion(this, 11, TimeSpan.FromMilliseconds(100), msg: $"Expected 11 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 20, 100);
+		AssertEx.AtLeastModelVersion(this, 11, TestTimeouts.ThrottleWaitFor, msg: $"Expected 11 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 20, TestTimeouts.ThrottleWaitFor);
 	}
 	[Fact]
 	public void can_wait_for_two_streams_to_go_live() {
 		Start(_stream1, null, true);
-		AssertEx.AtLeastModelVersion(this, 11, TimeSpan.FromMilliseconds(100), msg: $"Expected 11 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 20, 150);
+		AssertEx.AtLeastModelVersion(this, 11, TestTimeouts.ThrottleWaitFor, msg: $"Expected 11 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 20, TestTimeouts.ThrottleWaitFor);
 
 		Start(_stream2, null, true);
-		AssertEx.AtLeastModelVersion(this, 21, TimeSpan.FromMilliseconds(100), msg: $"Expected 21 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 50, 150);
+		AssertEx.AtLeastModelVersion(this, 21, TestTimeouts.ThrottleWaitFor, msg: $"Expected 21 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 50, TestTimeouts.ThrottleWaitFor);
 	}
 	[Fact]
 	public void can_listen_to_one_stream() {
 		Start(_stream1);
-		AssertEx.AtLeastModelVersion(this, 11, msg: $"Expected 11 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 20);
+		AssertEx.AtLeastModelVersion(this, 11, TestTimeouts.ThrottleWaitFor, msg: $"Expected 11 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 20, TestTimeouts.ThrottleWaitFor);
 		//add more messages
 		AppendEvents(10, _conn, _stream1, 5);
-		AssertEx.AtLeastModelVersion(this, 21, msg: $"Expected 21 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 70);
+		AssertEx.AtLeastModelVersion(this, 21, TestTimeouts.ThrottleWaitFor, msg: $"Expected 21 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 70, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
 		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
 		Assert.Equal(19, GetCheckpoint()[0].Item2);
@@ -125,13 +125,13 @@ public sealed class when_using_read_model_base :
 	public void can_listen_to_two_streams() {
 		Start(_stream1);
 		Start(_stream2);
-		AssertEx.AtLeastModelVersion(this, 22, msg: $"Expected 22 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 50);
+		AssertEx.AtLeastModelVersion(this, 22, TestTimeouts.ThrottleWaitFor, msg: $"Expected 22 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 50, TestTimeouts.ThrottleWaitFor);
 		//add more messages
 		AppendEvents(10, _conn, _stream1, 5);
 		AppendEvents(10, _conn, _stream2, 7);
-		AssertEx.AtLeastModelVersion(this, 42, msg: $"Expected 42 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 170);
+		AssertEx.AtLeastModelVersion(this, 42, TestTimeouts.ThrottleWaitFor, msg: $"Expected 42 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 170, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
 		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
 		Assert.Equal(19, GetCheckpoint()[0].Item2);
@@ -146,14 +146,12 @@ public sealed class when_using_read_model_base :
 		//start at the checkpoint
 		Start(_stream1, checkPoint);
 		//add the one recorded event
-		AssertEx.AtLeastModelVersion(this, 2, TimeSpan.FromMilliseconds(100), msg: $"Expected 2 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 20);
+		AssertEx.AtLeastModelVersion(this, 2, TestTimeouts.ThrottleWaitFor, msg: $"Expected 2 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 20, TestTimeouts.ThrottleWaitFor);
 		//add more messages
 		AppendEvents(10, _conn, _stream1, 5);
-		AssertEx.AtLeastModelVersion(this, 3, TimeSpan.FromMilliseconds(200), msg: $"Expected 3 got {Version}");
-		AssertEx.AtLeastModelVersion(this, 8, TimeSpan.FromMilliseconds(100), msg: $"Expected 8 got {Version}");
-		AssertEx.AtLeastModelVersion(this, 12, TimeSpan.FromMilliseconds(100), msg: $"Expected 12 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 70);
+		AssertEx.AtLeastModelVersion(this, 12, TestTimeouts.ThrottleWaitFor, msg: $"Expected 12 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 70, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
 		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
 		Assert.Equal(19, GetCheckpoint()[0].Item2);
@@ -167,13 +165,13 @@ public sealed class when_using_read_model_base :
 		Start(_stream1, checkPoint1);
 		Start(_stream2, checkPoint2);
 		//add the recorded events 2 on stream 1 & 5 on stream 2
-		AssertEx.AtLeastModelVersion(this, 7, msg: $"Expected 7 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 50, msg: $"Expected 50 got {Sum}");
+		AssertEx.AtLeastModelVersion(this, 7, TestTimeouts.ThrottleWaitFor, msg: $"Expected 7 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 50, TestTimeouts.ThrottleWaitFor, msg: $"Expected 50 got {Sum}");
 		//add more messages
 		AppendEvents(10, _conn, _stream1, 5);
 		AppendEvents(10, _conn, _stream2, 7);
-		AssertEx.AtLeastModelVersion(this, 27, msg: $"Expected 27 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 170);
+		AssertEx.AtLeastModelVersion(this, 27, TestTimeouts.ThrottleWaitFor, msg: $"Expected 27 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 170, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
 		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
 		Assert.Equal(19, GetCheckpoint()[0].Item2);
@@ -188,12 +186,12 @@ public sealed class when_using_read_model_base :
 		Start(_stream1);
 		Start(_stream1);
 		//double events
-		AssertEx.AtLeastModelVersion(this, 22, msg: $"Expected 22 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 40);
+		AssertEx.AtLeastModelVersion(this, 22, TestTimeouts.ThrottleWaitFor, msg: $"Expected 22 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 40, TestTimeouts.ThrottleWaitFor);
 		//even more doubled events
 		AppendEvents(10, _conn, _stream1, 5);
-		AssertEx.AtLeastModelVersion(this, 42, TimeSpan.FromSeconds(2), msg: $"Expected 42 got {Version}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 140);
+		AssertEx.AtLeastModelVersion(this, 42, TestTimeouts.ThrottleWaitFor, msg: $"Expected 42 got {Version}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 140, TestTimeouts.ThrottleWaitFor);
 	}
 
 	public long Sum { get; private set; }

--- a/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base_with_reader.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base_with_reader.cs
@@ -52,8 +52,8 @@ public sealed class when_using_read_model_base_with_reader :
 		var s1 = _namer.GenerateForAggregate(typeof(TestAggregate), aggId);
 		AppendEvents(1, _conn, s1, 7);
 		Start<TestAggregate>(aggId);
-		AssertEx.IsOrBecomesTrue(() => Count == 1, 1000, msg: $"Expected 1 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 7);
+		AssertEx.IsOrBecomesTrue(() => Count == 1, TestTimeouts.ThrottleWaitFor, msg: $"Expected 1 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 7, TestTimeouts.ThrottleWaitFor);
 	}
 
 	[Fact]
@@ -63,8 +63,8 @@ public sealed class when_using_read_model_base_with_reader :
 		AppendEvents(1, _conn, s1, 7);
 		StartAsync<TestAggregate>(aggId);
 		await IsLive;
-		AssertEx.IsOrBecomesTrue(() => Count == 1, 1000, msg: $"Expected 1 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 7);
+		AssertEx.IsOrBecomesTrue(() => Count == 1, TestTimeouts.ThrottleWaitFor, msg: $"Expected 1 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 7, TestTimeouts.ThrottleWaitFor);
 	}
 
 	[Fact]
@@ -76,15 +76,15 @@ public sealed class when_using_read_model_base_with_reader :
 		StartAsync<ReadModelTestCategoryAggregate>();
 
 		await IsLive;
-		AssertEx.IsOrBecomesTrue(() => Count == 2, 1000, msg: $"Expected 2 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 12);
+		AssertEx.IsOrBecomesTrue(() => Count == 2, TestTimeouts.ThrottleWaitFor, msg: $"Expected 2 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 12, TestTimeouts.ThrottleWaitFor);
 	}
 
 	[Fact]
 	public void can_read_one_stream() {
 		Start(_stream1);
-		AssertEx.IsOrBecomesTrue(() => Count == 10, 1000, msg: $"Expected 10 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 20);
+		AssertEx.IsOrBecomesTrue(() => Count == 10, TestTimeouts.ThrottleWaitFor, msg: $"Expected 10 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 20, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
 		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
 		Assert.Equal(9, GetCheckpoint()[0].Item2);
@@ -94,8 +94,8 @@ public sealed class when_using_read_model_base_with_reader :
 	public void can_read_two_streams() {
 		Start(_stream1);
 		Start(_stream2);
-		AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 50);
+		AssertEx.IsOrBecomesTrue(() => Count == 20, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 50, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
 		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
 		Assert.Equal(9, GetCheckpoint()[0].Item2);
@@ -113,8 +113,8 @@ public sealed class when_using_read_model_base_with_reader :
 	public async Task can_await_one_stream_going_live() {
 		StartAsync(_stream1);
 		await IsLive;
-		AssertEx.IsOrBecomesTrue(() => Count == 10, 1000, msg: $"Expected 10 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 20, 1000, msg: $"Expected 20 got {Sum}");
+		AssertEx.IsOrBecomesTrue(() => Count == 10, TestTimeouts.ThrottleWaitFor, msg: $"Expected 10 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 20, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Sum}");
 	}
 
 	[Fact]
@@ -122,19 +122,19 @@ public sealed class when_using_read_model_base_with_reader :
 		StartAsync(_stream1);
 		StartAsync(_stream2);
 		await IsLive;
-		AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 50, 1000, msg: $"Expected 50 got {Sum}");
+		AssertEx.IsOrBecomesTrue(() => Count == 20, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 50, TestTimeouts.ThrottleWaitFor, msg: $"Expected 50 got {Sum}");
 	}
 
 	[Fact]
 	public void can_listen_to_one_stream() {
 		Start(_stream1);
-		AssertEx.IsOrBecomesTrue(() => Count == 10, 1000, msg: $"Expected 10 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 20);
+		AssertEx.IsOrBecomesTrue(() => Count == 10, TestTimeouts.ThrottleWaitFor, msg: $"Expected 10 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 20, TestTimeouts.ThrottleWaitFor);
 		//add more messages
 		AppendEvents(10, _conn, _stream1, 5);
-		AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 70);
+		AssertEx.IsOrBecomesTrue(() => Count == 20, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 70, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
 		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
 		Assert.Equal(19, GetCheckpoint()[0].Item2);
@@ -146,13 +146,13 @@ public sealed class when_using_read_model_base_with_reader :
 	public void can_listen_to_two_streams() {
 		Start(_stream1);
 		Start(_stream2);
-		AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 50);
+		AssertEx.IsOrBecomesTrue(() => Count == 20, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 50, TestTimeouts.ThrottleWaitFor);
 		//add more messages
 		AppendEvents(10, _conn, _stream1, 5);
 		AppendEvents(10, _conn, _stream2, 7);
-		AssertEx.IsOrBecomesTrue(() => Count == 40, 1000, msg: $"Expected 20 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 170);
+		AssertEx.IsOrBecomesTrue(() => Count == 40, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 170, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
 		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
 		Assert.Equal(19, GetCheckpoint()[0].Item2);
@@ -169,12 +169,12 @@ public sealed class when_using_read_model_base_with_reader :
 		//start at the checkpoint
 		Start(_stream1, checkPoint);
 		//add the one recorded event
-		AssertEx.IsOrBecomesTrue(() => Count == 10, 100, msg: $"Expected 10 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 20);
+		AssertEx.IsOrBecomesTrue(() => Count == 10, TestTimeouts.ThrottleWaitFor, msg: $"Expected 10 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 20, TestTimeouts.ThrottleWaitFor);
 		//add more messages
 		AppendEvents(10, _conn, _stream1, 5);
-		AssertEx.IsOrBecomesTrue(() => Count == 20, 100, msg: $"Expected 20 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 70);
+		AssertEx.IsOrBecomesTrue(() => Count == 20, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 70, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
 		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
 		Assert.Equal(19, GetCheckpoint()[0].Item2);
@@ -190,13 +190,13 @@ public sealed class when_using_read_model_base_with_reader :
 		Start(_stream1, checkPoint1);
 		Start(_stream2, checkPoint2);
 		//add the recorded events 2 on stream 1 & 5 on stream 2
-		AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 50, msg: $"Expected 50 got {Sum}");
+		AssertEx.IsOrBecomesTrue(() => Count == 20, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 50, TestTimeouts.ThrottleWaitFor, msg: $"Expected 50 got {Sum}");
 		//add more messages
 		AppendEvents(10, _conn, _stream1, 5);
 		AppendEvents(10, _conn, _stream2, 7);
-		AssertEx.IsOrBecomesTrue(() => Count == 40, 1000, msg: $"Expected 20 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 170);
+		AssertEx.IsOrBecomesTrue(() => Count == 40, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 170, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
 		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
 		Assert.Equal(19, GetCheckpoint()[0].Item2);
@@ -212,12 +212,12 @@ public sealed class when_using_read_model_base_with_reader :
 		Start(_stream1);
 		Start(_stream1);
 		//double events
-		AssertEx.IsOrBecomesTrue(() => Count == 20, 1000, msg: $"Expected 20 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 40);
+		AssertEx.IsOrBecomesTrue(() => Count == 20, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 40, TestTimeouts.ThrottleWaitFor);
 		//even more doubled events
 		AppendEvents(10, _conn, _stream1, 5);
-		AssertEx.IsOrBecomesTrue(() => Count == 40, 2000, msg: $"Expected 40 got {Count}");
-		AssertEx.IsOrBecomesTrue(() => Sum == 140);
+		AssertEx.IsOrBecomesTrue(() => Count == 40, TestTimeouts.ThrottleWaitFor, msg: $"Expected 40 got {Count}");
+		AssertEx.IsOrBecomesTrue(() => Sum == 140, TestTimeouts.ThrottleWaitFor);
 	}
 
 	public long Sum { get; private set; }

--- a/src/ReactiveDomain.Foundation.Tests/when_using_snapshot_read_model.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_snapshot_read_model.cs
@@ -41,7 +41,7 @@ public sealed class when_using_snapshot_read_model : IClassFixture<StreamStoreCo
 	[Fact]
 	public void can_get_snapshot_from_read_model() {
 		var rm = new TestSnapShotReadModel(_aggId, _configuredConnection, null);
-		AssertEx.IsOrBecomesTrue(() => rm.Count == 10);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 10, TestTimeouts.ThrottleWaitFor);
 		var snapshot = rm.GetState();
 
 		Assert.Equal(nameof(TestSnapShotReadModel), snapshot.ModelName);
@@ -62,35 +62,35 @@ public sealed class when_using_snapshot_read_model : IClassFixture<StreamStoreCo
 			new TestSnapShotReadModel.MyState { Count = 10, Sum = 20 });
 
 		var rm = new TestSnapShotReadModel(_aggId, _configuredConnection, snapshot);
-		AssertEx.IsOrBecomesTrue(() => rm.Count == 10);
-		AssertEx.IsOrBecomesTrue(() => rm.Sum == 20);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 10, TestTimeouts.ThrottleWaitFor);
+		AssertEx.IsOrBecomesTrue(() => rm.Sum == 20, TestTimeouts.ThrottleWaitFor);
 		AppendEvents(1, _conn, _stream, 5);
-		AssertEx.IsOrBecomesTrue(() => rm.Count == 11, 1000);
-		AssertEx.IsOrBecomesTrue(() => rm.Sum == 25);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 11, TestTimeouts.ThrottleWaitFor);
+		AssertEx.IsOrBecomesTrue(() => rm.Sum == 25, TestTimeouts.ThrottleWaitFor);
 	}
 	[Fact]
 	[SuppressMessage("ReSharper", "AccessToDisposedClosure")]
 	public void can_snapshot_and_recover_read_model() {
 		var rm = new TestSnapShotReadModel(_aggId, _configuredConnection, null);
-		AssertEx.IsOrBecomesTrue(() => rm.Count == 10);
-		AssertEx.IsOrBecomesTrue(() => rm.Sum == 20);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 10, TestTimeouts.ThrottleWaitFor);
+		AssertEx.IsOrBecomesTrue(() => rm.Sum == 20, TestTimeouts.ThrottleWaitFor);
 		AppendEvents(1, _conn, _stream, 5);
-		AssertEx.IsOrBecomesTrue(() => rm.Count == 11, 1000);
-		AssertEx.IsOrBecomesTrue(() => rm.Sum == 25);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 11, TestTimeouts.ThrottleWaitFor);
+		AssertEx.IsOrBecomesTrue(() => rm.Sum == 25, TestTimeouts.ThrottleWaitFor);
 		var snap = rm.GetState();
 		rm.Dispose();
 		var rm2 = new TestSnapShotReadModel(_aggId, _configuredConnection, snap);
-		AssertEx.IsOrBecomesTrue(() => rm2.Count == 11, 1000);
-		AssertEx.IsOrBecomesTrue(() => rm2.Sum == 25);
+		AssertEx.IsOrBecomesTrue(() => rm2.Count == 11, TestTimeouts.ThrottleWaitFor);
+		AssertEx.IsOrBecomesTrue(() => rm2.Sum == 25, TestTimeouts.ThrottleWaitFor);
 		AppendEvents(1, _conn, _stream, 5);
-		AssertEx.IsOrBecomesTrue(() => rm2.Count == 12, 1000);
-		AssertEx.IsOrBecomesTrue(() => rm2.Sum == 30);
+		AssertEx.IsOrBecomesTrue(() => rm2.Count == 12, TestTimeouts.ThrottleWaitFor);
+		AssertEx.IsOrBecomesTrue(() => rm2.Sum == 30, TestTimeouts.ThrottleWaitFor);
 	}
 	[Fact]
 	public void can_only_restore_once() {
 		var rm = new TestSnapShotReadModel(_aggId, _configuredConnection, null);
 		// ReSharper disable once AccessToDisposedClosure
-		AssertEx.IsOrBecomesTrue(() => rm.Count == 10);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 10, TestTimeouts.ThrottleWaitFor);
 		var state = rm.GetState();
 		rm.Dispose();
 		//create while forcing double restore
@@ -108,32 +108,32 @@ public sealed class when_using_snapshot_read_model : IClassFixture<StreamStoreCo
 			new TestSnapShotReadModel.MyState { Count = 10, Sum = 20 });
 
 		var rm = new TestSnapShotReadModel(_aggId, _configuredConnection, snapshot);
-		AssertEx.IsOrBecomesTrue(() => rm.Count == 10);
-		AssertEx.IsOrBecomesTrue(() => rm.Sum == 20);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 10, TestTimeouts.ThrottleWaitFor);
+		AssertEx.IsOrBecomesTrue(() => rm.Sum == 20, TestTimeouts.ThrottleWaitFor);
 
 		//n.b. will not start listening because no streams are provided
-		//confirm not listening
+		//confirm not listening (Count is already 10, so this returns immediately without waiting)
 		AppendEvents(1, _conn, _stream, 5);
-		AssertEx.IsOrBecomesTrue(() => rm.Count == 10, 1000);
-		AssertEx.IsOrBecomesTrue(() => rm.Sum == 20);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 10, TestTimeouts.ThrottleWaitFor);
+		AssertEx.IsOrBecomesTrue(() => rm.Sum == 20, TestTimeouts.ThrottleWaitFor);
 
 		//can manually start
 		rm.Start<SnapReadModelTestAggregate>(_aggId, 9, true);
-		AssertEx.IsOrBecomesTrue(() => rm.Count == 11, 1000);
-		AssertEx.IsOrBecomesTrue(() => rm.Sum == 25);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 11, TestTimeouts.ThrottleWaitFor);
+		AssertEx.IsOrBecomesTrue(() => rm.Sum == 25, TestTimeouts.ThrottleWaitFor);
 		AppendEvents(1, _conn, _stream, 5);
-		AssertEx.IsOrBecomesTrue(() => rm.Count == 12, 1000);
-		AssertEx.IsOrBecomesTrue(() => rm.Sum == 30);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 12, TestTimeouts.ThrottleWaitFor);
+		AssertEx.IsOrBecomesTrue(() => rm.Sum == 30, TestTimeouts.ThrottleWaitFor);
 
 		//can still get complete snapshot
 		var snap2 = rm.GetState();
 		//works as expected
 		var rm2 = new TestSnapShotReadModel(_aggId, _configuredConnection, snap2);
-		AssertEx.IsOrBecomesTrue(() => rm2.Count == 12, 1000);
-		AssertEx.IsOrBecomesTrue(() => rm2.Sum == 30);
+		AssertEx.IsOrBecomesTrue(() => rm2.Count == 12, TestTimeouts.ThrottleWaitFor);
+		AssertEx.IsOrBecomesTrue(() => rm2.Sum == 30, TestTimeouts.ThrottleWaitFor);
 		AppendEvents(1, _conn, _stream, 5);
-		AssertEx.IsOrBecomesTrue(() => rm2.Count == 13, 1000);
-		AssertEx.IsOrBecomesTrue(() => rm2.Sum == 35);
+		AssertEx.IsOrBecomesTrue(() => rm2.Count == 13, TestTimeouts.ThrottleWaitFor);
+		AssertEx.IsOrBecomesTrue(() => rm2.Sum == 35, TestTimeouts.ThrottleWaitFor);
 
 	}
 	public sealed class TestSnapShotReadModel :


### PR DESCRIPTION
## Summary

Fixes the intermittent CI flakes in `ReactiveDomain.Foundation.Tests` in the read-model **catch-up / snapshot / IsLive** family (issue #248, milestone 0.15.3). These are the red-CI failures seen on runs like [29659088754](https://github.com/ReactiveDomain/reactive-domain/actions/runs/29659088754); a different test in the family fails each run, which is why it reads as a flake rather than a regression.

Representative failure: `AtLeastModelVersion(rm, 11)` → *"Expected 11 got 0"* — the read model never caught up within the timeout on a 2-core runner.

## Root cause

The catch-up / live / version assertions in this test family used timeouts below what a loaded 2-core CI runner needs:
- **Hardcoded** `100 / 150 / 200 ms` waits (e.g. `can_wait_for_one_stream_to_go_live`, `can_use_checkpoint_on_one_stream`).
- **Default** `1000 ms` `IsOrBecomesTrue` waits (the snapshot tests, listener siblings).
- `TestTimeouts.WaitFor` (**5 s** CI) for the `WaitForCatchUp` barrier — still timed out at ~5 s under load.

None of these scale with CI. The `"got 0 / got 9 / got 11"` signatures are partial/zero progress, i.e. **scheduler starvation**, not slow catch-up.

## Fix

Route every catch-up / live / version wait in the family through the CI-aware `TestTimeouts.ThrottleWaitFor` (**2 s local / 10 s CI**), per the repo's own [`Docs/ci-test-guidance.md`](Docs/ci-test-guidance.md) ("use `TestTimeouts`, not literal timeouts"):

- `when_using_read_model_base(_with_reader).cs`, `when_using_snapshot_read_model.cs`, `when_using_catch_up_connection.cs`, and the `StreamListenerTests` siblings (`CommonHelpers.WaitForStream` + the `start_with_*` tests).
- Collapsed the redundant staged `AtLeastModelVersion(3 → 8 → 12)` checks in `can_use_checkpoint_on_one_stream` to a single `version >= 12` gate.
- Left the **negative** test `timeout_names_the_lagging_stream` on its short 200 ms budget — it asserts that a timeout *fires*.

No production code changed — timing-budget only.

## Regression or contention? (contention)

Not a catch-up performance regression from the merged 0.15.x stack:
- The flaking `when_using_read_model_base` tests **never route through** the new `CatchUpConnection` / `ProjectedEvent` code, yet they flake.
- Failures show zero/partial progress (starvation), not slow completion.
- The `WaitForCatchUp` barrier completes fine once given the documented CI budget.

## Verification

Reproduced locally by pinning the test process + CPU burners to a single core under `GITHUB_ACTIONS=true`:

| Build | Result under identical contention |
|---|---|
| **Old timeouts** | **4 / 8 runs failed** — `can_use_checkpoint_on_one_stream` ("Expected 2 got 0"), `can_wait_for_two_streams_to_go_live` ("Expected 21 got 11"), reader variant ("Expected 10 got 9") |
| **This fix** | **0 / 12 runs failed** (durations 16–25 s confirm the contention was still present) |

Full suite: 154/154 pass (net8.0 and net10.0 build clean); `dotnet format --verify-no-changes` clean.

Closes #248. Note: PR #247 (CheckAssemblyVersion tooling) is also on 0.15.3 and its red CI is this same flake, not that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)