### PR TITLE
Make the duplicate-subscription check in InMemoryBus actually fire

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# ReactiveDomain
+
+Event-sourcing and CQRS framework, published as NuGet packages. Every change to a public surface is
+a change to a consumer's build, and consumers are not all visible from this repo.
+
+## Build & Test
+
+```bash
+dotnet build src/ReactiveDomain.sln -c Release
+dotnet test src/ReactiveDomain.sln -c Release --no-build
+dotnet format src/ReactiveDomain.sln --verify-no-changes --no-restore
+```
+
+All three are CI gates. The format check is the one most easily forgotten and it fails the build
+like any other.
+
+Libraries and tests multi-target `net8.0;net10.0` (`src/build.props`). Both must pass — see
+`CONTRIBUTING.md`. **Install both SDKs.** With only .NET 10 present, `dotnet test` silently runs
+net10.0 alone and reports green; the net8.0 half fails as `Testhost process ... exited with error:
+You must install or update .NET to run this application` only if you ask for it by name. Check
+`dotnet --list-sdks` before trusting a green run.
+
+## Comments
+
+Write only what the code cannot say. The test: delete the comment and ask what a reader loses. If
+the answer is nothing, leave it deleted.
+
+**Do not write**
+
+- The member's own name or signature in prose — `/// Registers handler for T` above
+  `Subscribe<T>(IHandle<T> handler)`.
+- The line underneath — `/// Adds it unless already present` above `if (present) return;`.
+- Why the previous version was wrong, or what a change fixed. That is the commit message's job; a
+  comment is read by someone who never saw the old code and does not know a PR happened.
+- A test's own name. The name states the contract; a comment adds only what the name cannot hold.
+
+**Do write**
+
+- Contracts a caller cannot infer from the signature: idempotence, ordering, thread-safety,
+  lifetime, what a returned handle owns. In a published library this is most of the value — the
+  caller has the XML docs and not the source.
+- Traps — where the obvious edit is wrong, and why. If a line would look like a mistake to someone
+  cleaning up, say why it is not.
+- Non-local constraints: what this must stay consistent with, and where that lives.
+
+**Keep them short — a comment scrolls code off the screen.** A four-line block above a three-line
+method means the method no longer fits on screen with its callers. Put the text on one line
+(`/// <summary>…</summary>`) whenever it fits.
+
+**A signal, not a gate:** when a diff's comment lines outnumber its code lines, the comments are
+usually restating. Re-read them before committing.
+
+## XML docs
+
+`CONTRIBUTING.md` requires XML comments on every public method. That stands — this governs what they
+say, not whether to write them. A method fully described by its own name still gets the tag; keep it
+to one line.
+
+These ship in the NuGet packages and are what a consumer sees in Intellisense, so write for the
+tooltip:
+
+- `<summary>` is the minimum. Never write `<param>`, `<typeparam>`, `<returns>` or `<remarks>`
+  without one.
+- The summary says what the member does in the normal case, in the caller's terms — not how it
+  behaves in an edge case. Idempotence, ordering, thread-safety, cost and worked examples go in
+  `<remarks>`.
+- One or two lines. A tooltip does not wrap until it is already too wide to read comfortably. If a
+  summary genuinely needs more, split it with `<para>` and keep each paragraph short.
+- Where several members do the same job by different routes, each says when to choose it and links
+  the alternatives with `<see cref="..."/>`. A signature does not convey a cost difference.
+- No reference to a previous implementation, explicit ("now", "no longer", "previously") or
+  elliptical ("unchanged", "untouched", "buckets, not places"). Comparing two things that both exist
+  is fine; comparing against what the code used to do is not.
+- `<exception>` for anything a caller is expected to catch.
+
+`CONTRIBUTING.md`'s Documentation Guidelines carry the same rules for human contributors, with a
+worked before/after example. Keep the two in step.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,4 +22,66 @@ We welcome well-considered feature requests. For **major features**, please enga
 When submitting a Pull Request, keep these rules in mind:
 - All unit tests in the solution must pass on all versions of .NET that the solution supports
 - Any new code must be covered by at least one unit test
