### PR TITLE
Read a category once and relay it, instead of once per read model

### DIFF
--- a/src/ReactiveDomain.Foundation.Tests/when_using_category_stream.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_category_stream.cs
@@ -1,0 +1,660 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reactive;
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests;
+
+// ReSharper disable once InconsistentNaming
+public sealed class when_using_category_stream : IClassFixture<StreamStoreConnectionFixture>, IDisposable {
+	private static readonly IEventSerializer _serializer = new JsonMessageSerializer();
+
+	private readonly IStreamStoreConnection _store;
+	private readonly CountingConnection _counter;
+	private readonly IConfiguredConnection _connection;
+	private readonly IStreamNameBuilder _namer;
+	private readonly string _categoryStream;
+	private readonly string _aggregateStream;
+	private readonly List<CategoryStream<CategoryStreamTestAggregate>> _streams = [];
+	private readonly List<TestSubscriber> _subscribers = [];
+
+	public when_using_category_stream(StreamStoreConnectionFixture fixture) {
+		_store = fixture.Connection;
+		_store.Connect();
+		// Every test instance gets its own category, so tests sharing the fixture's store never see each
+		// other's events and the read counts belong to this test alone.
+		_namer = new PrefixedCamelCaseStreamNameBuilder(Guid.NewGuid().ToString("N"));
+		_counter = new CountingConnection(_store);
+		_connection = new ConfiguredConnection(_counter, _namer, _serializer);
+		_categoryStream = _namer.GenerateForCategory(typeof(CategoryStreamTestAggregate));
+		_aggregateStream = _namer.GenerateForAggregate(typeof(CategoryStreamTestAggregate), Guid.NewGuid());
+	}
+
+	[Fact]
+	public void one_store_read_serves_every_subscriber() {
+		AppendEvents(6);
+		var first = NewSubscriber();
+		var second = NewSubscriber();
+		var source = NewStream();
+		source.RelayTo(first);
+		source.RelayTo(second);
+
+		source.Start();
+
+		WaitForGoLive(first, second);
+		Assert.Equal([0, 1, 2, 3, 4, 5], first.Received);
+		Assert.Equal(first.Received, second.Received);
+		// Two subscribers, one pass over the history — the whole point of the type.
+		Assert.Equal(1, _counter.PageReadCount(_categoryStream));
+	}
+
+	[Fact]
+	public async Task start_async_reads_the_category_once_for_every_subscriber() {
+		AppendEvents(6);
+		var first = NewSubscriber();
+		var second = NewSubscriber();
+		var source = NewStream();
+		source.RelayTo(first);
+		source.RelayTo(second);
+
+		await source.StartAsync().WaitAsync(TestTimeouts.ThrottleWaitFor);
+
+		WaitForGoLive(first, second);
+		Assert.Equal([0, 1, 2, 3, 4, 5], first.Received);
+		Assert.Equal(first.Received, second.Received);
+		Assert.Equal(1, _counter.PageReadCount(_categoryStream));
+	}
+
+	[Fact]
+	public void a_restored_relay_is_gated_and_a_from_scratch_relay_is_not() {
+		AppendEvents(6);
+		var restored = NewSubscriber();
+		var fromScratch = NewSubscriber();
+		var source = NewStream();
+		source.RelayTo(restored, fromPosition: 2);
+		source.RelayTo(fromScratch);
+
+		source.Start();
+
+		WaitForGoLive(restored, fromScratch);
+		Assert.Equal([3, 4, 5], restored.Received);
+		Assert.Equal([0, 1, 2, 3, 4, 5], fromScratch.Received);
+		// One read served both: the from-scratch relay forced the full read and the restored relay
+		// dropped what it already held.
+		Assert.Equal(1, _counter.PageReadCount(_categoryStream));
+		Assert.Equal(0, _counter.FirstPageReadStart(_categoryStream));
+	}
+
+	[Fact]
+	public void the_read_starts_at_the_lowest_position_any_relay_still_needs() {
+		AppendEvents(6);
+		var older = NewSubscriber();
+		var newer = NewSubscriber();
+		var source = NewStream();
+		source.RelayTo(older, fromPosition: 1);
+		source.RelayTo(newer, fromPosition: 3);
+
+		source.Start();
+
+		WaitForGoLive(older, newer);
+		Assert.Equal([2, 3, 4, 5], older.Received);
+		Assert.Equal([4, 5], newer.Received);
+		Assert.Equal(1, _counter.PageReadCount(_categoryStream));
+		// Read from the lowest checkpoint any relay still needs (1), i.e. starting at the next event.
+		Assert.Equal(2, _counter.FirstPageReadStart(_categoryStream));
+	}
+
+	[Fact]
+	public void exactly_one_go_live_is_forwarded_after_the_history() {
+		AppendEvents(4);
+		var subscriber = NewSubscriber();
+		var source = NewStream();
+		source.RelayTo(subscriber);
+
+		source.Start();
+
+		WaitForGoLive(subscriber);
+		// The go-live lands behind the whole history, never in the middle of it.
+		Assert.Equal(4, subscriber.EventsBeforeFirstGoLive);
+		// The live phase does not produce a second one — the count consumers rely on stays at one.
+		AppendEvents(3, firstValue: 100);
+		AssertEx.IsOrBecomesTrue(() => subscriber.Received.Length == 7, TestTimeouts.ThrottleWaitFor);
+		Assert.Equal(1, subscriber.GoLives);
+	}
+
+	[Fact]
+	public void live_events_reach_every_relay_whatever_its_gate() {
+		AppendEvents(4);
+		var restored = NewSubscriber();
+		var fromScratch = NewSubscriber();
+		var source = NewStream();
+		source.RelayTo(restored, fromPosition: 1);
+		source.RelayTo(fromScratch);
+		source.Start();
+		WaitForGoLive(restored, fromScratch);
+
+		AppendEvents(2, firstValue: 100);
+
+		AssertEx.IsOrBecomesTrue(() => restored.Received.Length == 4 && fromScratch.Received.Length == 6,
+			TestTimeouts.ThrottleWaitFor);
+		// The gate applies to the catch-up read only: live events are past every checkpoint by
+		// construction, so both relays see them.
+		Assert.Equal([2, 3, 100, 101], restored.Received);
+		Assert.Equal([0, 1, 2, 3, 100, 101], fromScratch.Received);
+		Assert.Equal(1, restored.GoLives);
+		Assert.Equal(1, fromScratch.GoLives);
+	}
+
+	[Fact]
+	public void position_at_go_live_is_the_last_position_read() {
+		AppendEvents(6);
+		var subscriber = NewSubscriber();
+		var source = NewStream();
+		source.RelayTo(subscriber);
+
+		source.Start();
+
+		WaitForGoLive(subscriber);
+		// Six events at category positions 0-5.
+		Assert.Equal(5L, source.PositionAtGoLive);
+	}
+
+	[Fact]
+	public void position_at_go_live_is_null_when_nothing_was_read() {
+		var subscriber = NewSubscriber();
+		var source = NewStream();
+		source.RelayTo(subscriber);
+
+		source.Start();
+
+		WaitForGoLive(subscriber);
+		Assert.Empty(subscriber.Received);
+		Assert.Null(source.PositionAtGoLive);
+	}
+
+	/// <summary>
+	/// The ordering rule is enforced, not merely documented, because getting it wrong fails silently:
+	/// a late relay misses the history already read and the go-live already forwarded, and a subscriber
+	/// whose liveness is counted one go-live per source would then never go live, with nothing to say
+	/// why. The throw is what turns that into a loud failure at the call site.
+	/// </summary>
+	[Fact]
+	public void a_relay_attached_after_start_throws_rather_than_miss_the_history_and_the_go_live() {
+		AppendEvents(3);
+		var early = NewSubscriber();
+		var source = NewStream();
+		source.RelayTo(early);
+		source.Start();
+		WaitForGoLive(early);
+
+		var late = NewSubscriber();
+		var thrown = Assert.Throws<InvalidOperationException>(() => source.RelayTo(late));
+
+		// The message has to name the consequence, or the caller learns only that it is not allowed.
+		Assert.Contains("history", thrown.Message, StringComparison.OrdinalIgnoreCase);
+		Assert.Contains("go-live", thrown.Message, StringComparison.OrdinalIgnoreCase);
+
+		// Refused outright, not half-attached: the live phase reaches the early subscriber and nothing
+		// at all reaches the late one.
+		AppendEvents(2, firstValue: 100);
+		AssertEx.IsOrBecomesTrue(() => early.Received.Length == 5, TestTimeouts.ThrottleWaitFor);
+		Assert.Equal([0, 1, 2, 100, 101], early.Received);
+		Assert.Empty(late.Received);
+		Assert.Equal(0, late.GoLives);
+	}
+
+	[Fact]
+	public void the_stream_names_the_category_it_reads() {
+		// The key half of the checkpoint a consumer stores alongside PositionAtGoLive.
+		Assert.Equal(_categoryStream, NewStream().StreamName);
+	}
+
+	/// <summary>
+	/// A relayed target reads nothing itself, so without the relay registering a source its IsLive
+	/// would be vacuously complete — reporting live over a model holding none of the category.
+	/// </summary>
+	[Fact]
+	public async Task a_relayed_target_is_not_live_until_the_relay_has_handed_over_history() {
+		AppendEvents(4);
+		var subscriber = NewSubscriber();
+		var source = NewStream();
+		source.RelayTo(subscriber);
+
+		// Registered by RelayTo, so the target is already accounted for before anything is read.
+		Assert.False(subscriber.IsLive.IsCompleted);
+
+		source.Start();
+
+		await subscriber.IsLive.WaitAsync(TestTimeouts.ThrottleWaitFor);
+		Assert.Equal(4, subscriber.Received.Length);
+	}
+
+	/// <summary>
+	/// Detaching before go-live leaves the target unfed, so its registration has to be released or
+	/// anyone awaiting it waits for history that is no longer coming.
+	/// </summary>
+	[Fact]
+	public void detaching_a_relay_before_go_live_releases_the_target() {
+		var subscriber = NewSubscriber();
+		var source = NewStream();
+		var subscription = source.RelayTo(subscriber);
+		Assert.False(subscriber.IsLive.IsCompleted);
+
+		subscription.Dispose();
+
+		AssertEx.IsOrBecomesTrue(() => subscriber.IsLive.IsCompleted, TestTimeouts.ThrottleWaitFor);
+	}
+
+	[Fact]
+	public void disposing_the_stream_before_go_live_releases_its_targets() {
+		var subscriber = NewSubscriber();
+		var source = NewStream();
+		source.RelayTo(subscriber);
+		Assert.False(subscriber.IsLive.IsCompleted);
+
+		source.Dispose();
+
+		AssertEx.IsOrBecomesTrue(() => subscriber.IsLive.IsCompleted, TestTimeouts.ThrottleWaitFor);
+	}
+
+	/// <summary>A second release would retire a source the target still has coming.</summary>
+	/// <remarks>
+	/// Both releases land on any relay held past go-live — the stream releases it as it forwards the
+	/// go-live, the consumer's disposal releases it again — so no concurrency is needed to reach the
+	/// guard. The marker event is the barrier: queued behind both, so once it lands the registration
+	/// count can be read for real rather than guessed at.
+	/// </remarks>
+	[Fact]
+	public void releasing_a_relay_twice_releases_one_registration() {
+		const int marker = -1;
+		AppendEvents(1);
+		var subscriber = NewSubscriber();
+		var held = NewStream();
+		var source = NewStream();
+		var subscription = source.RelayTo(subscriber);
+		// Never started, so nothing but a stray release can retire it.
+		held.RelayTo(subscriber);
+
+		source.Start();
+		WaitForGoLive(subscriber);
+		subscription.Dispose();
+
+		subscriber.Handle(new CategoryStreamTestEvent(marker));
+		AssertEx.IsOrBecomesTrue(() => subscriber.Received.Contains(marker), TestTimeouts.ThrottleWaitFor);
+
+		Assert.False(subscriber.IsLive.IsCompleted,
+			"releasing one relay twice retired the source still outstanding.");
+	}
+
+	/// <summary>
+	/// The other half of that checkpoint. A relayed model does not read the category, so the position
+	/// it stores is the stream's, and it has to come back on restore without a listener being started
+	/// for a stream the category stream already reads.
+	/// </summary>
+	[Fact]
+	public void the_go_live_position_round_trips_as_an_external_checkpoint() {
+		AppendEvents(4);
+		var subscriber = NewSubscriber();
+		var source = NewStream();
+		source.RelayTo(subscriber);
+		source.Start();
+		WaitForGoLive(subscriber);
+
+		var snapshot = new ReadModelState(
+			"relayed",
+			checkpoints: null,
+			state: new object(),
+			externalCheckpoints: [new StreamCheckpoint(source.StreamName, source.PositionAtGoLive!.Value)]);
+
+		using var restored = new RelayedSnapshotModel(_connection);
+		restored.RestoreFrom(snapshot);
+
+		Assert.True(restored.HasExternalCheckpoint(source.StreamName, out var checkpoint));
+		Assert.Equal(source.StreamName, checkpoint.StreamName);
+		Assert.Equal(source.PositionAtGoLive!.Value, checkpoint.Version);
+		// The category position is this stream's own clock, not an $all position, so there is none.
+		Assert.Null(checkpoint.Position);
+		// Nothing was started for it: the category stream owns that read.
+		Assert.Empty(restored.GetCheckpoint());
+	}
+
+	private sealed class RelayedSnapshotModel(IConfiguredConnection connection)
+		: SnapshotReadModel(nameof(RelayedSnapshotModel), connection) {
+		public void RestoreFrom(ReadModelState snapshot) => Restore(snapshot);
+
+		public bool HasExternalCheckpoint(
+			string streamName,
+			[NotNullWhen(true)] out StreamCheckpoint? checkpoint) =>
+			TryGetExternalCheckpoint(streamName, out checkpoint);
+
+		protected override void ApplyState(ReadModelState snapshot) { }
+
+		public override ReadModelState GetState() =>
+			new(nameof(RelayedSnapshotModel), GetCheckpoint(), new object(), GetExternalCheckpoints());
+	}
+
+	[Fact]
+	public void disposing_a_relay_stops_delivery_to_that_target() {
+		AppendEvents(2);
+		var kept = NewSubscriber();
+		var dropped = NewSubscriber();
+		var source = NewStream();
+		source.RelayTo(kept);
+		var subscription = source.RelayTo(dropped);
+		source.Start();
+		WaitForGoLive(kept, dropped);
+
+		subscription.Dispose();
+		AppendEvents(2, firstValue: 100);
+
+		AssertEx.IsOrBecomesTrue(() => kept.Received.Length == 4, TestTimeouts.ThrottleWaitFor);
+		Assert.Equal([0, 1, 100, 101], kept.Received);
+		Assert.Equal([0, 1], dropped.Received);
+	}
+
+	[Fact]
+	public void starting_twice_throws() {
+		AppendEvents(2);
+		var subscriber = NewSubscriber();
+		var source = NewStream();
+		source.RelayTo(subscriber);
+		source.Start();
+		WaitForGoLive(subscriber);
+
+		Assert.Throws<InvalidOperationException>(() => source.Start());
+		Assert.Equal(1, _counter.PageReadCount(_categoryStream));
+	}
+
+	/// <summary>
+	/// A relay registers a source on its target before anything is read. If the read then fails, the
+	/// target is left holding its liveness open for history that will never be sent, and awaiting it
+	/// waits forever — a hang, with nothing to say why.
+	/// </summary>
+	[Fact]
+	public void a_start_that_throws_releases_the_targets_it_registered() {
+		AppendEvents(2);
+		var subscriber = NewSubscriber();
+		var failing = new ConfiguredConnection(
+			new CountingConnection(_store, failReadsOn: _categoryStream), _namer, _serializer);
+		var source = new CategoryStream<CategoryStreamTestAggregate>(failing);
+		_streams.Add(source);
+		source.RelayTo(subscriber);
+		Assert.False(subscriber.IsLive.IsCompleted);
+
+		Assert.Throws<InvalidOperationException>(() => source.Start());
+
+		AssertEx.IsOrBecomesTrue(() => subscriber.IsLive.IsCompleted, TestTimeouts.ThrottleWaitFor,
+			"A failed start left its target waiting on history nobody will send.");
+	}
+
+	/// <summary>
+	/// A relay's registration is stamped with the generation it was made in, so a release that arrives
+	/// after that generation was abandoned cannot retire a source registered since.
+	/// </summary>
+	/// <remarks>
+	/// <para>The abandonment has to come from the <i>target's</i> own start failing. A failure in the
+	/// stream's start drains its relays as it leaves, in the generation they were registered in, which
+	/// is the ordinary path and proves nothing about the stamp.</para>
+	/// <para>The later stream is gated inside its <i>read</i> rather than in a handler. A handler gate
+	/// would park the queue thread, so the stale release would sit behind that stream's own sentinel
+	/// and be ignored because the count had already reached zero — again proving nothing. Holding the
+	/// read open lets the stale release reach an empty queue and a non-zero count, which is the only
+	/// arrangement a stamped and an unstamped release disagree on.</para>
+	/// </remarks>
+	[Fact]
+	public void a_relay_released_after_its_generation_was_abandoned_retires_nothing() {
+		var failing = _namer.GenerateForAggregate(typeof(CategoryStreamTestAggregate), Guid.NewGuid());
+		var gated = _namer.GenerateForAggregate(typeof(CategoryStreamTestAggregate), Guid.NewGuid());
+		foreach (var stream in new[] { failing, gated }) {
+			_store.AppendToStream(stream, ExpectedVersion.Any, null,
+				_serializer.Serialize(new CategoryStreamTestEvent(7)));
+		}
+		using var readGate = new ManualResetEventSlim(false);
+		var counter = new CountingConnection(_store, failReadsOn: failing, blockReadsOn: (gated, readGate));
+		var connection = new ConfiguredConnection(counter, _namer, _serializer);
+
+		var subscriber = new TestSubscriber("generation-target", connection);
+		_subscribers.Add(subscriber);
+		// Never started, so nothing drains this relay but the release below.
+		var source = new CategoryStream<CategoryStreamTestAggregate>(connection);
+		_streams.Add(source);
+		var relay = source.RelayTo(subscriber);
+
+		// The target's own start fails, abandoning every source outstanding — the relay's registration
+		// included — and moving the generation on.
+		Assert.Throws<InvalidOperationException>(() => subscriber.Start(failing));
+
+		// A stream registered in the new generation, held open inside its read so nothing has queued a
+		// sentinel for it yet.
+		subscriber.StartAsync(gated);
+		var live = subscriber.IsLive;
+		AssertEx.IsOrBecomesTrue(() => counter.BlockedReads > 0, TestTimeouts.ThrottleWaitFor,
+			"The gated read never started.");
+
+		relay.Dispose();
+		// Waited on rather than assumed: the release is a queued message, and asserting before it is
+		// handled would pass whether or not it was stamped.
+		AssertEx.IsOrBecomesTrue(() => subscriber.Idle && subscriber.MessageCount == 0,
+			TestTimeouts.ThrottleWaitFor, "The release was never handled.");
+
+		Assert.False(live.IsCompleted,
+			"A release from an abandoned generation retired a stream registered after it.");
+
+		readGate.Set();
+		AssertEx.IsOrBecomesTrue(() => live.IsCompleted, TestTimeouts.ThrottleWaitFor);
+	}
+
+	/// <summary>
+	/// The other half: a stamp that is merely <i>a</i> value rather than the registration's own would
+	/// make every release from a later generation a no-op, and its target would never go live.
+	/// </summary>
+	[Fact]
+	public void a_relay_registered_after_an_abandonment_still_retires_its_target() {
+		AppendEvents(2);
+		// Outside the category, so failing it moves the generation on without adding to what is relayed.
+		var failing = $"unrelated-{Guid.NewGuid():N}";
+		_store.AppendToStream(failing, ExpectedVersion.Any, null,
+			_serializer.Serialize(new CategoryStreamTestEvent(7)));
+		var connection = new ConfiguredConnection(
+			new CountingConnection(_store, failReadsOn: failing), _namer, _serializer);
+
+		var subscriber = new TestSubscriber("post-abandonment-target", connection);
+		_subscribers.Add(subscriber);
+		// Moves the generation on before the relay is registered, so the registration's own generation
+		// is no longer the first one.
+		Assert.Throws<InvalidOperationException>(() => subscriber.Start(failing));
+
+		var source = new CategoryStream<CategoryStreamTestAggregate>(connection);
+		_streams.Add(source);
+		source.RelayTo(subscriber);
+		var live = subscriber.IsLive;
+
+		source.Start();
+
+		AssertEx.IsOrBecomesTrue(() => live.IsCompleted, TestTimeouts.ThrottleWaitFor,
+			"The relay handed over its history and released, but the target never went live.");
+		Assert.Equal([0, 1], subscriber.Received);
+	}
+
+	private CategoryStream<CategoryStreamTestAggregate> NewStream() {
+		var source = new CategoryStream<CategoryStreamTestAggregate>(_connection);
+		_streams.Add(source);
+		return source;
+	}
+
+	private TestSubscriber NewSubscriber() {
+		var subscriber = new TestSubscriber($"subscriber-{_subscribers.Count}", _connection);
+		_subscribers.Add(subscriber);
+		return subscriber;
+	}
+
+	private static void WaitForGoLive(params TestSubscriber[] subscribers) =>
+		AssertEx.IsOrBecomesTrue(() => subscribers.All(s => s.GoLives == 1), TestTimeouts.ThrottleWaitFor,
+			"Expected every subscriber to be handed exactly one go-live.");
+
+	private void AppendEvents(int count, int firstValue = 0) {
+		var existing = _store.ReadStreamForward(_aggregateStream, 0, 500)?.Events.Length ?? 0;
+		for (var i = 0; i < count; i++) {
+			_store.AppendToStream(_aggregateStream, ExpectedVersion.Any, null,
+				_serializer.Serialize(new CategoryStreamTestEvent(firstValue + i)));
+		}
+
+		_store.TryConfirmStream(_categoryStream, existing + count);
+	}
+
+	public void Dispose() {
+		_streams.ForEach(s => s.Dispose());
+		_subscribers.ForEach(s => s.Dispose());
+	}
+
+	public record CategoryStreamTestEvent(int Value) : Event;
+
+	public class CategoryStreamTestAggregate : EventDrivenStateMachine;
+
+	/// <summary>A read model that records what a relay handed it, and when it was told the source is live.</summary>
+	private sealed class TestSubscriber : ReadModelBase,
+		IHandle<CategoryStreamTestEvent>,
+		IHandle<StreamStoreMsgs.CatchupSubscriptionBecameLive> {
+		private readonly List<int> _received = [];
+		private int _goLives;
+		private int _eventsBeforeFirstGoLive = -1;
+
+		public TestSubscriber(string name, IConfiguredConnection connection) : base(name, connection) {
+			EventStream.Subscribe<CategoryStreamTestEvent>(this);
+			EventStream.Subscribe<StreamStoreMsgs.CatchupSubscriptionBecameLive>(this);
+		}
+
+		public int[] Received {
+			get {
+				lock (ReaderLock) {
+					return _received.ToArray();
+				}
+			}
+		}
+
+		public int GoLives {
+			get {
+				lock (ReaderLock) {
+					return _goLives;
+				}
+			}
+		}
+
+		public int EventsBeforeFirstGoLive {
+			get {
+				lock (ReaderLock) {
+					return _eventsBeforeFirstGoLive;
+				}
+			}
+		}
+
+		public void Handle(CategoryStreamTestEvent @event) => _received.Add(@event.Value);
+
+		public void Handle(StreamStoreMsgs.CatchupSubscriptionBecameLive message) {
+			if (_goLives == 0)
+				_eventsBeforeFirstGoLive = _received.Count;
+			_goLives++;
+		}
+	}
+
+	/// <summary>
+	/// Counts the reads that reach the store, so "one read serves N subscribers" is asserted against the
+	/// store rather than inferred. Page reads (the ones that carry history) are counted apart from the
+	/// single-event probes a reader uses to check that a stream exists.
+	/// </summary>
+	private sealed class CountingConnection(
+		IStreamStoreConnection inner,
+		string? failReadsOn = null,
+		(string Stream, ManualResetEventSlim Gate)? blockReadsOn = null) : IStreamStoreConnection {
+		private readonly object _countLock = new();
+		private readonly Dictionary<string, List<long>> _pageReadStarts = [];
+		private int _blockedReads;
+
+		/// <summary>How many reads have parked on the gate, so a test can wait for one rather than sleep.</summary>
+		public int BlockedReads => Volatile.Read(ref _blockedReads);
+
+		public int PageReadCount(string stream) {
+			lock (_countLock) {
+				return _pageReadStarts.TryGetValue(stream, out var starts) ? starts.Count : 0;
+			}
+		}
+
+		public long FirstPageReadStart(string stream) {
+			lock (_countLock) {
+				return _pageReadStarts[stream][0];
+			}
+		}
+
+		public StreamEventsSlice? ReadStreamForward(string stream, long start, long count,
+			UserCredentials? credentials = null) {
+			// Page reads only: the reader probes existence with a single-event read and swallows what
+			// that throws, so failing it would never reach the caller. History is read in pages.
+			if (stream == failReadsOn && count > 1)
+				throw new InvalidOperationException($"Reads of {stream} are failing.");
+			if (blockReadsOn is { } blocked && stream == blocked.Stream && count > 1) {
+				Interlocked.Increment(ref _blockedReads);
+				blocked.Gate.Wait(TestTimeouts.ThrottleWaitFor);
+			}
+			if (count > 1) {
+				lock (_countLock) {
+					if (!_pageReadStarts.TryGetValue(stream, out var starts)) {
+						starts = [];
+						_pageReadStarts.Add(stream, starts);
+					}
+
+					starts.Add(start);
+				}
+			}
+
+			return inner.ReadStreamForward(stream, start, count, credentials);
+		}
+
+		public string ConnectionName => inner.ConnectionName;
+		public void Connect() => inner.Connect();
+		public void Close() => inner.Close();
+
+		public WriteResult AppendToStream(string stream, long expectedVersion, UserCredentials? credentials = null,
+			params EventData[] events) =>
+			inner.AppendToStream(stream, expectedVersion, credentials, events);
+
+		public StreamEventsSlice? ReadStreamBackward(string stream, long start, long count,
+			UserCredentials? credentials = null) =>
+			inner.ReadStreamBackward(stream, start, count, credentials);
+
+		public IDisposable SubscribeToStream(string stream, Action<RecordedEvent> eventAppeared,
+			Action<SubscriptionDropReason, Exception?>? subscriptionDropped = null,
+			UserCredentials? credentials = null) =>
+			inner.SubscribeToStream(stream, eventAppeared, subscriptionDropped, credentials);
+
+		public IDisposable SubscribeToStreamFrom(string stream, long? lastCheckpoint,
+			CatchUpSubscriptionSettings? settings, Action<RecordedEvent> eventAppeared,
+			Action<Unit>? liveProcessingStarted = null,
+			Action<SubscriptionDropReason, Exception?>? subscriptionDropped = null,
+			UserCredentials? credentials = null) =>
+			inner.SubscribeToStreamFrom(stream, lastCheckpoint, settings, eventAppeared, liveProcessingStarted,
+				subscriptionDropped, credentials);
+
+		public IDisposable SubscribeToAll(Action<RecordedEvent> eventAppeared,
+			Action<SubscriptionDropReason, Exception?>? subscriptionDropped = null,
+			UserCredentials? credentials = null, bool resolveLinkTos = true) =>
+			inner.SubscribeToAll(eventAppeared, subscriptionDropped, credentials, resolveLinkTos);
+
+		public IDisposable SubscribeToAllFrom(Position from, Action<RecordedEvent> eventAppeared,
+			CatchUpSubscriptionSettings? settings = null, Action? liveProcessingStarted = null,
+			Action<SubscriptionDropReason, Exception?>? subscriptionDropped = null,
+			UserCredentials? credentials = null, bool resolveLinkTos = true) =>
+			inner.SubscribeToAllFrom(from, eventAppeared, settings, liveProcessingStarted, subscriptionDropped,
+				credentials, resolveLinkTos);
+
+		public void DeleteStream(string stream, long expectedVersion, UserCredentials? credentials = null) =>
+			inner.DeleteStream(stream, expectedVersion, credentials);
+
+		public void HardDeleteStream(string stream, long expectedVersion, UserCredentials? credentials = null) =>
+			inner.HardDeleteStream(stream, expectedVersion, credentials);
+
+		// The fixture owns the underlying connection's lifetime; this wrapper is a counter, not an owner.
+		public void Dispose() { }
+	}
+}

