### PR TITLE
Carry the positions of externally-fed streams through a snapshot

### DIFF
--- a/src/ReactiveDomain.Foundation.Tests/when_awaiting_read_model_liveness.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_awaiting_read_model_liveness.cs
@@ -244,7 +244,7 @@ public sealed class when_awaiting_read_model_liveness : IClassFixture<StreamStor
 		var stream = NewStream();
 		AppendEvents(stream, 6, 5);
 		var rm = Track(new LivenessTestSnapshotReadModel(_configured,
-			new ReadModelState(nameof(LivenessTestSnapshotReadModel), [new Tuple<string, long>(stream, 2)], new object())));
+			new ReadModelState(nameof(LivenessTestSnapshotReadModel), [new StreamCheckpoint(stream, 2)], new object())));
 
 		await rm.IsLive.WaitAsync(TestTimeouts.ThrottleWaitFor);
 

--- a/src/ReactiveDomain.Foundation.Tests/when_using_external_snapshot_positions.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_external_snapshot_positions.cs
@@ -1,0 +1,249 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests;
+
+/// <summary>
+/// A relay-fed model is handed events from a stream it never listens to, and its snapshot still has
+/// to carry that stream's position — the feeding side has nowhere else to resume from.
+/// </summary>
+// ReSharper disable once InconsistentNaming
+public sealed class when_using_external_snapshot_positions : IClassFixture<StreamStoreConnectionFixture> {
+	private readonly IConfiguredConnection _configuredConnection;
+	private readonly IStreamStoreConnection _conn;
+	private readonly IEventSerializer _serializer = new JsonMessageSerializer();
+	private readonly IStreamNameBuilder _namer =
+		new PrefixedCamelCaseStreamNameBuilder(nameof(when_using_external_snapshot_positions));
+
+	private readonly string _ownStream;
+	private readonly Guid _ownAggId;
+	private readonly string _relayedStream;
+
+	private const int OwnEventValue = 2;
+	private const int RelayedEventValue = 100;
+
+	public when_using_external_snapshot_positions(StreamStoreConnectionFixture fixture) {
+		_conn = fixture.Connection;
+		_conn.Connect();
+		_configuredConnection = new ConfiguredConnection(_conn, _namer, _serializer);
+
+		_ownAggId = Guid.NewGuid();
+		_ownStream = _namer.GenerateForAggregate(typeof(ExternalPositionTestAggregate), _ownAggId);
+		_relayedStream = _namer.GenerateForAggregate(typeof(ExternalPositionTestAggregate), Guid.NewGuid());
+
+		AppendEvents(10, _ownStream, OwnEventValue);
+		AppendEvents(5, _relayedStream, RelayedEventValue);
+	}
+
+	private void AppendEvents(int count, string streamName, int value) {
+		for (var i = 0; i < count; i++) {
+			_conn.AppendToStream(streamName, ExpectedVersion.Any, null,
+				_serializer.Serialize(new ExternalPositionTestEvent(i, value)));
+		}
+	}
+
+	private ReadModelState StateWith(List<StreamCheckpoint>? externalCheckpoints) =>
+		new(
+			nameof(RelayFedReadModel),
+			[new StreamCheckpoint(_ownStream, 9)],
+			new RelayFedReadModel.MyState { Count = 10, Sum = 20 },
+			externalCheckpoints);
+
+	[Fact]
+	public void external_positions_round_trip_untouched() {
+		var snapshot = StateWith([new StreamCheckpoint(_relayedStream, 4)]);
+
+		using var rm = new RelayFedReadModel(_configuredConnection, _relayedStream, snapshot);
+		var roundTripped = rm.GetState();
+
+		Assert.NotNull(roundTripped.ExternalCheckpoints);
+		var external = Assert.Single(roundTripped.ExternalCheckpoints);
+		Assert.Equal(_relayedStream, external.StreamName);
+		Assert.Equal(4, external.Version);
+		// The model's own checkpoints are unaffected by the external entry.
+		Assert.NotNull(roundTripped.Checkpoints);
+		Assert.Equal(_ownStream, Assert.Single(roundTripped.Checkpoints).StreamName);
+	}
+
+	[Fact]
+	public void a_state_with_no_external_positions_is_unchanged() {
+		// The three-argument shape every existing state was written with.
+		var snapshot = new ReadModelState(
+			nameof(RelayFedReadModel),
+			[new StreamCheckpoint(_ownStream, 9)],
+			new RelayFedReadModel.MyState { Count = 10, Sum = 20 });
+		Assert.Null(snapshot.ExternalCheckpoints);
+
+		using var rm = new RelayFedReadModel(_configuredConnection, _relayedStream, snapshot);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 10, TestTimeouts.ThrottleWaitFor);
+
+		// Nothing was recorded, so nothing is emitted: the same shape goes back out.
+		Assert.Null(rm.GetState().ExternalCheckpoints);
+		Assert.False(rm.HasExternalCheckpoint(_relayedStream, out _));
+	}
+
+	[Fact]
+	public void a_model_reads_its_external_positions_while_restoring() {
+		var snapshot = StateWith([new StreamCheckpoint(_relayedStream, 4)]);
+
+		using var rm = new RelayFedReadModel(_configuredConnection, _relayedStream, snapshot);
+
+		// Recorded before ApplyState ran: restore is when a model has to tell its relay where
+		// to resume from.
+		Assert.Equal(4, rm.PositionSeenWhileRestoring);
+	}
+
+	[Fact]
+	public void an_unrecorded_external_stream_reports_no_position() {
+		using var rm = new RelayFedReadModel(
+			_configuredConnection, _relayedStream, StateWith([new StreamCheckpoint(_relayedStream, 4)]));
+
+		Assert.False(rm.HasExternalCheckpoint("no.such.stream", out var checkpoint));
+		Assert.Null(checkpoint);
+	}
+
+	[Fact]
+	public void external_positions_never_start_a_listener() {
+		var snapshot = StateWith([new StreamCheckpoint(_relayedStream, 1)]);
+
+		using var rm = new RelayFedReadModel(_configuredConnection, _relayedStream, snapshot);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 10, TestTimeouts.ThrottleWaitFor);
+
+		// Append to the relayed stream first, then to the model's own stream. The own listener
+		// is running, so once its event lands, anything the relayed stream would have delivered
+		// has had at least as long to arrive.
+		AppendEvents(1, _relayedStream, RelayedEventValue);
+		AppendEvents(1, _ownStream, OwnEventValue);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 11, TestTimeouts.ThrottleWaitFor);
+
+		Assert.Equal(11, rm.Count);
+		Assert.Equal(20 + OwnEventValue, rm.Sum); // no relayed event was folded in
+		Assert.Equal(_ownStream, Assert.Single(rm.GetCheckpoint()).StreamName);
+	}
+
+	// The version resumes the stream; the $all position is what makes this checkpoint comparable
+	// against one taken on a different stream. A snapshot has to carry both or the second is lost.
+	[Fact]
+	public void a_relayed_all_position_is_carried_into_the_next_snapshot() {
+		var snapshot = StateWith([new StreamCheckpoint(_relayedStream, 1, new Position(512, 512))]);
+
+		using var rm = new RelayFedReadModel(_configuredConnection, _relayedStream, snapshot);
+		Assert.True(rm.HasExternalCheckpoint(_relayedStream, out var restored));
+		Assert.Equal(new Position(512, 512), restored.Position);
+
+		rm.Relay(new ExternalPositionTestEvent(2, RelayedEventValue), 2, new Position(1024, 1024));
+
+		var saved = Assert.Single(rm.GetState().ExternalCheckpoints!);
+		Assert.Equal(2, saved.Version);
+		Assert.Equal(new Position(1024, 1024), saved.Position);
+	}
+
+	// A source that cannot supply an $all position still checkpoints its version.
+	[Fact]
+	public void a_relayed_position_is_optional() {
+		var snapshot = StateWith([new StreamCheckpoint(_relayedStream, 1)]);
+
+		using var rm = new RelayFedReadModel(_configuredConnection, _relayedStream, snapshot);
+		rm.Relay(new ExternalPositionTestEvent(2, RelayedEventValue), 2);
+
+		var saved = Assert.Single(rm.GetState().ExternalCheckpoints!);
+		Assert.Equal(2, saved.Version);
+		Assert.Null(saved.Position);
+	}
+
+	[Fact]
+	public void a_relayed_position_is_carried_into_the_next_snapshot() {
+		var snapshot = StateWith([new StreamCheckpoint(_relayedStream, 1)]);
+
+		using var rm = new RelayFedReadModel(_configuredConnection, _relayedStream, snapshot);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 10, TestTimeouts.ThrottleWaitFor);
+
+		// What a relay does: hand over the event, then the position it came from.
+		rm.Relay(new ExternalPositionTestEvent(2, RelayedEventValue), 2);
+		rm.Relay(new ExternalPositionTestEvent(3, RelayedEventValue), 3);
+
+		var saved = rm.GetState();
+		Assert.NotNull(saved.ExternalCheckpoints);
+		Assert.Equal(3, Assert.Single(saved.ExternalCheckpoints).Version);
+
+		using var restored = new RelayFedReadModel(_configuredConnection, _relayedStream, saved);
+		Assert.Equal(3, restored.PositionSeenWhileRestoring);
+		AssertEx.IsOrBecomesTrue(() => restored.Count == 12, TestTimeouts.ThrottleWaitFor);
+	}
+
+	public sealed class RelayFedReadModel :
+		SnapshotReadModel,
+		IHandle<ExternalPositionTestEvent> {
+		private readonly string _relayedStream;
+
+		public RelayFedReadModel(
+			IConfiguredConnection configuredConnection,
+			string relayedStream,
+			ReadModelState snapshot) :
+			base(nameof(RelayFedReadModel), configuredConnection) {
+			_relayedStream = relayedStream;
+			// ReSharper disable once RedundantTypeArgumentsOfMethod
+			EventStream.Subscribe<ExternalPositionTestEvent>(this);
+			Restore(snapshot);
+		}
+
+		public long Sum { get; private set; }
+		public long Count { get; private set; }
+
+		/// <summary>The relayed stream's position the model found while restoring, or -1.</summary>
+		public long PositionSeenWhileRestoring { get; private set; } = -1;
+
+		/// <summary>Stands in for a relay: apply the event, then record where it came from.</summary>
+		public void Relay(ExternalPositionTestEvent @event, long version, Position? position = null) {
+			DirectApply(@event);
+			SetExternalCheckpoint(_relayedStream, version, position);
+		}
+
+		/// <summary>Exposes the protected accessor so the tests can assert on it.</summary>
+		public bool HasExternalCheckpoint(
+			string streamName,
+			[NotNullWhen(true)] out StreamCheckpoint? checkpoint) =>
+			TryGetExternalCheckpoint(streamName, out checkpoint);
+
+		void IHandle<ExternalPositionTestEvent>.Handle(ExternalPositionTestEvent @event) {
+			Sum += @event.Value;
+			Count++;
+		}
+
+		protected override void ApplyState(ReadModelState snapshot) {
+			if (snapshot.State is not MyState state) {
+				throw new ArgumentException(
+					$"Unknown state object: Expected {nameof(MyState)}, got {snapshot.State?.GetType().Name}");
+			}
+
+			Count = state.Count;
+			Sum = state.Sum;
+			if (TryGetExternalCheckpoint(_relayedStream, out var checkpoint)) {
+				PositionSeenWhileRestoring = checkpoint.Version;
+			}
+		}
+
+		public override ReadModelState GetState() =>
+			new(
+				nameof(RelayFedReadModel),
+				GetCheckpoint(),
+				new MyState { Sum = Sum, Count = Count },
+				GetExternalCheckpoints());
+
+		public class MyState {
+			public long Sum { get; set; }
+			public long Count { get; set; }
+		}
+	}
+
+	public class ExternalPositionTestAggregate : EventDrivenStateMachine;
+
+	public record ExternalPositionTestEvent(int Number, int Value) : IMessage {
+		public Guid MsgId { get; private set; } = Guid.NewGuid();
+		public readonly int Number = Number;
+		public readonly int Value = Value;
+	}
+}