-- All public methods must be documented with XML comments
+- All public methods must be documented with XML comments, following the [documentation guidelines](#docs) below
+
+### <a href="docs"></a>Documentation Guidelines
+RD ships its XML docs in its NuGet packages. They are what a consumer sees in Intellisense, so
+write for the tooltip, not for someone reading the source.
+
+**Tags**
+- `<summary>` is the minimum for a public member.
+- `<param>`, `<typeparam>`, `<returns>`, `<remarks>` are a bonus. Never write one without a `<summary>`.
+- `<exception>` for anything a caller is expected to catch.
+
+**What goes in `<summary>`**
+
+What the member does, in the caller's terms, for the normal case. One or two lines — an
+Intellisense tooltip does not wrap until it is already too wide to read comfortably.
+
+Edge cases, idempotence, threading, ordering, cost, and worked examples go in `<remarks>`. If a
+summary genuinely needs more than two lines, split it with `<para>` and keep each paragraph short.
+
+Bad — the summary is entirely edge case, and the reader still does not learn what the method does:
+
+```csharp
+/// <summary>
+/// Subscribing the same handler again for the same <typeparamref name="T"/> is a no-op — a
+/// subscription is a set, not a count, so any one of the returned disposers releases it.
+/// Subscribing it for a <i>different</i> <typeparamref name="T"/> is a separate subscription:
+/// a handler registered for both a base and a derived type is called once through each.
+/// </summary>
+public IDisposable Subscribe<T>(IHandle<T> handler, bool includeDerived = true)
+```
+
+Good:
+
+```csharp
+/// <summary>
+/// Subscribes <paramref name="handler"/> to messages of type <typeparamref name="T"/>, and by
+/// default to types derived from it.
+/// </summary>
+/// <remarks>
+/// Subscribing the same handler again for the same <typeparamref name="T"/> is a no-op — a
+/// subscription is a set, not a count, so any one of the returned disposers releases it.
+/// Subscribing it for a <i>different</i> <typeparamref name="T"/> is a separate subscription:
+/// a handler registered for both a base and a derived type is called once through each.
+/// </remarks>
+public IDisposable Subscribe<T>(IHandle<T> handler, bool includeDerived = true)
+```
+
+**Overlapping APIs**
+
+Where more than one public member does the same job by a different route, each one's docs say when
+to choose it and link the alternatives with `<see cref="..."/>`. Signatures alone do not convey a
+cost difference — a consumer choosing between `ReadModelBase.Start<T>()`, `Start(string)` and a
+shared `CategoryStream` has no way to tell what each one costs.
+
+**Write about the code as it is**
+
+No reference to a previous implementation, whether explicit ("now", "no longer", "changed to",
+"previously") or elliptical ("buckets, not places"). Source control is the history.
+
+This applies to ordinary comments as well as XML docs. It does not bar comparisons between things
+that both exist — saying how a member differs from its sibling is useful.
+
+The summary/remarks split applies wherever XML docs appear, public or not.

--- a/src/ReactiveDomain.Messaging.Tests/when_subscribing_the_same_handler_more_than_once.cs
+++ b/src/ReactiveDomain.Messaging.Tests/when_subscribing_the_same_handler_more_than_once.cs
@@ -1,0 +1,134 @@
+﻿using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using Xunit;
+
+namespace ReactiveDomain.Messaging.Tests;
+
+// ReSharper disable once InconsistentNaming
+public sealed class when_subscribing_the_same_handler_more_than_once {
+	[Fact]
+	public void duplicate_subscriptions_are_idempotent() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handled = 0;
+		var handler = new AdHocHandler<ParentTestMessage>(_ => handled++);
+
+		bus.Subscribe(handler);
+		bus.Subscribe(handler);
+		bus.Publish(new ParentTestMessage());
+
+		Assert.Equal(1, handled);
+	}
+
+	/// <summary>The guard runs against every slot a registration covers, not just the declared one.</summary>
+	[Fact]
+	public void duplicate_subscriptions_are_idempotent_for_derived_types_too() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handled = 0;
+		var handler = new AdHocHandler<ParentTestMessage>(_ => handled++);
+
+		bus.Subscribe(handler);
+		bus.Subscribe(handler);
+		bus.Publish(new ChildTestMessage());
+
+		Assert.Equal(1, handled);
+	}
+
+	[Fact]
+	public void the_same_handler_for_a_base_and_a_derived_type_stays_two_registrations() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handler = new BothLevels();
+
+		bus.Subscribe<ParentTestMessage>(handler);
+		bus.Subscribe<ChildTestMessage>(handler);
+		bus.Publish(new ChildTestMessage());
+
+		Assert.Equal(1, handler.AsParent);
+		Assert.Equal(1, handler.AsChild);
+	}
+
+	[Fact]
+	public void unsubscribing_a_derived_registration_leaves_the_base_registration() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handler = new BothLevels();
+
+		bus.Subscribe<ParentTestMessage>(handler);
+		bus.Subscribe<ChildTestMessage>(handler);
+		bus.Unsubscribe<ChildTestMessage>(handler);
+		bus.Publish(new ChildTestMessage());
+
+		Assert.Equal(1, handler.AsParent);
+		Assert.Equal(0, handler.AsChild);
+	}
+
+	[Fact]
+	public void resubscribing_after_unsubscribing_registers_again() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handled = 0;
+		var handler = new AdHocHandler<ParentTestMessage>(_ => handled++);
+
+		bus.Subscribe(handler);
+		bus.Unsubscribe(handler);
+		bus.Subscribe(handler);
+		bus.Publish(new ParentTestMessage());
+
+		Assert.Equal(1, handled);
+	}
+
+	[Fact]
+	public void either_disposer_releases_the_single_registration() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handled = 0;
+		var handler = new AdHocHandler<ParentTestMessage>(_ => handled++);
+
+		var first = bus.Subscribe(handler);
+		var second = bus.Subscribe(handler);
+
+		second.Dispose();
+		bus.Publish(new ParentTestMessage());
+		Assert.Equal(0, handled);
+
+		first.Dispose();
+		bus.Publish(new ParentTestMessage());
+		Assert.Equal(0, handled);
+	}
+
+	[Fact]
+	public void duplicate_subscribe_to_all_is_idempotent() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handled = 0;
+		var handler = new AdHocHandler<IMessage>(_ => handled++);
+
+		bus.SubscribeToAll(handler);
+		bus.SubscribeToAll(handler);
+		bus.Publish(new ParentTestMessage());
+
+		Assert.Equal(1, handled);
+	}
+
+	[Fact]
+	public void subscribing_to_all_and_to_a_type_delivers_through_both() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handler = new AnyAndParent();
+
+		bus.SubscribeToAll(handler);
+		bus.Subscribe<ParentTestMessage>(handler);
+		bus.Publish(new ParentTestMessage());
+
+		Assert.Equal(1, handler.AsAny);
+		Assert.Equal(1, handler.AsParent);
+	}
+
+	private sealed class AnyAndParent : IHandle<IMessage>, IHandle<ParentTestMessage> {
+		public int AsAny;
+		public int AsParent;
+		public void Handle(IMessage message) => AsAny++;
+		public void Handle(ParentTestMessage message) => AsParent++;
+	}
+
+	private sealed class BothLevels : IHandle<ParentTestMessage>, IHandle<ChildTestMessage> {
+		public int AsParent;
+		public int AsChild;
+		public void Handle(ParentTestMessage message) => AsParent++;
+		public void Handle(ChildTestMessage message) => AsChild++;
+	}
+}

