### PR TITLE
Chores: updates multiple NuGet packages.

### DIFF
--- a/src/ReactiveDomain.Core/ReactiveDomain.Core.csproj
+++ b/src/ReactiveDomain.Core/ReactiveDomain.Core.csproj
@@ -10,6 +10,6 @@
     <InternalsVisibleTo Include="ReactiveDomain.Persistence" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
-    <PackageReference Include="System.Reactive" Version="6.1.0" />
+    <PackageReference Include="System.Reactive" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/src/ReactiveDomain.Core/ReactiveDomain.Core.csproj
+++ b/src/ReactiveDomain.Core/ReactiveDomain.Core.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="ReactiveDomain.Persistence" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>
 </Project>

--- a/src/ReactiveDomain.Foundation.Tests/ReactiveDomain.Foundation.Tests.csproj
+++ b/src/ReactiveDomain.Foundation.Tests/ReactiveDomain.Foundation.Tests.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ReactiveDomain.Foundation/ReactiveDomain.Foundation.csproj
+++ b/src/ReactiveDomain.Foundation/ReactiveDomain.Foundation.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.Reactive" Version="6.1.0" />
+    <PackageReference Include="System.Reactive" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ReactiveDomain.Messaging\ReactiveDomain.Messaging.csproj" />

--- a/src/ReactiveDomain.IdentityStorage.Tests/ReactiveDomain.IdentityStorage.Tests.csproj
+++ b/src/ReactiveDomain.IdentityStorage.Tests/ReactiveDomain.IdentityStorage.Tests.csproj
@@ -8,7 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="xunit.runner.console" Version="2.9.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ReactiveDomain.IdentityStorage/ReactiveDomain.IdentityStorage.csproj
+++ b/src/ReactiveDomain.IdentityStorage/ReactiveDomain.IdentityStorage.csproj
@@ -13,10 +13,10 @@
     <PackageReference Include="DynamicData" Version="9.4.33" />
     <PackageReference Include="IdentityModel" Version="4.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.DirectoryServices" Version="10.0.9" />
-    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.9" />
+    <PackageReference Include="System.DirectoryServices" Version="10.0.10" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.10" />
     <PackageReference Include="IdentityServer4.Storage" Version="4.1.2" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="10.0.9" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />

--- a/src/ReactiveDomain.Messaging.Tests/ReactiveDomain.Messaging.Tests.csproj
+++ b/src/ReactiveDomain.Messaging.Tests/ReactiveDomain.Messaging.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageReference Include="System.CodeDom" Version="10.0.9" />
+    <PackageReference Include="System.CodeDom" Version="10.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" PrivateAssets="all" />

--- a/src/ReactiveDomain.Messaging.Tests/ReactiveDomain.Messaging.Tests.csproj
+++ b/src/ReactiveDomain.Messaging.Tests/ReactiveDomain.Messaging.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ReactiveDomain.Messaging.Tests/when_creating_a_message.cs
+++ b/src/ReactiveDomain.Messaging.Tests/when_creating_a_message.cs
@@ -1,5 +1,5 @@
-﻿using ReactiveDomain.Testing;
-using Xunit;
+﻿using Xunit;
+using TestMessage = ReactiveDomain.Testing.TestMessage;
 
 namespace ReactiveDomain.Messaging.Tests;
 

--- a/src/ReactiveDomain.Messaging/ReactiveDomain.Messaging.csproj
+++ b/src/ReactiveDomain.Messaging/ReactiveDomain.Messaging.csproj
@@ -7,7 +7,7 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" PrivateAssets="all" />
-		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.9" />
+		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.10" />
 		<PackageReference Include="System.Reactive" Version="6.1.0" />
 		<ProjectReference Include="..\ReactiveDomain.Core\ReactiveDomain.Core.csproj" />
 	</ItemGroup>

--- a/src/ReactiveDomain.Messaging/ReactiveDomain.Messaging.csproj
+++ b/src/ReactiveDomain.Messaging/ReactiveDomain.Messaging.csproj
@@ -8,7 +8,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" PrivateAssets="all" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.10" />
-		<PackageReference Include="System.Reactive" Version="6.1.0" />
+		<PackageReference Include="System.Reactive" Version="7.0.0" />
 		<ProjectReference Include="..\ReactiveDomain.Core\ReactiveDomain.Core.csproj" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/ReactiveDomain.Policy.Tests/ReactiveDomain.Policy.Tests.csproj