--- a/src/ReactiveDomain.Foundation/StreamStore/CategoryStream.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/CategoryStream.cs
@@ -1,0 +1,369 @@
+﻿using ReactiveDomain.Logging;
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Util;
+
+// ReSharper disable once CheckNamespace
+namespace ReactiveDomain.Foundation;
+
+/// <summary>
+/// One catch-up read over one aggregate's category stream, shared by every read model that needs it.
+/// </summary>
+/// <remarks>
+/// <para><b>When to use this rather than <see cref="ReadModelBase.StartAsync{TAggregate}(long?,bool,CancellationToken)"/>.</b>
+/// That overload is an independent full read of a category — its own reader, its own listener, its own
+/// pass over the history — and it is the right choice for a single model. Where several models fold the
+/// same category they each open one, and the cost lands on whatever path constructs them. This type reads
+/// the category <b>once</b> and hands every event to each read model that attached a relay, so N
+/// interested models cost one read instead of N. The trade is ordering: every relay must be attached
+/// before <see cref="Start"/>, which a model starting its own stream never has to arrange.</para>
+///
+/// <para><b>Why the relay forwards everything.</b> <see cref="RelayTo"/> forwards the whole category, not a
+/// chosen set of event types, because that is precisely what a read model sees when it reads the category
+/// itself: its bus is handed every event and dispatches only the types it subscribed. Forwarding a subset
+/// would quietly change which messages arrive, and would break the "count the streams that went live"
+/// idiom consumers use to flush a buffered cache — this way each source contributes exactly one
+/// <see cref="StreamStoreMsgs.CatchupSubscriptionBecameLive"/>, the same as one <c>StartAsync</c> did, so
+/// those counts stay correct without being touched.</para>
+///
+/// <para><b>Why it is a relay and not a shared subscription.</b> The target is handed the message through
+/// <see cref="ReadModelBase.Handle(IMessage)"/>, which enqueues onto the target's own queue. Subscribing a
+/// read model's typed handler directly to another model's event stream would instead run that handler on
+/// the <i>source's</i> thread and mutate the target's state outside its own reader lock — a data race, and
+/// an easy one to write by accident.</para>
+///
+/// <para><b>Liveness still belongs to the target.</b> <see cref="RelayTo"/> registers the relay as a
+/// source on the target, so a relayed stream counts in the target's <see cref="ReadModelBase.IsLive"/>
+/// exactly as a stream it read itself would: the registration is released once this stream has handed
+/// over the history, behind it in the target's queue. Awaiting the target is therefore the whole
+/// hydration barrier — there is no need to await this stream as well.</para>
+/// </remarks>
+/// <typeparam name="TAggregate">The aggregate whose category stream this reads.</typeparam>
+public sealed class CategoryStream<TAggregate> : IDisposable where TAggregate : class, IEventSource {
+	private const long NoPosition = -1;
+
+	private static readonly ILogger Log = LogManager.GetLogger("ReactiveDomain");
+
+	private readonly IConfiguredConnection _connection;
+	private readonly string _name;
+	private readonly object _relayLock = new();
+	private readonly List<Relay> _relays = [];
+
+	private IStreamReader? _reader;
+	private IListener? _listener;
+	private IDisposable? _listenerSubscription;
+	// Read and written only under _relayLock, so "attach a relay" and "start" cannot interleave: a
+	// relay is either registered before the read begins or refused.
+	private bool _started;
+	private long _lastRelayedPosition = NoPosition;
+	private long _positionAtGoLive = NoPosition;
+	private volatile bool _disposed;
+
+	/// <summary>
+	/// Creates a shared reader over the category stream of <typeparamref name="TAggregate"/>. Nothing is
+	/// read until <see cref="Start"/> or <see cref="StartAsync"/> is called.
+	/// </summary>
+	/// <param name="connection">A configured connection to the stream store.</param>
+	public CategoryStream(IConfiguredConnection connection) {
+		Ensure.NotNull(connection, nameof(connection));
+		_connection = connection;
+		_name = $"{nameof(CategoryStream<TAggregate>)}:{typeof(TAggregate).Name}";
+		StreamName = connection.StreamNamer.GenerateForCategory(typeof(TAggregate));
+	}
+
+	/// <summary>
+	/// The category stream this reads, as the store names it.
+	/// </summary>
+	/// <remarks>A checkpoint is a stream name and a position, and this type already owns the position
+	/// (<see cref="PositionAtGoLive"/>). A consumer merging checkpoints from several sources needs the
+	/// key as well, and the stream is the only thing that knows for certain which category it read —
+	/// rebuilding the name from the connection's namer is a second derivation that nothing keeps in step
+	/// with the first.</remarks>
+	public string StreamName { get; }
+
+	/// <summary>
+	/// The category position of the last event relayed before this stream forwarded its go-live, or
+	/// <c>null</c> if it went live having relayed nothing. This is the checkpoint a relayed read model
+	/// persists for this source.
+	/// </summary>
+	/// <remarks>
+	/// <para><b>The stream is the position authority.</b> A relayed <see cref="IMessage"/> carries no
+	/// position, and stamping one onto it would change the delivered type and so change which handlers
+	/// dispatch. The stream therefore counts positions as it reads and publishes the one value a
+	/// subscriber needs.</para>
+	/// <para><b>Subscribers checkpoint at the forwarded go-live, and only there.</b> At that moment a
+	/// subscriber has, by queue order, consumed exactly everything relayed before the go-live, so this
+	/// value is precisely its own position. Mid-live it is not: the subscriber's consumed position lags
+	/// this one by whatever is sitting in its queue, so a checkpoint taken at <see cref="Dispose"/> would
+	/// overclaim by that queue depth and the next restore would skip events the model never folded. The
+	/// only cost of not writing one at dispose is re-folding the live-session delta on the next open.</para>
+	/// </remarks>
+	public long? PositionAtGoLive {
+		get {
+			var position = Interlocked.Read(ref _positionAtGoLive);
+			return position == NoPosition ? null : position;
+		}
+	}
+
+	/// <summary>
+	/// Forwards every event in this category onto <paramref name="target"/>'s own queue, for as long as
+	/// the returned subscription is held. Must be called before <see cref="Start"/>.
+	/// </summary>
+	/// <param name="target">The read model to relay to.</param>
+	/// <param name="fromPosition">
+	/// The category position this target has already folded — from a snapshot's checkpoint for this
+	/// stream. During the catch-up read the relay drops events at positions at or below it; the go-live
+	/// and every live-phase event are always delivered. <c>null</c> (the default) means "I hold nothing",
+	/// and the target is relayed the whole category.
+	/// </param>
+	/// <returns>A subscription; disposing it detaches this relay.</returns>
+	/// <exception cref="InvalidOperationException">The stream has already been started, so this relay
+	/// would miss the history and the go-live.</exception>
+	/// <remarks>
+	/// <para>Gating is per relay, so one read serves a restored subscriber and a from-scratch one at the
+	/// same time: <see cref="Start"/> reads from the <b>lowest</b> position any relay still needs, and the
+	/// relays that already hold more simply skip what they already have. A single subscriber without a
+	/// checkpoint therefore forces the full read, which is correct — it needs the whole history — and
+	/// costs the restored subscribers nothing but a comparison per event.</para>
+	/// <para>Gating never touches the go-live, so a consumer counting one go-live per source still counts
+	/// correctly whether it was restored or not.</para>
+	/// <para><b>Attaching after <see cref="Start"/> throws</b>, for the same reason a second
+	/// <see cref="Start"/> does: the alternative fails silently. A late relay misses the history that has
+	/// already been read and the go-live that has already been forwarded, and since exactly one go-live
+	/// per source is what subscriber liveness counting rests on, its target would sit forever one go-live
+	/// short of live with nothing to indicate why. The rule is: attach every relay, then start.</para>
+	/// </remarks>
+	public IDisposable RelayTo(ReadModelBase target, long? fromPosition = null) {
+		Ensure.NotNull(target, nameof(target));
+		if (fromPosition is not null)
+			Ensure.Nonnegative(fromPosition.Value, nameof(fromPosition));
+
+		lock (_relayLock) {
+			// Inside the lock, with the same flag Dispose sets there: outside it, a relay could be
+			// registered onto a list Dispose had already taken and drained, and never be released.
+			ObjectDisposedException.ThrowIf(_disposed, this);
+			if (_started) {
+				throw new InvalidOperationException(
+					$"{_name} has already been started, so this relay would miss the history already read " +
+					"and the go-live already forwarded, and its target would never go live. Attach every " +
+					"relay before starting.");
+			}
+
+			// The target does not read this stream, so nothing else would hold its IsLive open until
+			// this relay has handed over the history.
+			var relay = new Relay(this, target, fromPosition, target.RegisterExternalSource());
+			_relays.Add(relay);
+			return relay;
+		}
+	}
+
+	/// <summary>
+	/// Reads the category on the calling thread, relaying as it goes, then starts a listener for live
+	/// events. Call once, <b>after</b> every <see cref="RelayTo"/>.
+	/// </summary>
+	/// <param name="cancelWaitToken">Cancellation token passed to the live listener.</param>
+	/// <exception cref="InvalidOperationException">The stream has already been started.</exception>
+	/// <remarks><para>Reading does not start in the constructor, and that is the whole point of having
+	/// this method. A read model opening its own catch-up subscribes its handlers first and starts reading
+	/// last, all inside one constructor, so it cannot miss its own history. A shared reader cannot: its
+	/// subscribers attach from <i>their</i> constructors, which necessarily run after this one. Reading on
+	/// construction would therefore lose every event delivered before a subscriber attached — and, worse,
+	/// the go-live along with them, so a model counting streams to live would never reach its count and
+	/// never flush its cache. That failure is a race, and it gets <i>more</i> likely as the store gets
+	/// faster: the faster the read, the more reliably it wins and the more data goes missing.</para>
+	/// <para>This marks the stream started before it reads, so a <see cref="RelayTo"/> racing it is
+	/// refused rather than half-attached: a relay is either registered before the read begins or
+	/// throws.</para></remarks>
+	public void Start(CancellationToken cancelWaitToken = default) {
+		ObjectDisposedException.ThrowIf(_disposed, this);
+		lock (_relayLock) {
+			if (_started)
+				throw new InvalidOperationException($"{_name} has already been started.");
+			_started = true;
+		}
+
+		var checkpoint = LowestPositionNeeded();
+		Log.Debug($"{_name} starting catch-up from checkpoint {(checkpoint?.ToString() ?? "start of stream")} " +
+				  $"for {RelayCount()} relay(s).");
+
+		try {
+			using (var reader = _connection.GetReader(_name, _ => { })) {
+				_reader = reader;
+				// The reader's position is the event it is handing over, so the gate is evaluated where the
+				// position is known. Nothing is queued here that the reader must wait for — a relayed message
+				// is enqueued on the target's own queue synchronously — so the read needs no completion check.
+				reader.Handle = message => RelayRead(message, reader.Position);
+				reader.Read<TAggregate>(() => true, checkpoint);
+				checkpoint = reader.Position ?? checkpoint;
+				_reader = null;
+			}
+
+			if (_disposed) {
+				// Disposal took the relays and drained them; there is nothing left to release here.
+				return;
+			}
+
+			var listener = _connection.GetListener(_name);
+			_listener = listener;
+			_listenerSubscription = listener.EventStream.SubscribeToAll(new AdHocHandler<IMessage>(RelayLive));
+			listener.Start<TAggregate>(checkpoint, false, false, cancelWaitToken);
+		} catch {
+			// Every target is holding its liveness open for a source that will now never arrive. Release
+			// them before the throw leaves, or awaiting one of them waits for history nobody will send.
+			foreach (var relay in CurrentRelays())
+				relay.Drain();
+			throw;
+		}
+	}
+
+	/// <summary>
+	/// Runs <see cref="Start"/> on a task pool thread. Call once, <b>after</b> every
+	/// <see cref="RelayTo"/>; a relay attached after this throws, and <see cref="Start"/> says why.
+	/// </summary>
+	/// <param name="cancelWaitToken">Cancellation token passed to the live listener.</param>
+	/// <returns>A task that completes when the catch-up read has finished and the live listener has been
+	/// started. It does not signal that the stream has gone live.</returns>
+	/// <exception cref="InvalidOperationException">The stream has already been started. Thrown from the
+	/// returned task.</exception>
+	public Task StartAsync(CancellationToken cancelWaitToken = default) =>
+		Task.Run(() => Start(cancelWaitToken), cancelWaitToken);
+
+	/// <summary>
+	/// Stops reading and listening, and releases every relay's registration on its target — disposing
+	/// the stream leaves those targets unfed, so it owes them the release a detach would have made.
+	/// </summary>
+	/// <remarks>
+	/// Draining runs outside the lock: it enqueues onto each target's queue, and a lock held across a
+	/// call into another object is how a deadlock gets written. Taking the relays and marking disposed
+	/// in one locked step is what makes it safe — a <see cref="RelayTo"/> racing this either registers
+	/// first and is drained here, or sees the flag and throws.
+	/// </remarks>
+	public void Dispose() {
+		Relay[] stranded;
+		lock (_relayLock) {
+			if (_disposed)
+				return;
+			_disposed = true;
+			stranded = _relays.ToArray();
+			_relays.Clear();
+		}
+
+		_reader?.Cancel();
+		_listenerSubscription?.Dispose();
+		_listener?.Dispose();
+		foreach (var relay in stranded)
+			relay.Drain();
+	}
+
+	/// <summary>
+	/// The lowest position any relay still needs, as a reader checkpoint: <c>null</c> — read the whole
+	/// category — as soon as one relay holds no checkpoint, since it needs the whole history.
+	/// </summary>
+	private long? LowestPositionNeeded() {
+		long? lowest = null;
+		lock (_relayLock) {
+			foreach (var relay in _relays) {
+				if (relay.FromPosition is not { } position)
+					return null;
+				if (lowest is null || position < lowest)
+					lowest = position;
+			}
+		}
+
+		return lowest;
+	}
+
+	private void RelayRead(IMessage message, long? position) {
+		if (_disposed)
+			return;
+		if (position is { } read)
+			Interlocked.Exchange(ref _lastRelayedPosition, read);
+
+		foreach (var relay in CurrentRelays()) {
+			// Gated relays are the restored ones: they already folded everything up to their checkpoint.
+			// An unknown position delivers rather than drops — a duplicate an idempotent fold absorbs is
+			// the cheaper mistake of the two.
+			if (relay.FromPosition is { } gate && position is { } current && current <= gate)
+				continue;
+			relay.Target.Handle(message);
+		}
+	}
+
+	private void RelayLive(IMessage message) {
+		if (_disposed)
+			return;
+		if (message is StreamStoreMsgs.CatchupSubscriptionBecameLive) {
+			// Captured before the go-live is forwarded, so a subscriber reading it while handling the
+			// go-live sees the position that go-live stands for.
+			var position = Interlocked.Read(ref _lastRelayedPosition);
+			Interlocked.Exchange(ref _positionAtGoLive, position);
+			Log.Debug($"{_name} live at position {(position == NoPosition ? "none" : position.ToString())}.");
+		} else if (_listener is { } listener) {
+			Interlocked.Exchange(ref _lastRelayedPosition, listener.Position);
+		}
+
+		// Live-phase events go to every relay unconditionally: the listener starts where the read stopped,
+		// so anything it delivers is past every checkpoint a relay could honestly hold. (A checkpoint from
+		// a store that was since rebuilt or rewound is not honest, and no gate can rescue it.)
+		var live = message is StreamStoreMsgs.CatchupSubscriptionBecameLive;
+		foreach (var relay in CurrentRelays()) {
+			relay.Target.Handle(message);
+			// Behind the go-live it has just been handed, so the target's queue drains the history first.
+			if (live)
+				relay.Drain();
+		}
+	}
+
+	private Relay[] CurrentRelays() {
+		lock (_relayLock) {
+			return _relays.ToArray();
+		}
+	}
+
+	private int RelayCount() {
+		lock (_relayLock) {
+			return _relays.Count;
+		}
+	}
+
+	private void Detach(Relay relay) {
+		lock (_relayLock) {
+			_relays.Remove(relay);
+		}
+	}
+
+	private sealed class Relay(
+		CategoryStream<TAggregate> source,
+		ReadModelBase target,
+		long? fromPosition,
+		int generation) : IDisposable {
+		public ReadModelBase Target { get; } = target;
+		public long? FromPosition { get; } = fromPosition;
+
+		private int _disposed;
+		private int _drained;
+
+		/// <summary>
+		/// Releases the target's registration for this source, once. Interlocked because the two callers
+		/// run on different threads and take no common lock — the stream drains every relay from the
+		/// listener thread as it forwards the go-live, while a consumer may be disposing the same relay.
+		/// A second release would retire a source the target still has coming.
+		/// </summary>
+		public void Drain() {
+			if (Interlocked.Exchange(ref _drained, 1) != 0)
+				return;
+			Target.MarkExternalSourceDrained(generation);
+		}
+
+		/// <summary>
+		/// Detaching before go-live still drains: the target is no longer being fed this source, so
+		/// leaving its registration open would hang anyone awaiting its IsLive with nothing to arrive.
+		/// </summary>
+		public void Dispose() {
+			if (Interlocked.Exchange(ref _disposed, 1) != 0)
+				return;
+			source.Detach(this);
+			Drain();
+		}
+	}
+}

