### PR TITLE
Give the other subscriber bases ReadModelBase's ReaderLock contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# ReactiveDomain
+
+Event-sourcing and CQRS framework, published as NuGet packages. Every change to a public surface is
+a change to a consumer's build, and consumers are not all visible from this repo.
+
+## Build & Test
+
+```bash
+dotnet build src/ReactiveDomain.sln -c Release
+dotnet test src/ReactiveDomain.sln -c Release --no-build
+dotnet format src/ReactiveDomain.sln --verify-no-changes --no-restore
+```
+
+All three are CI gates. The format check is the one most easily forgotten and it fails the build
+like any other.
+
+Libraries and tests multi-target `net8.0;net10.0` (`src/build.props`). Both must pass — see
+`CONTRIBUTING.md`. **Install both SDKs.** With only .NET 10 present, `dotnet test` silently runs
+net10.0 alone and reports green; the net8.0 half fails as `Testhost process ... exited with error:
+You must install or update .NET to run this application` only if you ask for it by name. Check
+`dotnet --list-sdks` before trusting a green run.
+
+## Comments
+
+Write only what the code cannot say. The test: delete the comment and ask what a reader loses. If
+the answer is nothing, leave it deleted.
+
+**Do not write**
+
+- The member's own name or signature in prose — `/// Registers handler for T` above
+  `Subscribe<T>(IHandle<T> handler)`.
+- The line underneath — `/// Adds it unless already present` above `if (present) return;`.
+- Why the previous version was wrong, or what a change fixed. That is the commit message's job; a
+  comment is read by someone who never saw the old code and does not know a PR happened.
+- A test's own name. The name states the contract; a comment adds only what the name cannot hold.
+
+**Do write**
+
+- Contracts a caller cannot infer from the signature: idempotence, ordering, thread-safety,
+  lifetime, what a returned handle owns. In a published library this is most of the value — the
+  caller has the XML docs and not the source.
+- Traps — where the obvious edit is wrong, and why. If a line would look like a mistake to someone
+  cleaning up, say why it is not.
+- Non-local constraints: what this must stay consistent with, and where that lives.
+
+**Keep them short — a comment scrolls code off the screen.** A four-line block above a three-line
+method means the method no longer fits on screen with its callers. Put the text on one line
+(`/// <summary>…</summary>`) whenever it fits.
+
+**A signal, not a gate:** when a diff's comment lines outnumber its code lines, the comments are
+usually restating. Re-read them before committing.
+
+## XML docs
+
+`CONTRIBUTING.md` requires XML comments on every public method. That stands — this governs what they
+say, not whether to write them. A method fully described by its own name still gets the tag; keep it
+to one line.
+
+These ship in the NuGet packages and are what a consumer sees in Intellisense, so write for the
+tooltip:
+
+- `<summary>` is the minimum. Never write `<param>`, `<typeparam>`, `<returns>` or `<remarks>`
+  without one.
+- The summary says what the member does in the normal case, in the caller's terms — not how it
+  behaves in an edge case. Idempotence, ordering, thread-safety, cost and worked examples go in
+  `<remarks>`.
+- One or two lines. A tooltip does not wrap until it is already too wide to read comfortably. If a
+  summary genuinely needs more, split it with `<para>` and keep each paragraph short.
+- Where several members do the same job by different routes, each says when to choose it and links
+  the alternatives with `<see cref="..."/>`. A signature does not convey a cost difference.
+- No reference to a previous implementation, explicit ("now", "no longer", "previously") or
+  elliptical ("unchanged", "untouched", "buckets, not places"). Comparing two things that both exist
+  is fine; comparing against what the code used to do is not.
+- `<exception>` for anything a caller is expected to catch.
+
+`CONTRIBUTING.md`'s Documentation Guidelines carry the same rules for human contributors, with a
+worked before/after example. Keep the two in step.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,4 +22,66 @@ We welcome well-considered feature requests. For **major features**, please enga
 When submitting a Pull Request, keep these rules in mind:
 - All unit tests in the solution must pass on all versions of .NET that the solution supports
 - Any new code must be covered by at least one unit test