--- a/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base.cs
@@ -75,8 +75,8 @@ public sealed class when_using_read_model_base :
 		AssertEx.AtLeastModelVersion(this, 11, TestTimeouts.ThrottleWaitFor, msg: $"Expected 11 got {Version}");
 		AssertEx.IsOrBecomesTrue(() => Sum == 20, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
-		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
-		Assert.Equal(9, GetCheckpoint()[0].Item2);
+		Assert.Equal(_stream1, GetCheckpoint()[0].StreamName);
+		Assert.Equal(9, GetCheckpoint()[0].Version);
 	}
 	[Fact]
 	public void can_read_two_streams() {
@@ -85,10 +85,10 @@ public sealed class when_using_read_model_base :
 		AssertEx.AtLeastModelVersion(this, 22, TestTimeouts.ThrottleWaitFor, msg: $"Expected 22 got {Version}");
 		AssertEx.IsOrBecomesTrue(() => Sum == 50, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
-		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
-		Assert.Equal(9, GetCheckpoint()[0].Item2);
-		Assert.Equal(_stream2, GetCheckpoint()[1].Item1);
-		Assert.Equal(9, GetCheckpoint()[1].Item2);
+		Assert.Equal(_stream1, GetCheckpoint()[0].StreamName);
+		Assert.Equal(9, GetCheckpoint()[0].Version);
+		Assert.Equal(_stream2, GetCheckpoint()[1].StreamName);
+		Assert.Equal(9, GetCheckpoint()[1].Version);
 	}
 	[Fact]
 	public void can_wait_for_one_stream_to_go_live() {
@@ -116,10 +116,10 @@ public sealed class when_using_read_model_base :
 		AssertEx.AtLeastModelVersion(this, 21, TestTimeouts.ThrottleWaitFor, msg: $"Expected 21 got {Version}");
 		AssertEx.IsOrBecomesTrue(() => Sum == 70, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
-		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
-		Assert.Equal(19, GetCheckpoint()[0].Item2);
-		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
-		Assert.Equal(19, GetCheckpoint()[0].Item2);
+		Assert.Equal(_stream1, GetCheckpoint()[0].StreamName);
+		Assert.Equal(19, GetCheckpoint()[0].Version);
+		Assert.Equal(_stream1, GetCheckpoint()[0].StreamName);
+		Assert.Equal(19, GetCheckpoint()[0].Version);
 	}
 	[Fact]
 	public void can_listen_to_two_streams() {
@@ -133,10 +133,10 @@ public sealed class when_using_read_model_base :
 		AssertEx.AtLeastModelVersion(this, 42, TestTimeouts.ThrottleWaitFor, msg: $"Expected 42 got {Version}");
 		AssertEx.IsOrBecomesTrue(() => Sum == 170, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
-		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
-		Assert.Equal(19, GetCheckpoint()[0].Item2);
-		Assert.Equal(_stream2, GetCheckpoint()[1].Item1);
-		Assert.Equal(19, GetCheckpoint()[1].Item2);
+		Assert.Equal(_stream1, GetCheckpoint()[0].StreamName);
+		Assert.Equal(19, GetCheckpoint()[0].Version);
+		Assert.Equal(_stream2, GetCheckpoint()[1].StreamName);
+		Assert.Equal(19, GetCheckpoint()[1].Version);
 	}
 	[Fact]
 	public void can_use_checkpoint_on_one_stream() {
@@ -153,8 +153,8 @@ public sealed class when_using_read_model_base :
 		AssertEx.AtLeastModelVersion(this, 12, TestTimeouts.ThrottleWaitFor, msg: $"Expected 12 got {Version}");
 		AssertEx.IsOrBecomesTrue(() => Sum == 70, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
-		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
-		Assert.Equal(19, GetCheckpoint()[0].Item2);
+		Assert.Equal(_stream1, GetCheckpoint()[0].StreamName);
+		Assert.Equal(19, GetCheckpoint()[0].Version);
 	}
 	[Fact]
 	public void can_use_checkpoint_on_two_streams() {
@@ -173,10 +173,10 @@ public sealed class when_using_read_model_base :
 		AssertEx.AtLeastModelVersion(this, 27, TestTimeouts.ThrottleWaitFor, msg: $"Expected 27 got {Version}");
 		AssertEx.IsOrBecomesTrue(() => Sum == 170, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
-		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
-		Assert.Equal(19, GetCheckpoint()[0].Item2);
-		Assert.Equal(_stream2, GetCheckpoint()[1].Item1);
-		Assert.Equal(19, GetCheckpoint()[1].Item2);
+		Assert.Equal(_stream1, GetCheckpoint()[0].StreamName);
+		Assert.Equal(19, GetCheckpoint()[0].Version);
+		Assert.Equal(_stream2, GetCheckpoint()[1].StreamName);
+		Assert.Equal(19, GetCheckpoint()[1].Version);
 	}
 	[Fact]
 	public void can_listen_to_the_same_stream_twice() {

--- a/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base_with_reader.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_read_model_base_with_reader.cs
@@ -87,8 +87,8 @@ public sealed class when_using_read_model_base_with_reader :
 		AssertEx.IsOrBecomesTrue(() => Count == 10, TestTimeouts.ThrottleWaitFor, msg: $"Expected 10 got {Count}");
 		AssertEx.IsOrBecomesTrue(() => Sum == 20, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
-		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
-		Assert.Equal(9, GetCheckpoint()[0].Item2);
+		Assert.Equal(_stream1, GetCheckpoint()[0].StreamName);
+		Assert.Equal(9, GetCheckpoint()[0].Version);
 	}
 
 	[Fact]
@@ -98,10 +98,10 @@ public sealed class when_using_read_model_base_with_reader :
 		AssertEx.IsOrBecomesTrue(() => Count == 20, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Count}");
 		AssertEx.IsOrBecomesTrue(() => Sum == 50, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
-		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
-		Assert.Equal(9, GetCheckpoint()[0].Item2);
-		Assert.Equal(_stream2, GetCheckpoint()[1].Item1);
-		Assert.Equal(9, GetCheckpoint()[1].Item2);
+		Assert.Equal(_stream1, GetCheckpoint()[0].StreamName);
+		Assert.Equal(9, GetCheckpoint()[0].Version);
+		Assert.Equal(_stream2, GetCheckpoint()[1].StreamName);
+		Assert.Equal(9, GetCheckpoint()[1].Version);
 	}
 
 	[Fact]
@@ -137,10 +137,10 @@ public sealed class when_using_read_model_base_with_reader :
 		AssertEx.IsOrBecomesTrue(() => Count == 20, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Count}");
 		AssertEx.IsOrBecomesTrue(() => Sum == 70, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
-		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
-		Assert.Equal(19, GetCheckpoint()[0].Item2);
-		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
-		Assert.Equal(19, GetCheckpoint()[0].Item2);
+		Assert.Equal(_stream1, GetCheckpoint()[0].StreamName);
+		Assert.Equal(19, GetCheckpoint()[0].Version);
+		Assert.Equal(_stream1, GetCheckpoint()[0].StreamName);
+		Assert.Equal(19, GetCheckpoint()[0].Version);
 	}
 
 	[Fact]
@@ -155,10 +155,10 @@ public sealed class when_using_read_model_base_with_reader :
 		AssertEx.IsOrBecomesTrue(() => Count == 40, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Count}");
 		AssertEx.IsOrBecomesTrue(() => Sum == 170, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
-		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
-		Assert.Equal(19, GetCheckpoint()[0].Item2);
-		Assert.Equal(_stream2, GetCheckpoint()[1].Item1);
-		Assert.Equal(19, GetCheckpoint()[1].Item2);
+		Assert.Equal(_stream1, GetCheckpoint()[0].StreamName);
+		Assert.Equal(19, GetCheckpoint()[0].Version);
+		Assert.Equal(_stream2, GetCheckpoint()[1].StreamName);
+		Assert.Equal(19, GetCheckpoint()[1].Version);
 	}
 
 	[Fact]
@@ -177,8 +177,8 @@ public sealed class when_using_read_model_base_with_reader :
 		AssertEx.IsOrBecomesTrue(() => Count == 20, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Count}");
 		AssertEx.IsOrBecomesTrue(() => Sum == 70, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
-		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
-		Assert.Equal(19, GetCheckpoint()[0].Item2);
+		Assert.Equal(_stream1, GetCheckpoint()[0].StreamName);
+		Assert.Equal(19, GetCheckpoint()[0].Version);
 	}
 
 	[Fact]
@@ -199,10 +199,10 @@ public sealed class when_using_read_model_base_with_reader :
 		AssertEx.IsOrBecomesTrue(() => Count == 40, TestTimeouts.ThrottleWaitFor, msg: $"Expected 20 got {Count}");
 		AssertEx.IsOrBecomesTrue(() => Sum == 170, TestTimeouts.ThrottleWaitFor);
 		//confirm checkpoints
-		Assert.Equal(_stream1, GetCheckpoint()[0].Item1);
-		Assert.Equal(19, GetCheckpoint()[0].Item2);
-		Assert.Equal(_stream2, GetCheckpoint()[1].Item1);
-		Assert.Equal(19, GetCheckpoint()[1].Item2);
+		Assert.Equal(_stream1, GetCheckpoint()[0].StreamName);
+		Assert.Equal(19, GetCheckpoint()[0].Version);
+		Assert.Equal(_stream2, GetCheckpoint()[1].StreamName);
+		Assert.Equal(19, GetCheckpoint()[1].Version);
 	}
 
 	[Fact]

--- a/src/ReactiveDomain.Foundation.Tests/when_using_snapshot_read_model.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_snapshot_read_model.cs
@@ -47,8 +47,8 @@ public sealed class when_using_snapshot_read_model : IClassFixture<StreamStoreCo
 		Assert.Equal(nameof(TestSnapShotReadModel), snapshot.ModelName);
 		Assert.NotNull(snapshot.Checkpoints);
 		Assert.Single(snapshot.Checkpoints);
-		Assert.Equal(_stream, snapshot.Checkpoints[0].Item1);
-		Assert.Equal(9, snapshot.Checkpoints[0].Item2);
+		Assert.Equal(_stream, snapshot.Checkpoints[0].StreamName);
+		Assert.Equal(9, snapshot.Checkpoints[0].Version);
 		var state = snapshot.State as TestSnapShotReadModel.MyState;
 		Assert.NotNull(state);
 		Assert.Equal(10, state.Count);
@@ -58,7 +58,7 @@ public sealed class when_using_snapshot_read_model : IClassFixture<StreamStoreCo
 	public void can_apply_snapshot_to_read_model() {
 		var snapshot = new ReadModelState(
 			nameof(TestSnapShotReadModel),
-			[new Tuple<string, long>(_stream, 9)],
+			[new StreamCheckpoint(_stream, 9)],
 			new TestSnapShotReadModel.MyState { Count = 10, Sum = 20 });
 
 		var rm = new TestSnapShotReadModel(_aggId, _configuredConnection, snapshot);

--- a/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
@@ -238,13 +238,14 @@ public abstract class ReadModelBase :
 		return l;
 	}
 
-	/// <summary>
-	/// Get the positions of all listeners.
-	/// </summary>
-	/// <returns>A list of Tuples of listener names and checkpoints.</returns>
-	public List<Tuple<string, long>> GetCheckpoint() {
+	/// <summary>How far this model has applied each stream it listens to.</summary>
+	/// <remarks>
+	/// <see cref="StreamCheckpoint.Position"/> is null: a listener tracks its stream's version, not the
+	/// <c>$all</c> position of the events it delivered.
+	/// </remarks>
+	public List<StreamCheckpoint> GetCheckpoint() {
 		lock (_listeners) {
-			return _listeners.Select(l => new Tuple<string, long>(l.StreamName, l.Position)).ToList();
+			return _listeners.Select(l => new StreamCheckpoint(l.StreamName, l.Position)).ToList();
 		}
 	}
 

--- a/src/ReactiveDomain.Foundation/StreamStore/ReadModelState.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/ReadModelState.cs
@@ -5,16 +5,32 @@ namespace ReactiveDomain.Foundation;
 
 public class ReadModelState {
 	public readonly string ModelName;
-	public readonly List<Tuple<string, long>>? Checkpoints;
+
+	/// <summary>
+	/// Checkpoints for the streams the model reads itself. <see cref="SnapshotReadModel.Restore"/>
+	/// starts a listener for each of these, resuming from its <see cref="StreamCheckpoint.Version"/>.
+	/// </summary>
+	public readonly List<StreamCheckpoint>? Checkpoints;
+
+	/// <summary>
+	/// Checkpoints for streams fed to the model by something else — a relay, a shared category
+	/// reader — that the model does not read itself. Restoring records them without starting a
+	/// listener for any of them; it is the feeding source that resumes from these positions.
+	/// Null when the model has no external sources.
+	/// </summary>
+	public readonly List<StreamCheckpoint>? ExternalCheckpoints;
+
 	public readonly object State;
 
 	public ReadModelState(
 		string modelName,
-		List<Tuple<string, long>>? checkpoints,
-		object state) {
+		List<StreamCheckpoint>? checkpoints,
+		object state,
+		List<StreamCheckpoint>? externalCheckpoints = null) {
 		Ensure.NotNullOrEmpty(modelName, nameof(modelName));
 		ModelName = modelName;
 		Checkpoints = checkpoints;
 		State = state;
+		ExternalCheckpoints = externalCheckpoints;
 	}
 }

--- a/src/ReactiveDomain.Foundation/StreamStore/SnapshotReadModel.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/SnapshotReadModel.cs
@@ -1,4 +1,5 @@
-﻿using ReactiveDomain.Util;
+﻿using System.Diagnostics.CodeAnalysis;
+using ReactiveDomain.Util;
 
 // ReSharper disable once CheckNamespace
 namespace ReactiveDomain.Foundation;
@@ -6,12 +7,24 @@ namespace ReactiveDomain.Foundation;
 public abstract class SnapshotReadModel : ReadModelBase {
 	protected ReadModelState? StartingState { get; private set; }
 
+	// Kept apart from the listener checkpoints: merging them would start a listener for a stream a
+	// relay already reads, and deliver every event on it twice.
+	private readonly Dictionary<string, StreamCheckpoint> _externalCheckpoints = new(StringComparer.Ordinal);
+
 	protected SnapshotReadModel(
 		string name,
 		IConfiguredConnection connection)
 		: base(name, connection) {
 	}
 
+	/// <summary>Restores the model from a snapshot.</summary>
+	/// <param name="snapshot">The state to restore from.</param>
+	/// <param name="startListeners">Start a listener for each entry in
+	/// <see cref="ReadModelState.Checkpoints"/>. Never starts one for an entry in
+	/// <see cref="ReadModelState.ExternalCheckpoints"/> — those streams are read elsewhere.</param>
+	/// <param name="block">Block until each started listener is live.</param>
+	/// <param name="validateStreams">Ensure each started stream exists.</param>
+	/// <param name="cancelWaitToken">Cancels waiting when <paramref name="block"/> is true.</param>
 	protected virtual void Restore(
 		ReadModelState snapshot,
 		bool startListeners = true,
@@ -23,12 +36,68 @@ public abstract class SnapshotReadModel : ReadModelBase {
 		}
 		Ensure.NotNull(snapshot, nameof(snapshot));
 		StartingState = snapshot;
+		// Recorded before ApplyState so a model can read its sources' positions while restoring
+		// — that is when it has to tell its relay where to resume from.
+		if (snapshot.ExternalCheckpoints != null) {
+			lock (_externalCheckpoints) {
+				foreach (var external in snapshot.ExternalCheckpoints) {
+					_externalCheckpoints[external.StreamName] = external;
+				}
+			}
+		}
 		ApplyState(StartingState);
 		if (!startListeners || StartingState.Checkpoints == null)
 			return;
 
 		foreach (var stream in StartingState.Checkpoints) {
-			Start(stream.Item1, stream.Item2, block, validateStreams, cancelWaitToken);
+			Start(stream.StreamName, stream.Version, block, validateStreams, cancelWaitToken);
+		}
+	}
+
+	/// <summary>The recorded checkpoint of an external source.</summary>
+	/// <param name="streamName">The external stream's name.</param>
+	/// <param name="checkpoint">The recorded checkpoint, or null when none is recorded.</param>
+	/// <returns>True when a checkpoint is recorded for that stream.</returns>
+	protected bool TryGetExternalCheckpoint(
+		string streamName,
+		[NotNullWhen(true)] out StreamCheckpoint? checkpoint) {
+		Ensure.NotNullOrEmpty(streamName, nameof(streamName));
+		lock (_externalCheckpoints) {
+			if (_externalCheckpoints.TryGetValue(streamName, out var recorded)) {
+				checkpoint = recorded;
+				return true;
+			}
+		}
+		checkpoint = null;
+		return false;
+	}
+
+	/// <summary>
+	/// Records how far an external source has reached, for the next snapshot to carry. Replaces any
+	/// checkpoint already recorded for that stream.
+	/// </summary>
+	/// <param name="streamName">The external stream's name.</param>
+	/// <param name="version">The version reached on that stream.</param>
+	/// <param name="position">
+	/// That event's <c>$all</c> position, when the feeding source has one. Supplying it is what makes
+	/// the checkpoint comparable against other streams' — see <see cref="StreamCheckpoint"/>.
+	/// </param>
+	protected void SetExternalCheckpoint(string streamName, long version, Position? position = null) {
+		Ensure.NotNullOrEmpty(streamName, nameof(streamName));
+		lock (_externalCheckpoints) {
+			_externalCheckpoints[streamName] = new StreamCheckpoint(streamName, version, position);
+		}
+	}
+
+	/// <summary>
+	/// For <see cref="GetState"/> to pass to <see cref="ReadModelState"/>. Null when there are none,
+	/// so a model without external sources emits the state shape it always has.
+	/// </summary>
+	protected List<StreamCheckpoint>? GetExternalCheckpoints() {
+		lock (_externalCheckpoints) {
+			return _externalCheckpoints.Count == 0
+				? null
+				: _externalCheckpoints.Values.ToList();
 		}
 	}
 

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamCheckpoint.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamCheckpoint.cs
@@ -1,0 +1,41 @@
+﻿using ReactiveDomain.Util;
+
+// ReSharper disable once CheckNamespace
+namespace ReactiveDomain.Foundation;
+
+/// <summary>
+/// How far a read model has applied one stream: the stream's own version, and where that event sits
+/// in the store's global <c>$all</c> log.
+/// </summary>
+/// <remarks>
+/// <para>The two are different clocks and answer different questions. <see cref="Version"/> is dense
+/// and per-stream, so it is what a subscription resumes from and the only one that can express "the
+/// next event". <see cref="Position"/> is a store-wide log position that supports comparison and
+/// nothing else — no successor, no distance — but it is comparable <i>across</i> streams, which
+/// versions are not.</para>
+/// <para><see cref="Position"/> is null when the store does not report one, and is meaningful only
+/// within the store that issued it. Positions from two stores have no defined ordering.</para>
+/// </remarks>
+public sealed record StreamCheckpoint {
+	/// <summary>The stream this checkpoint is for.</summary>
+	public string StreamName { get; }
+
+	/// <summary>The version of the last event applied from that stream.</summary>
+	public long Version { get; }
+
+	/// <summary>
+	/// The <c>$all</c> position of the last event applied from that stream, when the store reports one.
+	/// </summary>
+	public Position? Position { get; }
+
+	/// <summary>Records how far a stream has been applied.</summary>
+	/// <param name="streamName">The stream this checkpoint is for.</param>
+	/// <param name="version">The version of the last event applied from that stream.</param>
+	/// <param name="position">That event's <c>$all</c> position, when the store reports one.</param>
+	public StreamCheckpoint(string streamName, long version, Position? position = null) {
+		Ensure.NotNullOrEmpty(streamName, nameof(streamName));
+		StreamName = streamName;
+		Version = version;
+		Position = position;
+	}
+}


### PR DESCRIPTION
**What does this pull request do?**

A snapshot could only record positions for streams a model reads itself. A model fed by something
else — a relay, a shared category reader — had nowhere to put where its feed had reached, so
restoring lost that position. This adds a place for it.

**How does this pull request accomplish that goal?**

`ReadModelState` gains a second, nullable list:

```csharp
public readonly List<Tuple<string, long>>? ExternalCheckpoints;
```

`SnapshotReadModel.Restore` records those positions and **starts no listener** for any of them. The
feeding source is what resumes from there; starting a listener as well would deliver every event
twice.

The write side is `SetExternalCheckpoint` / `TryGetExternalCheckpoint` / `GetExternalCheckpoints`, so
a position recorded while running is carried into the next snapshot. Positions are recorded before
`ApplyState` runs, so a model can read its sources' positions while restoring — which is when it has
to tell its relay where to resume.

The new constructor parameter is optional and last, so existing positional callers are unaffected.

**The contract worth reviewing** is the asymmetry between the two lists, because it is the whole
change:

- `Checkpoints` — *I read this stream.* Restore starts a listener from the recorded position.
- `ExternalCheckpoints` — *something else feeds me this stream.* Restore records the position and
  starts nothing.

Reversed in either direction the failure is silent: a listener started for an externally-fed stream
double-delivers everything, and a stream left out of `Checkpoints` never resumes at all. Verified by
mutation — making `Restore` start listeners for the external list fails three of the six tests,
including `external_positions_never_start_a_listener`.

**Why is this pull request important?**

Without it, any model behind a shared reader or relay either cannot be snapshotted or restores to a
position its feed disagrees with. It is also the piece the shared category reader needs in order to
survive a restart, so it sits directly beneath that work.

**Link to any issues that this resolves**

This does not address any open issues.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports — green on `net8.0` and `net10.0`
- [x] Any new code must be covered by at least one unit test — `when_using_external_snapshot_positions`, six cases
- [x] All public methods must be documented with XML comments

**Worth knowing before merge**

`GetState` is `public abstract`, so carrying external positions into a snapshot is opt-in per model:
a model that records them but does not pass `GetExternalCheckpoints()` into its `ReadModelState`
loses them silently. A protected helper that builds the state with both lists would make the correct
thing the default; not added here because it changes how every deriving model is expected to write
`GetState`.

Nothing in this repo serialises `ReadModelState` — persistence is the consumer's. The new field is
nullable and defaulted, so it is additive by construction, but how any particular serialiser handles
an added field is outside what this PR can verify.