--- a/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
@@ -185,6 +185,25 @@ public abstract class ReadModelBase :
 	private void MarkReadDrained(int generation) =>
 		((IHandle<IMessage>)_queue).Handle(new ReadDrained(generation));
 
+	/// <summary>
+	/// Records that something else will feed this model a stream it does not read itself, so
+	/// <see cref="IsLive"/> does not report live before that feed has handed over its history.
+	/// </summary>
+	/// <returns>
+	/// The generation to hand back to <see cref="MarkExternalSourceDrained"/>. Stamping it keeps a
+	/// late release from retiring a source registered after this one was abandoned.
+	/// </returns>
+	/// <exception cref="InvalidOperationException">A capture is in flight.</exception>
+	internal int RegisterExternalSource() => RegisterStream();
+
+	/// <summary>
+	/// Queues the sentinel retiring a source registered by <see cref="RegisterExternalSource"/>. Call
+	/// it after the last of that source's history has been handed over, so the sentinel goes in behind
+	/// it and the target's queue folds that history first.
+	/// </summary>
+	/// <param name="generation">The value <see cref="RegisterExternalSource"/> returned.</param>
+	internal void MarkExternalSourceDrained(int generation) => MarkReadDrained(generation);
+
 	private sealed record ReadDrained(int Generation) : IMessage {
 		public Guid MsgId { get; } = Guid.NewGuid();
 	}