-- All public methods must be documented with XML comments
+- All public methods must be documented with XML comments, following the [documentation guidelines](#docs) below
+
+### <a href="docs"></a>Documentation Guidelines
+RD ships its XML docs in its NuGet packages. They are what a consumer sees in Intellisense, so
+write for the tooltip, not for someone reading the source.
+
+**Tags**
+- `<summary>` is the minimum for a public member.
+- `<param>`, `<typeparam>`, `<returns>`, `<remarks>` are a bonus. Never write one without a `<summary>`.
+- `<exception>` for anything a caller is expected to catch.
+
+**What goes in `<summary>`**
+
+What the member does, in the caller's terms, for the normal case. One or two lines — an
+Intellisense tooltip does not wrap until it is already too wide to read comfortably.
+
+Edge cases, idempotence, threading, ordering, cost, and worked examples go in `<remarks>`. If a
+summary genuinely needs more than two lines, split it with `<para>` and keep each paragraph short.
+
+Bad — the summary is entirely edge case, and the reader still does not learn what the method does:
+
+```csharp
+/// <summary>
+/// Subscribing the same handler again for the same <typeparamref name="T"/> is a no-op — a
+/// subscription is a set, not a count, so any one of the returned disposers releases it.
+/// Subscribing it for a <i>different</i> <typeparamref name="T"/> is a separate subscription:
+/// a handler registered for both a base and a derived type is called once through each.
+/// </summary>
+public IDisposable Subscribe<T>(IHandle<T> handler, bool includeDerived = true)
+```
+
+Good:
+
+```csharp
+/// <summary>
+/// Subscribes <paramref name="handler"/> to messages of type <typeparamref name="T"/>, and by
+/// default to types derived from it.
+/// </summary>
+/// <remarks>
+/// Subscribing the same handler again for the same <typeparamref name="T"/> is a no-op — a
+/// subscription is a set, not a count, so any one of the returned disposers releases it.
+/// Subscribing it for a <i>different</i> <typeparamref name="T"/> is a separate subscription:
+/// a handler registered for both a base and a derived type is called once through each.
+/// </remarks>
+public IDisposable Subscribe<T>(IHandle<T> handler, bool includeDerived = true)
+```
+
+**Overlapping APIs**
+
+Where more than one public member does the same job by a different route, each one's docs say when
+to choose it and link the alternatives with `<see cref="..."/>`. Signatures alone do not convey a
+cost difference — a consumer choosing between `ReadModelBase.Start<T>()`, `Start(string)` and a
+shared `CategoryStream` has no way to tell what each one costs.
+
+**Write about the code as it is**
+
+No reference to a previous implementation, whether explicit ("now", "no longer", "changed to",
+"previously") or elliptical ("buckets, not places"). Source control is the history.
+
+This applies to ordinary comments as well as XML docs. It does not bar comparisons between things
+that both exist — saying how a member differs from its sibling is useful.
+
+The summary/remarks split applies wherever XML docs appear, public or not.

--- a/src/ReactiveDomain.Foundation.Tests/when_reading_subscriber_state_under_the_reader_lock.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_reading_subscriber_state_under_the_reader_lock.cs
@@ -1,0 +1,187 @@
+﻿using System.Reflection;
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests;
+
+// ReSharper disable once InconsistentNaming
+public sealed class when_reading_subscriber_state_under_the_reader_lock {
+	// Only ever used to prove a wait did NOT complete; a broken lock fails it regardless of length.
+	private static readonly TimeSpan BlockedProbe = TimeSpan.FromMilliseconds(100);
+
+	[Fact]
+	public async Task a_transient_subscriber_reader_holding_the_lock_sees_no_torn_state() {
+		using var bus = new InMemoryBus(nameof(when_reading_subscriber_state_under_the_reader_lock));
+		using var entered = new ManualResetEventSlim(false);
+		using var release = new ManualResetEventSlim(false);
+		using var sut = new PairSubscriber(bus, entered, release);
+
+		var publishing = Blocking(() => bus.Publish(new ReaderLockTestEvent()));
+		Assert.True(entered.Wait(TestTimeouts.ThrottleWaitFor));
+
+		// The handler is parked between the two mutations, so the pair really is inconsistent...
+		Assert.Equal((1, 0), sut.ReadPairWithoutLock());
+		// ...and a reader taking the lock cannot observe that.
+		var read = Reading(sut.ReadPairUnderLock);
+		Assert.NotSame(read, await Task.WhenAny(read, Task.Delay(BlockedProbe)));
+
+		release.Set();
+		Assert.Equal((1, 1), await read.WaitAsync(TestTimeouts.ThrottleWaitFor));
+		Assert.True(publishing.Join(TestTimeouts.ThrottleWaitFor));
+		Assert.Equal(1, sut.Version);
+	}
+
+	/// <summary>
+	/// A dedicated thread, not the pool: the handler parks inside the lock for as long as the test needs
+	/// it to, and a parked pool thread is one the reader below may then be unable to get. Under a loaded
+	/// run that shows up as this test timing out waiting to enter the handler at all.
+	/// </summary>
+	private static Thread Blocking(Action work) {
+		var thread = new Thread(() => work()) { IsBackground = true };
+		thread.Start();
+		return thread;
+	}
+
+	/// <summary>
+	/// The reader, on its own thread, returned as a task that is pending only because the lock is held.
+	/// This does not return until the thread is running, so the "did not complete" probe below cannot
+	/// pass merely because the reader was never scheduled — which on the pool it could.
+	/// </summary>
+	private static Task<(int, int)> Reading(Func<(int, int)> read) {
+		var running = new ManualResetEventSlim(false);
+		var result = new TaskCompletionSource<(int, int)>(TaskCreationOptions.RunContinuationsAsynchronously);
+		Blocking(() => {
+			running.Set();
+			try {
+				result.SetResult(read());
+			} catch (Exception ex) {
+				result.SetException(ex);
+			}
+		});
+		Assert.True(running.Wait(TestTimeouts.ThrottleWaitFor));
+		return result.Task;
+	}
+
+	[Fact]
+	public async Task a_transient_subscriber_command_handler_runs_under_the_lock() {
+		using var dispatcher = new Dispatcher(nameof(when_reading_subscriber_state_under_the_reader_lock));
+		using var entered = new ManualResetEventSlim(false);
+		using var release = new ManualResetEventSlim(false);
+		using var sut = new PairCommandSubscriber(dispatcher, entered, release);
+
+		var sending = Blocking(() => dispatcher.Send(new ReaderLockTestCommand(), responseTimeout: TestTimeouts.ThrottleWaitFor));
+		Assert.True(entered.Wait(TestTimeouts.ThrottleWaitFor));
+
+		Assert.Equal((1, 0), sut.ReadPairWithoutLock());
+		var read = Reading(sut.ReadPairUnderLock);
+		Assert.NotSame(read, await Task.WhenAny(read, Task.Delay(BlockedProbe)));
+
+		release.Set();
+		Assert.Equal((1, 1), await read.WaitAsync(TestTimeouts.ThrottleWaitFor));
+		Assert.True(sending.Join(TestTimeouts.ThrottleWaitFor));
+		Assert.Equal(1, sut.Version);
+	}
+
+	[Theory]
+	[InlineData(typeof(ReadModelBase))]
+	[InlineData(typeof(TransientSubscriber))]
+	[InlineData(typeof(QueuedSubscriber))]
+	public void every_subscriber_base_exposes_the_same_reader_lock_contract(Type subscriberBase) {
+		var readerLock = subscriberBase.GetField("ReaderLock", BindingFlags.Instance | BindingFlags.NonPublic);
+		Assert.NotNull(readerLock);
+		Assert.True(readerLock.IsFamily, $"{subscriberBase.Name}.ReaderLock must be protected.");
+		Assert.True(readerLock.IsInitOnly, $"{subscriberBase.Name}.ReaderLock must be readonly.");
+		Assert.Equal(typeof(object), readerLock.FieldType);
+
+		var version = subscriberBase.GetProperty("Version", BindingFlags.Instance | BindingFlags.Public);
+		Assert.NotNull(version);
+		Assert.Equal(typeof(int), version.PropertyType);
+		Assert.NotNull(version.GetMethod);
+		Assert.True(version.SetMethod is null or { IsPublic: false },
+			$"{subscriberBase.Name}.Version must not be publicly settable.");
+	}
+
+	/// <summary>The wrapper must reach the bus as the same object, or the bus cannot match the two.</summary>
+	[Fact]
+	public void subscribing_the_same_handler_twice_registers_once() {
+		using var bus = new InMemoryBus(nameof(when_reading_subscriber_state_under_the_reader_lock));
+		using var sut = new TwiceSubscribedSubscriber(bus);
+
+		bus.Publish(new ReaderLockTestEvent());
+
+		Assert.Equal(1, sut.Handled);
+		Assert.Equal(1, sut.Version);
+	}
+
+	private sealed class TwiceSubscribedSubscriber : TransientSubscriber, IHandle<ReaderLockTestEvent> {
+		public int Handled;
+
+		public TwiceSubscribedSubscriber(IBus bus) : base(bus) {
+			Subscribe<ReaderLockTestEvent>(this);
+			Subscribe<ReaderLockTestEvent>(this);
+		}
+
+		public void Handle(ReaderLockTestEvent message) => Interlocked.Increment(ref Handled);
+	}
+
+	private sealed class PairSubscriber : TransientSubscriber, IHandle<ReaderLockTestEvent> {
+		private readonly ManualResetEventSlim _entered;
+		private readonly ManualResetEventSlim _release;
+		private int _first;
+		private int _second;
+
+		public PairSubscriber(IBus bus, ManualResetEventSlim entered, ManualResetEventSlim release) : base(bus) {
+			_entered = entered;
+			_release = release;
+			// ReSharper disable once RedundantTypeArgumentsOfMethod
+			Subscribe<ReaderLockTestEvent>(this);
+		}
+
+		public void Handle(ReaderLockTestEvent message) {
+			_first++;
+			_entered.Set();
+			_release.Wait(TestTimeouts.ThrottleWaitFor);
+			_second++;
+		}
+
+		public (int, int) ReadPairUnderLock() {
+			lock (ReaderLock) { return (_first, _second); }
+		}
+
+		public (int, int) ReadPairWithoutLock() => (Volatile.Read(ref _first), Volatile.Read(ref _second));
+	}
+
+	private sealed class PairCommandSubscriber : TransientSubscriber, IHandleCommand<ReaderLockTestCommand> {
+		private readonly ManualResetEventSlim _entered;
+		private readonly ManualResetEventSlim _release;
+		private int _first;
+		private int _second;
+
+		public PairCommandSubscriber(IDispatcher bus, ManualResetEventSlim entered, ManualResetEventSlim release)
+			: base(bus) {
+			_entered = entered;
+			_release = release;
+			// ReSharper disable once RedundantTypeArgumentsOfMethod
+			Subscribe<ReaderLockTestCommand>(this);
+		}
+
+		public CommandResponse Handle(ReaderLockTestCommand command) {
+			_first++;
+			_entered.Set();
+			_release.Wait(TestTimeouts.ThrottleWaitFor);
+			_second++;
+			return command.Succeed();
+		}
+
+		public (int, int) ReadPairUnderLock() {
+			lock (ReaderLock) { return (_first, _second); }
+		}
+
+		public (int, int) ReadPairWithoutLock() => (Volatile.Read(ref _first), Volatile.Read(ref _second));
+	}
+
+	public record ReaderLockTestEvent : Event;
+	public record ReaderLockTestCommand : Command;
+}

--- a/src/ReactiveDomain.Foundation/TransientSubscriber.cs
+++ b/src/ReactiveDomain.Foundation/TransientSubscriber.cs
@@ -7,6 +7,7 @@ namespace ReactiveDomain.Foundation;
 
 public abstract class TransientSubscriber : IDisposable {
 	private readonly List<IDisposable> _subscriptions = [];
+	private readonly List<(object Handler, Type MessageType, object Wrapper)> _wrappers = [];
 	private readonly ISubscriber? _eventSubscriber;
 	private readonly ICommandSubscriber? _commandSubscriber;
 
@@ -24,16 +25,99 @@ public abstract class TransientSubscriber : IDisposable {
 		_commandSubscriber = subscriber ?? throw new ArgumentNullException(nameof(subscriber));
 	}
 
+	/// <summary>
+	/// Locks the message handlers. Hold it while reading the subscriber's state to see that state
+	/// unchanged for the duration of the read.
+	/// </summary>
+	/// <remarks>
+	/// Do <i>not</i> take it in a Handle method — handlers already run inside it. A handler holds it
+	/// for its whole duration, so one that blocks waiting on work this subscriber must itself handle
+	/// will deadlock.
+	/// </remarks>
+	protected readonly object ReaderLock = new();
+
+	/// <summary>
+	/// The number of handler invocations: a message matching two of this subscriber's registrations
+	/// advances it twice.
+	/// </summary>
+	/// <remarks>
+	/// Incremented inside the <see cref="ReaderLock"/> after the handler returns, so a reader holding
+	/// the lock always sees state and version agree.
+	/// </remarks>
+	public int Version { get; private set; }
+
 	protected void Subscribe<T>(IHandle<T> handler) where T : class, IMessage {
 		if (_eventSubscriber == null)
 			throw new InvalidOperationException("TransientSubscriber not created with EventBus to register on.");
-		_subscriptions.Add(_eventSubscriber.Subscribe<T>(handler));
+		_subscriptions.Add(_eventSubscriber.Subscribe<T>(Serialized(handler)));
 	}
 
 	protected void Subscribe<T>(IHandleCommand<T> handler) where T : Command {
 		if (_commandSubscriber == null)
 			throw new InvalidOperationException("TransientSubscriber not created with CommandBus to register on.");
-		_subscriptions.Add(_commandSubscriber.Subscribe<T>(handler));
+		_subscriptions.Add(_commandSubscriber.Subscribe<T>(Serialized(handler)));
+	}
+
+	/// <summary>
+	/// One wrapper per handler and message type, so subscribing the same handler again is the same
+	/// registration to the bus rather than a second one calling the same code.
+	/// </summary>
+	/// <remarks>
+	/// Scanned rather than hashed: reference identity is what the bus matches on, and a hashed key
+	/// would misbehave for a handler type that overrides <see cref="object.Equals(object)"/>.
+	/// </remarks>
+	private IHandle<T> Serialized<T>(IHandle<T> handler) where T : class, IMessage {
+		if (Existing<T>(handler) is SerializedHandler<T> existing)
+			return existing;
+		var wrapper = new SerializedHandler<T>(this, handler);
+		_wrappers.Add((handler, typeof(T), wrapper));
+		return wrapper;
+	}
+
+	private IHandleCommand<T> Serialized<T>(IHandleCommand<T> handler) where T : Command {
+		if (Existing<T>(handler) is SerializedCommandHandler<T> existing)
+			return existing;
+		var wrapper = new SerializedCommandHandler<T>(this, handler);
+		_wrappers.Add((handler, typeof(T), wrapper));
+		return wrapper;
+	}
+
+	private object? Existing<T>(object handler) {
+		foreach (var entry in _wrappers)
+			if (ReferenceEquals(entry.Handler, handler) && entry.MessageType == typeof(T))
+				return entry.Wrapper;
+		return null;
+	}
+
+	/// <summary>Runs a handler under <see cref="ReaderLock"/> and advances the version.</summary>
+	/// <remarks>
+	/// There is no queue here — dispatch is on whichever thread published — so this lock is the only
+	/// thing serializing handlers against each other and against readers. Dispatch order is the
+	/// publisher's; the wrapper calls straight through.
+	/// </remarks>
+	private void DispatchMessage(Action handle) {
+		lock (ReaderLock) {
+			handle();
+			Version++;
+		}
+	}
+
+	private CommandResponse DispatchCommand(Func<CommandResponse> handle) {
+		lock (ReaderLock) {
+			var response = handle();
+			Version++;
+			return response;
+		}
+	}
+
+	private sealed class SerializedHandler<T>(TransientSubscriber owner, IHandle<T> handler)
+		: IHandle<T> where T : class, IMessage {
+		public void Handle(T message) => owner.DispatchMessage(() => handler.Handle(message));
+	}
+
+	private sealed class SerializedCommandHandler<T>(TransientSubscriber owner, IHandleCommand<T> handler)
+		: IHandleCommand<T> where T : Command {
+		public CommandResponse Handle(T command) => owner.DispatchCommand(() => handler.Handle(command));
 	}
 
 	public void Dispose() {

--- a/src/ReactiveDomain.Messaging.Tests/Subscribers/QueuedSubscriber/when_reading_queued_subscriber_state_under_the_reader_lock.cs
+++ b/src/ReactiveDomain.Messaging.Tests/Subscribers/QueuedSubscriber/when_reading_queued_subscriber_state_under_the_reader_lock.cs
@@ -1,0 +1,61 @@
+﻿using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using Xunit;
+
+namespace ReactiveDomain.Messaging.Tests.Subscribers.QueuedSubscriber;
+
+// ReSharper disable once InconsistentNaming
+public sealed class when_reading_queued_subscriber_state_under_the_reader_lock {
+	// Only ever used to prove a wait did NOT complete; a broken lock fails it regardless of length.
+	private static readonly TimeSpan BlockedProbe = TimeSpan.FromMilliseconds(100);
+
+	[Fact]
+	public async Task a_reader_holding_the_lock_sees_no_torn_state() {
+		using var bus = new InMemoryBus(nameof(when_reading_queued_subscriber_state_under_the_reader_lock));
+		using var entered = new ManualResetEventSlim(false);
+		using var release = new ManualResetEventSlim(false);
+		using var sut = new PairSubscriber(bus, entered, release);
+
+		bus.Publish(new ReaderLockTestEvent());
+		Assert.True(entered.Wait(TestTimeouts.ThrottleWaitFor));
+
+		// The handler is parked between the two mutations, so the pair really is inconsistent...
+		Assert.Equal((1, 0), sut.ReadPairWithoutLock());
+		// ...and a reader taking the lock cannot observe that.
+		var read = Task.Run(sut.ReadPairUnderLock);
+		Assert.NotSame(read, await Task.WhenAny(read, Task.Delay(BlockedProbe)));
+
+		release.Set();
+		Assert.Equal((1, 1), await read.WaitAsync(TestTimeouts.ThrottleWaitFor));
+		AssertEx.IsOrBecomesTrue(() => sut.Version == 1, TestTimeouts.ThrottleWaitFor);
+	}
+
+	private sealed class PairSubscriber : Bus.QueuedSubscriber, IHandle<ReaderLockTestEvent> {
+		private readonly ManualResetEventSlim _entered;
+		private readonly ManualResetEventSlim _release;
+		private int _first;
+		private int _second;
+
+		public PairSubscriber(IBus bus, ManualResetEventSlim entered, ManualResetEventSlim release) : base(bus) {
+			_entered = entered;
+			_release = release;
+			// ReSharper disable once RedundantTypeArgumentsOfMethod
+			Subscribe<ReaderLockTestEvent>(this);
+		}
+
+		public void Handle(ReaderLockTestEvent message) {
+			_first++;
+			_entered.Set();
+			_release.Wait(TestTimeouts.ThrottleWaitFor);
+			_second++;
+		}
+
+		public (int, int) ReadPairUnderLock() {
+			lock (ReaderLock) { return (_first, _second); }
+		}
+
+		public (int, int) ReadPairWithoutLock() => (Volatile.Read(ref _first), Volatile.Read(ref _second));
+	}
+
+	public record ReaderLockTestEvent : Event;
+}

--- a/src/ReactiveDomain.Messaging.Tests/when_subscribing_the_same_handler_more_than_once.cs
+++ b/src/ReactiveDomain.Messaging.Tests/when_subscribing_the_same_handler_more_than_once.cs
@@ -1,0 +1,134 @@
+﻿using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using Xunit;
+
+namespace ReactiveDomain.Messaging.Tests;
+
+// ReSharper disable once InconsistentNaming
+public sealed class when_subscribing_the_same_handler_more_than_once {
+	[Fact]
+	public void duplicate_subscriptions_are_idempotent() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handled = 0;
+		var handler = new AdHocHandler<ParentTestMessage>(_ => handled++);
+
+		bus.Subscribe(handler);
+		bus.Subscribe(handler);
+		bus.Publish(new ParentTestMessage());
+
+		Assert.Equal(1, handled);
+	}
+
+	/// <summary>The guard runs against every slot a registration covers, not just the declared one.</summary>
+	[Fact]
+	public void duplicate_subscriptions_are_idempotent_for_derived_types_too() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handled = 0;
+		var handler = new AdHocHandler<ParentTestMessage>(_ => handled++);
+
+		bus.Subscribe(handler);
+		bus.Subscribe(handler);
+		bus.Publish(new ChildTestMessage());
+
+		Assert.Equal(1, handled);
+	}
+
+	[Fact]
+	public void the_same_handler_for_a_base_and_a_derived_type_stays_two_registrations() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handler = new BothLevels();
+
+		bus.Subscribe<ParentTestMessage>(handler);
+		bus.Subscribe<ChildTestMessage>(handler);
+		bus.Publish(new ChildTestMessage());
+
+		Assert.Equal(1, handler.AsParent);
+		Assert.Equal(1, handler.AsChild);
+	}
+
+	[Fact]
+	public void unsubscribing_a_derived_registration_leaves_the_base_registration() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handler = new BothLevels();
+
+		bus.Subscribe<ParentTestMessage>(handler);
+		bus.Subscribe<ChildTestMessage>(handler);
+		bus.Unsubscribe<ChildTestMessage>(handler);
+		bus.Publish(new ChildTestMessage());
+
+		Assert.Equal(1, handler.AsParent);
+		Assert.Equal(0, handler.AsChild);
+	}
+
+	[Fact]
+	public void resubscribing_after_unsubscribing_registers_again() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handled = 0;
+		var handler = new AdHocHandler<ParentTestMessage>(_ => handled++);
+
+		bus.Subscribe(handler);
+		bus.Unsubscribe(handler);
+		bus.Subscribe(handler);
+		bus.Publish(new ParentTestMessage());
+
+		Assert.Equal(1, handled);
+	}
+
+	[Fact]
+	public void either_disposer_releases_the_single_registration() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handled = 0;
+		var handler = new AdHocHandler<ParentTestMessage>(_ => handled++);
+
+		var first = bus.Subscribe(handler);
+		var second = bus.Subscribe(handler);
+
+		second.Dispose();
+		bus.Publish(new ParentTestMessage());
+		Assert.Equal(0, handled);
+
+		first.Dispose();
+		bus.Publish(new ParentTestMessage());
+		Assert.Equal(0, handled);
+	}
+
+	[Fact]
+	public void duplicate_subscribe_to_all_is_idempotent() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handled = 0;
+		var handler = new AdHocHandler<IMessage>(_ => handled++);
+
+		bus.SubscribeToAll(handler);
+		bus.SubscribeToAll(handler);
+		bus.Publish(new ParentTestMessage());
+
+		Assert.Equal(1, handled);
+	}
+
+	[Fact]
+	public void subscribing_to_all_and_to_a_type_delivers_through_both() {
+		using var bus = new InMemoryBus(nameof(when_subscribing_the_same_handler_more_than_once));
+		var handler = new AnyAndParent();
+
+		bus.SubscribeToAll(handler);
+		bus.Subscribe<ParentTestMessage>(handler);
+		bus.Publish(new ParentTestMessage());
+
+		Assert.Equal(1, handler.AsAny);
+		Assert.Equal(1, handler.AsParent);
+	}
+
+	private sealed class AnyAndParent : IHandle<IMessage>, IHandle<ParentTestMessage> {
+		public int AsAny;
+		public int AsParent;
+		public void Handle(IMessage message) => AsAny++;
+		public void Handle(ParentTestMessage message) => AsParent++;
+	}
+
+	private sealed class BothLevels : IHandle<ParentTestMessage>, IHandle<ChildTestMessage> {
+		public int AsParent;
+		public int AsChild;
+		public void Handle(ParentTestMessage message) => AsParent++;
+		public void Handle(ChildTestMessage message) => AsChild++;
+	}
+}