--- a/src/ReactiveDomain.Messaging/Bus/InMemoryBus.cs
+++ b/src/ReactiveDomain.Messaging/Bus/InMemoryBus.cs
@@ -53,21 +53,37 @@ public class InMemoryBus : IBus, ISubscriber, IPublisher, IHandle<IMessage>, IDi
 		}
 	}
 
+	/// <summary>
+	/// Subscribes <paramref name="handler"/> to messages of type <typeparamref name="T"/>, and by
+	/// default to types derived from it.
+	/// </summary>
+	/// <remarks>
+	/// Subscribing the same handler again for the same <typeparamref name="T"/> is a no-op — a
+	/// subscription is a set, not a count, so any one of the returned disposers releases it.
+	/// Subscribing it for a <i>different</i> <typeparamref name="T"/> is a separate subscription:
+	/// a handler registered for both a base and a derived type is called once through each.
+	/// </remarks>
 	public IDisposable Subscribe<T>(IHandle<T> handler, bool includeDerived = true) where T : class, IMessage {
 		Ensure.NotNull(handler, "handler");
-		Subscribe(new MessageHandler<T>(handler, handler.GetType().Name), includeDerived);
+		Subscribe(new MessageHandler<T>(handler, handler.GetType().Name), handler, includeDerived);
 		return new Disposer(() => { Unsubscribe(handler); return Unit.Default; });
 	}
 