### PR DESCRIPTION
**What does this pull request do?**

N read models over one category cost N reads of that category. `CategoryStream` reads it once and relays to every subscriber.

Now rebased onto `master`; the whole stack beneath it has landed, so this diff is its own work alone.

**How does this pull request accomplish that goal?**

```csharp
public IDisposable RelayTo(ReadModelBase target, long? fromPosition = null);
public void Start(CancellationToken cancelWaitToken = default);
public Task StartAsync(CancellationToken cancelWaitToken = default);
public long? PositionAtGoLive { get; }
public string StreamName { get; }
```

Subscribers attach with `RelayTo`, then one `Start` performs a single catch-up read of the category and fans every event out. Each subscriber gets exactly one go-live.

**Three things worth reviewing:**

**`RelayTo` after `Start` throws.** A relay attached late would silently miss everything already relayed, leaving a model that looks populated but is short a prefix of its history. It is refused outright rather than half-attached — the test asserts the late subscriber receives nothing at all, including no go-live, rather than receiving only the live tail.

**A liveness registration carries the generation it was made in.** `RelayTo` registers a source on its target so a relayed stream counts in that target's `IsLive`. If the target's own start later fails, every outstanding source is abandoned and the generation moves on; a relay released after that must not retire a stream registered since. This is the relay-side form of #280, and it is stamped for the same reason.