--- a/src/ReactiveDomain.Messaging/Bus/InMemoryBus.cs
+++ b/src/ReactiveDomain.Messaging/Bus/InMemoryBus.cs
@@ -53,21 +53,37 @@ public class InMemoryBus : IBus, ISubscriber, IPublisher, IHandle<IMessage>, IDi
 		}
 	}
 
+	/// <summary>
+	/// Subscribes <paramref name="handler"/> to messages of type <typeparamref name="T"/>, and by
+	/// default to types derived from it.
+	/// </summary>
+	/// <remarks>
+	/// Subscribing the same handler again for the same <typeparamref name="T"/> is a no-op — a
+	/// subscription is a set, not a count, so any one of the returned disposers releases it.
+	/// Subscribing it for a <i>different</i> <typeparamref name="T"/> is a separate subscription:
+	/// a handler registered for both a base and a derived type is called once through each.
+	/// </remarks>
 	public IDisposable Subscribe<T>(IHandle<T> handler, bool includeDerived = true) where T : class, IMessage {
 		Ensure.NotNull(handler, "handler");
-		Subscribe(new MessageHandler<T>(handler, handler.GetType().Name), includeDerived);
+		Subscribe(new MessageHandler<T>(handler, handler.GetType().Name), handler, includeDerived);
 		return new Disposer(() => { Unsubscribe(handler); return Unit.Default; });
 	}
 