+++ b/src/ReactiveDomain.Policy.Tests/ReactiveDomain.Policy.Tests.csproj
@@ -12,7 +12,7 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="xunit.runner.console" Version="2.9.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ReactiveDomain.PolicyStorage.Tests/ReactiveDomain.PolicyStorage.Tests.csproj
+++ b/src/ReactiveDomain.PolicyStorage.Tests/ReactiveDomain.PolicyStorage.Tests.csproj
@@ -17,7 +17,7 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="xunit.runner.console" Version="2.9.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ReactiveDomain.PolicyStorage/ReactiveDomain.PolicyStorage.csproj
+++ b/src/ReactiveDomain.PolicyStorage/ReactiveDomain.PolicyStorage.csproj
@@ -9,9 +9,9 @@
 		<PackageReference Include="DynamicData" Version="9.4.33" />
 		<PackageReference Include="IdentityModel" Version="4.6.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="System.DirectoryServices" Version="10.0.9" />
-		<PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.9" />
-		<PackageReference Include="System.Text.Encodings.Web" Version="10.0.9" />
+		<PackageReference Include="System.DirectoryServices" Version="10.0.10" />
+		<PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.10" />
+		<PackageReference Include="System.Text.Encodings.Web" Version="10.0.10" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />

--- a/src/ReactiveDomain.PolicyTool/ReactiveDomain.PolicyTool.csproj
+++ b/src/ReactiveDomain.PolicyTool/ReactiveDomain.PolicyTool.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
 		<PackageReference Include="EventStore.Client" Version="22.0.0" />
-		<PackageReference Include="System.CommandLine" Version="2.0.9" />
+		<PackageReference Include="System.CommandLine" Version="2.0.10" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\ReactiveDomain.IdentityStorage\ReactiveDomain.IdentityStorage.csproj" />

--- a/src/ReactiveDomain.PolicyTool/ReactiveDomain.PolicyTool.csproj
+++ b/src/ReactiveDomain.PolicyTool/ReactiveDomain.PolicyTool.csproj
@@ -9,8 +9,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
 		<PackageReference Include="EventStore.Client" Version="22.0.0" />
 		<PackageReference Include="System.CommandLine" Version="2.0.9" />
 	</ItemGroup>

--- a/src/ReactiveDomain.Testing.Tests/ReactiveDomain.Testing.Tests.csproj
+++ b/src/ReactiveDomain.Testing.Tests/ReactiveDomain.Testing.Tests.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="KurrentDB.Client" Version="1.4.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/ReactiveDomain.Testing/ReactiveDomain.Testing.csproj
+++ b/src/ReactiveDomain.Testing/ReactiveDomain.Testing.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
 	  <PackageReference Include="xunit" Version="2.9.3" />
 	  <PackageReference Include="xunit.runner.utility" Version="2.9.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ReactiveDomain.Foundation\ReactiveDomain.Foundation.csproj" />

--- a/src/ReactiveDomain.Testing/ReactiveDomain.Testing.csproj
+++ b/src/ReactiveDomain.Testing/ReactiveDomain.Testing.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
   <ItemGroup>
 	  <PackageReference Include="xunit" Version="2.9.3" />
+	  <PackageReference Include="xunit.runner.utility" Version="2.9.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ReactiveDomain.Transport.Tests/ReactiveDomain.Transport.Tests.csproj
+++ b/src/ReactiveDomain.Transport.Tests/ReactiveDomain.Transport.Tests.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="xunit.runner.console" Version="2.9.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Updates multiple from 10.0.9 to 10.0.10:
  - System.Configuration.ConfigurationManager
  - System.DirectoryServices
  - System.DirectoryServices.AccountManagement
  - System.Text.Encodings.Web, System.CodeDom
  - System.Diagnostics.PerformanceCounter
  - Microsoft.Extensions.Configuration.*
- Adds xunit.runner.utility ref to Testing project. This resolves an issue with the nCruch test framework.
- Updates System.CommandLine NuGet package from 2.0.9 to 2.0.10.
- Updates the Microsoft.NET.Test.Sdk NuGet package from version 18.7.0 to 18.8.1.
- Updates the System.Reactive NuGet package from 6.1.0 to 7.0.0.