### PR TITLE
Feed a queued subscriber's queue once per message, not once per registration

### DIFF
--- a/src/ReactiveDomain.Messaging.Tests/when_a_queued_subscriber_covers_a_type_more_than_once.cs
+++ b/src/ReactiveDomain.Messaging.Tests/when_a_queued_subscriber_covers_a_type_more_than_once.cs
@@ -1,0 +1,153 @@
+﻿using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using Xunit;
+
+namespace ReactiveDomain.Messaging.Tests;
+
+// ReSharper disable once InconsistentNaming
+public sealed class when_a_queued_subscriber_covers_a_type_more_than_once {
+	private sealed class Subscriber : QueuedSubscriber {
+		public int Parent, Child, GrandChild;
+		private readonly IDisposable? _parentSub, _childSub;
+
+		public Subscriber(IBus bus, bool idempotent = false, bool grandChild = false) : base(bus, idempotent) {
+			_parentSub = Subscribe(new AdHocHandler<ParentTestMessage>(_ => Interlocked.Increment(ref Parent)));
+			_childSub = Subscribe(new AdHocHandler<ChildTestMessage>(_ => Interlocked.Increment(ref Child)));
+			if (grandChild)
+				Subscribe(new AdHocHandler<GrandChildTestMessage>(_ => Interlocked.Increment(ref GrandChild)));
+		}
+
+		public void DropParent() => _parentSub?.Dispose();
+		public void DropChild() => _childSub?.Dispose();
+	}
+
+	/// <summary>Reads counters only after the queue has drained, since delivery is asynchronous.</summary>
+	private static void Settle(Subscriber s, Func<bool> reached) {
+		AssertEx.IsOrBecomesTrue(reached, TestTimeouts.WaitFor);
+		AssertEx.IsOrBecomesTrue(() => s.Starving, TestTimeouts.WaitFor);
+	}
+
+	[Fact]
+	public void a_message_is_delivered_once_per_handler() {
+		using var bus = new InMemoryBus(nameof(when_a_queued_subscriber_covers_a_type_more_than_once));
+		using var sub = new Subscriber(bus);
+
+		bus.Publish(new ChildTestMessage());
+		Settle(sub, () => sub.Child == 1);
+
+		Assert.Equal(1, sub.Parent);
+		Assert.Equal(1, sub.Child);
+	}
+
+	[Fact]
+	public void a_chain_of_covered_types_is_delivered_once_per_handler() {
+		using var bus = new InMemoryBus(nameof(when_a_queued_subscriber_covers_a_type_more_than_once));
+		using var sub = new Subscriber(bus, grandChild: true);
+
+		bus.Publish(new GrandChildTestMessage());
+		Settle(sub, () => sub.GrandChild == 1);
+
+		Assert.Equal(1, sub.Parent);
+		Assert.Equal(1, sub.Child);
+		Assert.Equal(1, sub.GrandChild);
+	}
+
+	[Fact]
+	public void dropping_the_covering_subscription_leaves_the_others_receiving() {
+		using var bus = new InMemoryBus(nameof(when_a_queued_subscriber_covers_a_type_more_than_once));
+		using var sub = new Subscriber(bus);
+
+		sub.DropParent();
+		bus.Publish(new ChildTestMessage());
+		Settle(sub, () => sub.Child == 1);
+
+		Assert.Equal(0, sub.Parent);
+		Assert.Equal(1, sub.Child);
+	}
+
+	[Fact]
+	public void dropping_a_covered_subscription_leaves_the_covering_one_receiving() {
+		using var bus = new InMemoryBus(nameof(when_a_queued_subscriber_covers_a_type_more_than_once));
+		using var sub = new Subscriber(bus);
+
+		sub.DropChild();
+		bus.Publish(new ChildTestMessage());
+		Settle(sub, () => sub.Parent == 1);
+
+		Assert.Equal(1, sub.Parent);
+		Assert.Equal(0, sub.Child);
+	}
+
+	/// <summary>
+	/// Parent covered both others, so the feed must be re-elected on release, not handed back to
+	/// each type it displaced — that would deliver to the grandchild handler twice.
+	/// </summary>
+	[Fact]
+	public void handing_the_feed_back_to_a_chain_still_delivers_once() {
+		using var bus = new InMemoryBus(nameof(when_a_queued_subscriber_covers_a_type_more_than_once));
+		using var sub = new Subscriber(bus, grandChild: true);
+
+		sub.DropParent();
+		bus.Publish(new GrandChildTestMessage());
+		Settle(sub, () => sub.GrandChild == 1);
+
+		Assert.Equal(0, sub.Parent);
+		Assert.Equal(1, sub.Child);
+		Assert.Equal(1, sub.GrandChild);
+	}
+
+	/// <summary>Idempotent subscribers already masked the duplicate, so they are the regression risk.</summary>
+	[Fact]
+	public void an_idempotent_subscriber_is_unaffected() {
+		using var bus = new InMemoryBus(nameof(when_a_queued_subscriber_covers_a_type_more_than_once));
+		using var sub = new Subscriber(bus, idempotent: true);
+
+		bus.Publish(new ChildTestMessage());
+		Settle(sub, () => sub.Child == 1);
+
+		Assert.Equal(1, sub.Parent);
+		Assert.Equal(1, sub.Child);
+	}
+
+	[Fact]
+	public void disposing_the_subscriber_twice_after_dropping_a_subscription_does_not_throw() {
+		using var bus = new InMemoryBus(nameof(when_a_queued_subscriber_covers_a_type_more_than_once));
+		var sub = new Subscriber(bus);
+
+		sub.DropParent();
+		sub.Dispose();
+		sub.Dispose();
+
+		// Dispose drops the subscriptions before returning, so the publish cannot even enqueue.
+		bus.Publish(new ChildTestMessage());
+
+		Assert.Equal(0, sub.Child);
+	}
+
+	/// <summary>The shared feed is held by a count, not a flag.</summary>
+	[Fact]
+	public void dropping_one_of_two_handlers_on_a_type_leaves_the_other_receiving() {
+		using var bus = new InMemoryBus(nameof(when_a_queued_subscriber_covers_a_type_more_than_once));
+		using var sub = new TwoOnOneType(bus);
+
+		sub.DropFirst();
+		bus.Publish(new ParentTestMessage());
+		AssertEx.IsOrBecomesTrue(() => sub.Second == 1, TestTimeouts.WaitFor);
+		AssertEx.IsOrBecomesTrue(() => sub.Starving, TestTimeouts.WaitFor);
+
+		Assert.Equal(0, sub.First);
+		Assert.Equal(1, sub.Second);
+	}
+
+	private sealed class TwoOnOneType : QueuedSubscriber {
+		public int First, Second;
+		private readonly IDisposable _firstSub;
+
+		public TwoOnOneType(IBus bus) : base(bus) {
+			_firstSub = Subscribe(new AdHocHandler<ParentTestMessage>(_ => Interlocked.Increment(ref First)));
+			Subscribe(new AdHocHandler<ParentTestMessage>(_ => Interlocked.Increment(ref Second)));
+		}
+
+		public void DropFirst() => _firstSub.Dispose();
+	}
+}

