### PR TITLE
Short-circuits Save when aggregate has no events

### DIFF
--- a/src/ReactiveDomain.Core/IEventSource.cs
+++ b/src/ReactiveDomain.Core/IEventSource.cs
@@ -34,8 +34,13 @@ public interface IEventSource {
 	void UpdateWithEvents(IEnumerable<object> events, long expectedVersion);
 
 	/// <summary>
-	/// Takes the recorded history of events from this instance (CQS violation, beware).
+	/// Takes the recorded history of events from this instance (CQRS violation, beware).
 	/// </summary>
 	/// <returns>The recorded events.</returns>
 	object[] TakeEvents();
+
+	/// <summary>
+	/// Indicates whether this instance has any recorded events.
+	/// </summary>
+	bool HasRecordedEvents { get; }
 }

--- a/src/ReactiveDomain.Foundation.Tests/StreamStoreRepositoryIntegrationTests.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamStoreRepositoryIntegrationTests.cs
@@ -88,7 +88,6 @@ public class StreamStoreRepositoryIntegrationTests {
 
 		var agg2 = _repo.GetById<TestWoftamAggregate>(savedId);
 		Assert.Equal(200, agg2.AppliedEventCount);
-
 	}
 
 	[Fact]
@@ -106,6 +105,16 @@ public class StreamStoreRepositoryIntegrationTests {
 		_repo.Save(aggregateToSave);
 
 		Assert.Empty(((IEventSource)aggregateToSave).TakeEvents());
+	}
+
+	[Fact]
+	public void SaveWithNoEventsProducesNoAppliedEvents() {
+		var savedId = SaveTestAggregateWithoutCustomHeaders(_repo, 0 /* excludes TestAggregateCreated */);
+
+		var agg = _repo.GetById<TestWoftamAggregate>(savedId);
+		_repo.Save(agg);
+
+		Assert.Equal(0, agg.AppliedEventCount);
 	}
 
 	[Fact]

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamStoreRepository.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamStoreRepository.cs
@@ -126,6 +126,8 @@ public class StreamStoreRepository : IRepository {
 	}
 
 	public void Save(IEventSource aggregate) {
+		if (!aggregate.HasRecordedEvents)
+			return;
 		var commitHeaders = new Dictionary<string, object>
 		{
 			{CommitIdHeader, Guid.NewGuid() /*commitId*/},


### PR DESCRIPTION
**What does this pull request do?**
Optimizes saving to a `StreamStoreRepository` when no events have been recorded on the aggregate being saved.

**How does this pull request accomplish that goal?**
`StreamStoreRepository` exits as soon as possible if the aggregate being saved has no recorded events. This avoids a bunch of code that generates the headers and does other work to prepare for and commit the appended events, none of which is necessary when there are none.

**Why is this pull request important?**
Speeds up `Save` and further eliminates the need for callers to check for recorded events before calling `Save`.

**Link to any issues that this resolves**
Fixes #263

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports
- [x] Any new code must be covered by at least one unit test
- [x] All public methods must be documented with XML comments