-	private void Subscribe(IMessageHandler handler, bool includeDerived) {
+	private void Subscribe(IMessageHandler handler, object rawHandler, bool includeDerived) {
 		var messageTypes = includeDerived
 			? MessageHierarchy.DescendantsAndSelf(handler.MessageType).ToArray()
 			: [handler.MessageType];
 		for (var i = 0; i < messageTypes.Length; i++) {
-			Subscribe(handler, messageTypes[i]);
+			Subscribe(handler, rawHandler, messageTypes[i]);
 		}
 	}
 
+	/// <summary>Subscribes <paramref name="handler"/> to every known message type.</summary>
+	/// <remarks>
+	/// Idempotent per handler; one that also subscribes to a type is called through both. The types
+	/// are taken from the message hierarchy as it stands when this is called, so a type first seen
+	/// afterwards — from an assembly loaded later — does not reach this handler.
+	/// </remarks>
 	public IDisposable SubscribeToAll(IHandle<IMessage> handler) {
 		Ensure.NotNull(handler, "handler");
 		var allHandler = new MessageHandler<IMessage>(handler, handler.GetType().Name);
@@ -75,21 +91,31 @@ public class InMemoryBus : IBus, ISubscriber, IPublisher, IHandle<IMessage>, IDi
 		var messageTypes = MessageHierarchy.DescendantsAndSelf(typeof(object)).ToArray();
 
 		for (var i = 0; i < messageTypes.Length; i++) {
-			Subscribe(allHandler, messageTypes[i]);
+			Subscribe(allHandler, handler, messageTypes[i]);
 		}
 		return new Disposer(() => { Unsubscribe(handler); return Unit.Default; });
 	}
-	private void Subscribe(IMessageHandler handler, Type messageType) {
-		var handlers = GetHandlesFor(messageType);
-		if (!handlers.Any(hndl => hndl.IsSame(messageType, handler))) {
-			lock (_handlers) {
-				if (!_handlers.TryGetValue(messageType, out var handleList)) {
-					handleList = new List<IMessageHandler>();
-					_handlers.Add(messageType, handleList);
-				}
 
-				handleList.Add(handler);
+	/// <summary>
+	/// Adds <paramref name="handler"/> to the handler list for <paramref name="messageType"/>, unless
+	/// <paramref name="rawHandler"/> is already registered there for <paramref name="handler"/>'s own
+	/// message type.
+	/// </summary>
+	/// <remarks>
+	/// Duplicates are matched on <c>handler.MessageType</c>, not <paramref name="messageType"/>. This
+	/// runs once per slot a registration covers, so matching the slot would read a base-type and a
+	/// derived-type registration of one handler as duplicates of each other.
+	/// </remarks>
+	private void Subscribe(IMessageHandler handler, object rawHandler, Type messageType) {
+		lock (_handlers) {
+			if (!_handlers.TryGetValue(messageType, out var handleList)) {
+				handleList = new List<IMessageHandler>();
+				_handlers.Add(messageType, handleList);
+			} else if (handleList.Any(hndl => hndl.IsSame(handler.MessageType, rawHandler))) {
+				return;
 			}
+
+			handleList.Add(handler);
 		}
 	}
 


### PR DESCRIPTION
**What does this pull request do?**

Repairs the duplicate-registration guard in `InMemoryBus.Subscribe`, which has never been able to
return true. Subscribing the same handler twice for the same type currently registers it twice, so
it receives every matching message twice.

A second, unrelated commit adds a `CLAUDE.md` — the repo has none, and a session working here
cannot infer the test gate correctly (see below).

**How does this pull request accomplish that goal?**

The guard is `handlers.Any(hndl => hndl.IsSame(messageType, handler))`, but `handler` there is the
`MessageHandler<T>` wrapper just constructed, while `IsSame` compares against an existing entry's
*inner* handler. Those are never the same object. `Unsubscribe` is the only caller that passes a raw
handler, which is why the predicate reads correctly in isolation.

The caller's handler is now threaded through the two private `Subscribe` overloads so the comparison
is inner against inner, and it is matched against `handler.MessageType` — the declared type of the
incoming registration — rather than `messageType`, the slot being written.

Both halves of that identity matter. The guard runs once per slot a registration covers, so matching
on the slot would treat a base-type and a derived-type registration of one handler as duplicates of
each other. Those are two subscriptions dispatching to two different `Handle` overloads and both must
fire; only an exact repeat of the same handler for the same declared type is dropped.

While in there: the check read a snapshot taken outside the lock it then added under, so two
concurrent subscribes could both pass it and both add. Lookup, check and add are now in one lock,
which also drops the array copy `GetHandlesFor` was making.

**Why is this pull request important?**

The behaviour it removes is silent. A handler registered twice runs twice per message, and if it
increments, appends, or projects, the duplicate lands in state with nothing to indicate it. The guard
existing at all says this was meant to be idempotent.

Low risk to land: instrumented to log every suppression and ran the full suite — **zero
suppressions**, so no current code takes the new path. Nothing in this repo subscribes a handler
twice for one type today.

The `CLAUDE.md` covers two things a session cannot infer. Tests multi-target `net8.0` and `net10.0`,
but with only the .NET 10 SDK installed `dotnet test` runs net10.0 alone and reports green — nothing
says the other half never ran, so "all tests pass" can be reported honestly and be wrong. That bit me
in this PR. The rest is a comment rule: write what the code cannot say, not the member's own
signature and not why an earlier version was wrong. It is explicit that CONTRIBUTING's
document-every-public-method requirement stands and this only governs what those comments say.

**Link to any issues that this resolves**

This does not address any open issues.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports — 439 on `net8.0` and 439 on `net10.0`
- [x] Any new code must be covered by at least one unit test — 8 in `when_subscribing_the_same_handler_more_than_once`, covering idempotence on the declared type and on covered derived slots, `SubscribeToAll`, that base/derived and subscribe-to-all/typed registrations stay distinct, disposer behaviour, and unsubscribe/resubscribe
- [x] All public methods must be documented with XML comments

---
_Generated by [Claude Code](https://claude.ai/code/session_01CouwhnZYDFQ1xsfiLiCg2j)_