--- a/src/ReactiveDomain.Messaging/Bus/QueuedSubscriber.cs
+++ b/src/ReactiveDomain.Messaging/Bus/QueuedSubscriber.cs
@@ -5,6 +5,8 @@ namespace ReactiveDomain.Messaging.Bus;
 
 public abstract class QueuedSubscriber : IMessageRegistry, IDisposable {
 	private readonly List<IDisposable> _subscriptions = [];
+	private readonly Dictionary<Type, Feed> _feeds = [];
+	private readonly object _feedLock = new();
 
 	private readonly QueuedHandler _messageQueue;
 	private readonly IBus _externalBus;
@@ -72,28 +74,93 @@ public abstract class QueuedSubscriber : IMessageRegistry, IDisposable {
 	}
 
 	public IDisposable Subscribe<T>(IHandle<T> handler) where T : class, IMessage {
-		var internalSub = _internalBus.Subscribe(handler);
-		var externalSub = _externalBus.Subscribe(new AdHocHandler<T>(_messageQueue.Handle));
-		_subscriptions.Add(internalSub);
-		_subscriptions.Add(externalSub);
+		return Register<T>(_internalBus.Subscribe(handler));
+	}
+
+	public IDisposable Subscribe<T>(IHandleCommand<T> handler) where T : class, ICommand {
+		return Register<T>(_internalBus.Subscribe(new CommandHandler<T>(_externalBus, handler)));
+	}
+
+	/// <summary>The returned handle drops this registration and its share of the feed, nothing else.</summary>
+	private IDisposable Register<T>(IDisposable internalSub) where T : class, IMessage {
+		lock (_feedLock) {
+			_subscriptions.Add(internalSub);
+			Claim(typeof(T), () => _externalBus.Subscribe(new AdHocHandler<T>(_messageQueue.Handle)));
+		}
 		return new Disposer(() => {
-			internalSub.Dispose();
-			externalSub.Dispose();
+			lock (_feedLock) {
+				internalSub.Dispose();
+				_subscriptions.Remove(internalSub);
+				Release(typeof(T));
+			}
 			return Unit.Default;
 		});
 	}
 
-	public IDisposable Subscribe<T>(IHandleCommand<T> handler) where T : class, ICommand {
-		var internalSub = _internalBus.Subscribe(new CommandHandler<T>(_externalBus, handler));
-		var externalSub = _externalBus.Subscribe(new AdHocHandler<T>(_messageQueue.Handle));
-		_subscriptions.Add(internalSub);
-		_subscriptions.Add(externalSub);
-		return new Disposer(() => {
-			internalSub.Dispose();
-			externalSub.Dispose();
-			return Unit.Default;
-		});
+	/// <summary>
+	/// One external-bus subscription feeding the queue, shared by every handler declared for this
+	/// type. <see cref="Attach"/> is a factory because the type is only known generically at
+	/// <c>Subscribe</c>, and a feed dropped as covered may have to come back.
+	/// </summary>
+	private sealed class Feed {
+		public Feed(Func<IDisposable> attach) => Attach = attach;
+		public readonly Func<IDisposable> Attach;
+		public IDisposable? Subscription;
+		public int Handlers;
 	}
+
+	private void Claim(Type declared, Func<IDisposable> attach) {
+		if (!_feeds.TryGetValue(declared, out var feed))
+			_feeds.Add(declared, feed = new Feed(attach));
+		feed.Handlers++;
+		Reconcile();
+	}
+
+	private void Release(Type declared) {
+		if (!_feeds.TryGetValue(declared, out var feed))
+			return;
+		feed.Handlers--;
+		Reconcile();
+	}
+
+	/// <summary>
+	/// Holds one subscription per <i>maximal</i> live type — one no other live type covers. A
+	/// subscription per declared type would feed the queue once per registration a message matches;
+	/// ancestors form a chain, so exactly one maximal type matches.
+	/// </summary>
+	/// <remarks>
+	/// Two orderings this must keep. Recompute rather than patch — one claim can subsume several
+	/// feeds and one release strand several. Attach before detaching — the reverse leaves an instant
+	/// with nothing subscribed, turning a handover into a dropped message.
+	/// </remarks>
+	private void Reconcile() {
+		var live = _feeds.Where(f => f.Value.Handlers > 0).Select(f => f.Key).ToArray();
+		var wanted = _feeds
+			.ToDictionary(f => f.Key,
+				f => f.Value.Handlers > 0 && !live.Any(other => other != f.Key && Covers(other, f.Key)));
+
+		foreach (var (type, feed) in _feeds)
+			if (wanted[type] && feed.Subscription is null)
+				feed.Subscription = feed.Attach();
+
+		foreach (var (type, feed) in _feeds) {
+			if (wanted[type] || feed.Subscription is null)
+				continue;
+			feed.Subscription.Dispose();
+			feed.Subscription = null;
+		}
+
+		foreach (var spent in _feeds.Where(f => f.Value.Handlers <= 0).Select(f => f.Key).ToArray())
+			_feeds.Remove(spent);
+	}
+
+	/// <summary>
+	/// Whether a subscription declared for <paramref name="outer"/> also receives
+	/// <paramref name="inner"/>. Equivalent to the <c>MessageHierarchy.DescendantsAndSelf</c>
+	/// expansion the bus uses, but that walk is uncached and allocates, and this runs over every
+	/// pair of declared types on each subscribe.
+	/// </summary>
+	private static bool Covers(Type outer, Type inner) => outer.IsAssignableFrom(inner);
 
 	public void Dispose() {
 		StopMessagePump();
@@ -113,7 +180,13 @@ public abstract class QueuedSubscriber : IMessageRegistry, IDisposable {
 	private void StopMessagePump() {
 		if (_pumpStopped)
 			return;
-		_subscriptions.ForEach(s => s.Dispose());
+		lock (_feedLock) {
+			_subscriptions.ForEach(s => s.Dispose());
+			_subscriptions.Clear();
+			foreach (var feed in _feeds.Values)
+				feed.Subscription?.Dispose();
+			_feeds.Clear();
+		}
 		_messageQueue.Stop();
 		_pumpStopped = true;
 	}


### PR DESCRIPTION
**What does this pull request do?**

A `QueuedSubscriber` registered for both a base type and a derived type runs every matching handler
twice for one derived message. This makes it once.

Independent of #268 — different file, no overlap — but found alongside it.

**How does this pull request accomplish that goal?**

`Subscribe<T>` added its own external-bus subscription per call, and the bus routes a registration to
the type's descendants as well. So two registrations match a derived message, the enqueue trigger
fires twice, and each dequeue republishes to the internal bus where *both* handlers match. One
message object — same `MsgId`, same reference — four handler invocations.

`ReadModelBase` does not have this: its queue is fed by one subscription per listener with the
handlers behind the queue, so handler count cannot reach the enqueue path. This brings
`QueuedSubscriber` to the same shape.

Subscriptions are now pooled per declared type, and reconciled so only *maximal* live types — those
no other live type covers — hold one. A type's ancestors form a chain, so exactly one maximal type
matches any given message.

Three things in `Reconcile` are load-bearing and each has a test:

- **Recompute, don't patch.** One claim can subsume several existing feeds and one release can strand
  several. The specific trap is release: dropping a parent that covered both a child and a grandchild
  must re-elect the child *alone*. Handing the feed back to each type the parent displaced gives both
  a subscription, and the grandchild handler runs twice again.
- **Attach before detaching.** The reverse order leaves an instant with nothing subscribed at all, so
  a message crossing a handover would be dropped rather than duplicated. Nothing before this change
  could drop a message, since subscriptions were only ever added.
- **A count, not a flag.** The feed is shared by every handler declared for the type and survives
  until the last one goes.

Coverage is answered by `IsAssignableFrom` rather than by re-walking `MessageHierarchy`. The bus
already expands a registration over `DescendantsAndSelf` once per subscribe; `TryGetDescendantsAndSelf`
is an uncached depth-first walk that allocates a list and a stack per call, and this runs over every
pair of declared types on every claim and release. The two agree over all 4,225 pairs of the 65
registered message types, at 0.0003 µs against 2.943 µs.

The handle returned by `Subscribe` drops its own internal registration and its share of the feed, and
nothing else. It also removes that registration from the teardown list, which previously only grew.

**Why is this pull request important?**

The duplicate is silent. A handler that increments, appends, projects or sends runs twice and the
extra lands in state with nothing to indicate it.

It has stayed hidden because `idempotent: true` suppresses it — the duplicate is dropped before
dispatch — and `TestInheritedMessageSubscriber`, the one type in this repo that registers overlapping
types, defaults to that. Anything using the default `idempotent: false` is exposed the moment it
registers a base and a derived type together.

**Link to any issues that this resolves**

This does not address any open issues.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports — 439 on `net8.0` and 439 on `net10.0`
- [x] Any new code must be covered by at least one unit test — 8 in `when_a_queued_subscriber_covers_a_type_more_than_once`; three fail on `master` without this change, including the re-election case
- [x] All public methods must be documented with XML comments

**Reviewer notes**

- A lock is now held across external-bus calls: `Reconcile` runs under the feed lock and calls
  `Subscribe`/`Dispose` on the bus, which take its handler lock. No cycle today — `InMemoryBus.Publish`
  releases its lock before dispatching, and `StopMessagePump` releases the feed lock before joining
  the queue thread — but it is a new ordering constraint.
- Subscribing after `Dispose` re-attaches to the external bus and enqueues onto a stopped queue. That
  predates this change and is left alone.