**A `Start` that throws releases the targets it registered.** They are holding liveness open for history that will now never arrive, so without this a failed start is a hang with nothing to say why.

**Positions come from the reader, not from arithmetic.** This class owns its reader and reports `IStreamReader.Position`. Deriving a relayed event's position by counting from the start instead — `start + n` — drifts silently the first time an event fails to deserialise, and every downstream checkpoint drifts with it. That is a real defect this shape avoids, and the reason `PositionAtGoLive` is nullable rather than a computed number.

**Why is this pull request important?**

It removes the per-model read cost for categories, and it is what lets several models share a feed without each one re-reading it. It also makes such a model snapshottable: the position it records is the category stream's, so restoring must not start a listener for a stream the category stream already reads.

**Link to any issues that this resolves**

This does not address any open issues. The generation stamp is the relay-side counterpart of #280.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports — green on `net8.0` and `net10.0`
- [x] Any new code must be covered by at least one unit test — `when_using_category_stream`, twenty cases
- [x] All public methods must be documented with XML comments

**Documented while here**

`ReadModelBase`'s `Start` overloads now say which to choose. The category overloads point at this type for the several-models case; the raw-name overloads are marked last resort, because they take the stream name verbatim and check nothing — a typo, or a name built by hand that the `IStreamNameBuilder` would have spelled differently, is a model that reads an empty stream and reports itself live over no data.

**Worth knowing**

`StreamReader.ValidateStreamName` catches everything and returns false, so `Read` returning `false` is how a failed read usually surfaces — not an exception. `CategoryStream.Start` ignores that return value, as `ReadModelBase.Start` does, so a read that fails this way attaches a listener and forwards a go-live over history that was never read. That is repo-wide and predates this branch, so it is left alone here rather than widened into it.