-	private void Subscribe(IMessageHandler handler, bool includeDerived) {
+	private void Subscribe(IMessageHandler handler, object rawHandler, bool includeDerived) {
 		var messageTypes = includeDerived
 			? MessageHierarchy.DescendantsAndSelf(handler.MessageType).ToArray()
 			: [handler.MessageType];
 		for (var i = 0; i < messageTypes.Length; i++) {
-			Subscribe(handler, messageTypes[i]);
+			Subscribe(handler, rawHandler, messageTypes[i]);
 		}
 	}
 
+	/// <summary>Subscribes <paramref name="handler"/> to every known message type.</summary>
+	/// <remarks>
+	/// Idempotent per handler; one that also subscribes to a type is called through both. The types
+	/// are taken from the message hierarchy as it stands when this is called, so a type first seen
+	/// afterwards — from an assembly loaded later — does not reach this handler.
+	/// </remarks>
 	public IDisposable SubscribeToAll(IHandle<IMessage> handler) {
 		Ensure.NotNull(handler, "handler");
 		var allHandler = new MessageHandler<IMessage>(handler, handler.GetType().Name);
@@ -75,21 +91,31 @@ public class InMemoryBus : IBus, ISubscriber, IPublisher, IHandle<IMessage>, IDi
 		var messageTypes = MessageHierarchy.DescendantsAndSelf(typeof(object)).ToArray();
 
 		for (var i = 0; i < messageTypes.Length; i++) {
-			Subscribe(allHandler, messageTypes[i]);
+			Subscribe(allHandler, handler, messageTypes[i]);
 		}
 		return new Disposer(() => { Unsubscribe(handler); return Unit.Default; });
 	}
-	private void Subscribe(IMessageHandler handler, Type messageType) {
-		var handlers = GetHandlesFor(messageType);
-		if (!handlers.Any(hndl => hndl.IsSame(messageType, handler))) {
-			lock (_handlers) {
-				if (!_handlers.TryGetValue(messageType, out var handleList)) {
-					handleList = new List<IMessageHandler>();
-					_handlers.Add(messageType, handleList);
-				}
 
-				handleList.Add(handler);
+	/// <summary>
+	/// Adds <paramref name="handler"/> to the handler list for <paramref name="messageType"/>, unless
+	/// <paramref name="rawHandler"/> is already registered there for <paramref name="handler"/>'s own
+	/// message type.
+	/// </summary>
+	/// <remarks>
+	/// Duplicates are matched on <c>handler.MessageType</c>, not <paramref name="messageType"/>. This
+	/// runs once per slot a registration covers, so matching the slot would read a base-type and a
+	/// derived-type registration of one handler as duplicates of each other.
+	/// </remarks>
+	private void Subscribe(IMessageHandler handler, object rawHandler, Type messageType) {
+		lock (_handlers) {
+			if (!_handlers.TryGetValue(messageType, out var handleList)) {
+				handleList = new List<IMessageHandler>();
+				_handlers.Add(messageType, handleList);
+			} else if (handleList.Any(hndl => hndl.IsSame(handler.MessageType, rawHandler))) {
+				return;
 			}
+
+			handleList.Add(handler);
 		}
 	}
 

--- a/src/ReactiveDomain.Messaging/Bus/QueuedSubscriber.cs
+++ b/src/ReactiveDomain.Messaging/Bus/QueuedSubscriber.cs
@@ -12,6 +12,25 @@ public abstract class QueuedSubscriber : IDisposable {
 	protected object? Last = null;
 	public bool Starving => _messageQueue.Idle;
 
+	/// <summary>
+	/// Locks the message handlers. Hold it while reading the subscriber's state to see that state
+	/// unchanged for the duration of the read.
+	/// </summary>
+	/// <remarks>
+	/// Do <i>not</i> take it in a Handle method — handlers already run inside it.
+	/// </remarks>
+	protected readonly object ReaderLock = new();
+
+	/// <summary>
+	/// The number of messages dequeued to this subscriber, whatever the handler count — including none.
+	/// </summary>
+	/// <remarks>
+	/// A duplicate dropped by an idempotent subscriber does not advance the version. Incremented
+	/// inside the <see cref="ReaderLock"/> after the handlers run, so a reader holding the lock
+	/// always sees state and version agree.
+	/// </remarks>
+	public int Version { get; private set; }
+
 	protected QueuedSubscriber(IBus bus, bool idempotent = false) {
 		_externalBus = bus ?? throw new ArgumentNullException(nameof(bus));
 		_internalBus = new InMemoryBus("SubscriptionBus");
@@ -19,14 +38,26 @@ public abstract class QueuedSubscriber : IDisposable {
 		if (idempotent)
 			_messageQueue = new QueuedHandler(
 				new IdempotentHandler<IMessage>(
-					new AdHocHandler<IMessage>(_internalBus.Publish)
+					new AdHocHandler<IMessage>(DequeueMessage)
 				),
 				"SubscriptionQueue");
 		else
 			_messageQueue = new QueuedHandler(
-				new AdHocHandler<IMessage>(_internalBus.Publish),
+				new AdHocHandler<IMessage>(DequeueMessage),
 				"SubscriptionQueue");
 		_messageQueue.Start();
+	}
+
+	/// <summary>Every message handled by the subscriber passes through here.</summary>
+	/// <remarks>
+	/// Dispatch order is the queue's — the lock only excludes readers and, through the single queue
+	/// thread, is uncontended on the dispatch path.
+	/// </remarks>
+	private void DequeueMessage(IMessage message) {
+		lock (ReaderLock) {
+			_internalBus.Publish(message);
+			Version++;
+		}
 	}
 
 	public IDisposable Subscribe<T>(IHandle<T> handler) where T : class, IMessage {


### PR DESCRIPTION
**What does this pull request do?**

Gives `TransientSubscriber` and `QueuedSubscriber` the `ReaderLock` + `Version` pair `ReadModelBase`
already had, so all three subscriber bases offer the same serialization contract instead of each
being a separate judgement call for anyone reading their state.

**Stacked on #268** — its duplicate-subscription fix is what the idempotence test below measures
against. Review that one first; this diff is only the commits above it.

**How does this pull request accomplish that goal?**

Both gain a `protected readonly object ReaderLock` and a `public int Version`, incremented inside
that lock after handlers run, so a reader holding the lock always sees state and version agree.

`QueuedSubscriber` already had the right shape; its dispatch simply moves inside the lock.

`TransientSubscriber` is the substantive change. It has no queue — it dispatches on whichever thread
published — so its handlers could previously run concurrently with each other. Registrations are now
wrapped in a serializing handler that calls straight through, leaving registration and dispatch order
untouched.

**Two consequences of that wrapping, both handled:**

- **Identity.** The bus matches registrations by reference. A fresh wrapper per `Subscribe` call would
  arrive as two unrelated objects, register twice, and run the handler twice — losing the idempotence
  #268 gives every other caller. One wrapper is now kept per handler and message type. A linear scan
  finds it: a subscriber registers a handful of handlers, and reference identity is what the bus
  itself matches on, so a hashed key would only add an equality contract to get wrong for a handler
  that overrides `Equals`.
- **Blocking.** A handler holds the lock for its whole duration, so one that blocks waiting on work
  this subscriber must itself handle will deadlock where it previously completed. The queued bases
  already had that shape; this one didn't, and nothing said so. Now documented on `ReaderLock`.

**`Version` means different things on the two, deliberately, and both say so on the member.** A queued
base counts messages *dequeued* — one per delivery, regardless of how many handlers match or whether
any do. `TransientSubscriber` counts *handler invocations*, because it has no queue to count at; a
message matching two of its registrations advances it twice. The two agree except where a subscriber's
registrations overlap.

**Why is this pull request important?**

Reading a subscriber's state safely currently requires knowing which base it derives from and what
that base happens to guarantee. One contract across all three removes that per-class question.

**Link to any issues that this resolves**

This does not address any open issues.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports — green on `net8.0` and `net10.0`
- [x] Any new code must be covered by at least one unit test — `when_reading_subscriber_state_under_the_reader_lock` (Foundation) and `when_reading_queued_subscriber_state_under_the_reader_lock` (Messaging). The identity case fails without the fix; verified by reverting it.
- [x] All public methods must be documented with XML comments

**Sequencing**

Touches `QueuedSubscriber` adjacent to #269 and #271, but depends on neither — whichever lands second
wants a rebase.

Deliberately omits a follow-up commit that documented `QueuedSubscriber.Version` as counting
registrations rather than messages. That is true today, but #269 makes it false, and documenting a
quirk another open PR removes would only have to be undone. The wording here — "the number of
messages dequeued to this subscriber" — holds either way.