### PR TITLE
Size the test wait budgets by cores, with defaults a project can tune

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -74,6 +74,11 @@ jobs:
     # Test
     - name: Test     
       working-directory: src
+      # A hosted runner reports 4 cores but shares them, and runs every test assembly of this
+      # solution at once. It behaves like the smallest bucket whatever the count says, so the
+      # budget is stated here rather than inferred.
+      env:
+        REACTIVEDOMAIN_TEST_CAPACITY: Small
       run: dotnet test ReactiveDomain.sln -f net${{ matrix.dotnet-version }} -p:ParallelizeTestCollections=false -c Release  --no-build 
 
     # Format

--- a/Docs/ci-test-guidance.md
+++ b/Docs/ci-test-guidance.md
@@ -1,25 +1,58 @@
-# CI Test Guidance
+# Test Timing Guidance
 
-CI runners (GitHub Actions: 2 cores) starve the scheduler in ways local machines don't.
-Timing-sensitive tests that pass locally fail on CI with spurious timeouts, and the failures
-don't reproduce on a developer box at default settings. Three practices keep the suite honest.
+A machine that cannot run the suite in parallel starves the scheduler in ways a larger one does
+not. Timing-sensitive tests that pass on a workstation fail there with spurious timeouts, and the
+failures do not reproduce at default settings. Four practices keep the suite honest.
 
 ## 1. Use `TestTimeouts`, not literal timeouts
 
-`ReactiveDomain.Testing.TestTimeouts` is the single timeout source, keyed on the
-`GITHUB_ACTIONS` environment variable:
+`ReactiveDomain.Testing.TestTimeouts` is the single timeout source. It picks its budgets from the
+cores available to the test process, because cores are the cause: a wait expires early when the
+machine could not schedule the work in time.
 
-| Purpose | Property | Local | CI |
-|---|---|---|---|
-| TestQueue / RepositoryEvents waits | `WaitFor` | 500 ms | 5 s |
-| Command Send response waits | `CommandTimeout` | 500 ms | 10 s |
-| Real-time Rx operators (Throttle, Buffer, Sample) | `ThrottleWaitFor` | 2 s | 10 s |
+| Purpose | Property | Small | Medium | Large |
+|---|---|---|---|---|
+| TestQueue / RepositoryEvents waits | `WaitFor` | 5 s | 2 s | 500 ms |
+| Command Send response waits | `CommandTimeout` | 10 s | 5 s | 500 ms |
+| Real-time Rx operators (Throttle, Buffer, Sample) | `ThrottleWaitFor` | 10 s | 5 s | 2 s |
 
-Don't copy timeout constants into test projects; reference these. A wait that needs more than
-the CI value is a design problem (an unbounded dependency or a heuristic wait), not a reason
-for a bigger number.
+`TestCapacityDetector` buckets the process by `Environment.ProcessorCount`:
 
-## 2. Run test assemblies sequentially (`MaxCpuCount=1`)
+| Bucket | Cores |
+|---|---|
+| `Small` | under 4 |
+| `Medium` | 4 to 7 |
+| `Large` | 8 and over |
+
+`ProcessorCount` already reflects a container's CPU cap, so a process limited to two cores on a
+large host reports two. A CI runner is whichever size its cores make it — nothing here asks where
+it is running.
+
+Don't copy timeout constants into test projects; reference these. A wait that needs more than the
+`Small` value is a design problem — an unbounded dependency, or a heuristic wait — not a reason for
+a bigger number.
+
+## 2. Tune the budgets to your own suite
+
+The shipped values are defaults, not measurements. A project that has measured its own suite
+assigns `TestTimeouts.Budget` once at startup, before any test reads a wait:
+
+```csharp
+TestTimeouts.Budget = new TestTimeoutBudget(
+    waitFor: TimeSpan.FromSeconds(3),
+    commandTimeout: TimeSpan.FromSeconds(8),
+    throttleWaitFor: TimeSpan.FromSeconds(8));
+```
+
+An xunit assembly fixture or a module initializer is the right home. The three wait properties read
+through `Budget` rather than caching, so a later assignment takes effect — but it is process-wide,
+and nothing re-reads a value a wait has already started against.
+
+`TestTimeouts.CapacityDescription` names the bucket, what chose it, and the budgets in force.
+`TestTimeouts.WriteCapacity()` writes that line, by default to the console, so a red run states the
+budget it used instead of leaving it to be guessed.
+
+## 3. Run test assemblies sequentially (`MaxCpuCount=1`)
 
 Concurrent test assemblies each hosting an in-process store starve the thread pool on small
 runners. Force sequential assembly execution:
@@ -40,18 +73,26 @@ dotnet test --settings ci.runsettings
 Test parallelism *within* an assembly is governed separately (xUnit
 `ParallelizeTestCollections`; this repo's CI passes `-p:ParallelizeTestCollections=false`).
 
-## 3. Reproduce 2-core CI flakes locally
+## 4. Reproduce a small-machine flake locally
 
-Restrict the runner to two cores and set the CI flag — most "CI-only" failures reproduce in
+Restrict the runner to two cores — most failures seen only on constrained machines reproduce in
 seconds:
 
 ```cmd
-set GITHUB_ACTIONS=true
 start /affinity 3 dotnet test src/SomeProject.Tests
 ```
 
 (`/affinity 3` = cores 0–1. PowerShell: start the process, then
 `(Get-Process -Id $pid).ProcessorAffinity = 3`.)
 
-Setting `GITHUB_ACTIONS=true` also switches `TestTimeouts` to CI values, so the repro
-exercises the same waits CI does.
+Two cores put the process in the `Small` bucket on their own, so the repro exercises the same waits
+a small runner does. Where the core count is not the whole story — a many-core machine already
+running several test jobs, so the cores are there but the capacity is not — force the bucket:
+
+```cmd
+set REACTIVEDOMAIN_TEST_CAPACITY=Small
+```
+
+The recognized values are the `TestCapacity` names, case-insensitively. Anything else falls through
+to the cores rather than being honoured as some default: the core count is still a real answer, and
+"the override worked" is the costlier thing to believe wrongly.

--- a/src/ReactiveDomain.Testing.Tests/TestCapacityDetectorTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/TestCapacityDetectorTests.cs
@@ -1,0 +1,84 @@
+using Xunit;
+
+namespace ReactiveDomain.Testing.Tests;
+
+public sealed class TestCapacityDetectorTests {
+	// A lookup over an in-memory map, so every branch is exercised without mutating real process
+	// environment variables — which are shared, order-dependent state across the whole test run.
+	private static Func<string, string?> Env(params (string Name, string Value)[] vars) {
+		var map = vars.ToDictionary(v => v.Name, v => v.Value, StringComparer.OrdinalIgnoreCase);
+		return name => map.TryGetValue(name, out var value) ? value : null;
+	}
+
+	private static Func<string, string?> Override(string value) =>
+		Env((TestCapacityDetector.OverrideEnvironmentVariable, value));
+
+	[Theory]
+	[InlineData(1, TestCapacity.Small)]
+	[InlineData(2, TestCapacity.Small)]
+	[InlineData(3, TestCapacity.Small)]
+	[InlineData(4, TestCapacity.Medium)]
+	[InlineData(7, TestCapacity.Medium)]
+	[InlineData(8, TestCapacity.Large)]
+	[InlineData(128, TestCapacity.Large)]
+	public void the_cores_choose_the_bucket(int cores, TestCapacity expected) {
+		var (capacity, reported, reason) = TestCapacityDetector.Detect(cores, Env());
+
+		Assert.Equal(expected, capacity);
+		Assert.Equal(cores, reported);
+		Assert.Contains(cores.ToString(), reason);
+	}
+
+	/// <summary>Consumers force against the boundaries, so they are pinned at the edge.</summary>
+	[Fact]
+	public void each_boundary_is_inclusive_at_its_own_bucket() {
+		Assert.Equal(TestCapacity.Large,
+			TestCapacityDetector.Detect(TestCapacityDetector.LargeCores, Env()).Capacity);
+		Assert.Equal(TestCapacity.Medium,
+			TestCapacityDetector.Detect(TestCapacityDetector.LargeCores - 1, Env()).Capacity);
+		Assert.Equal(TestCapacity.Medium,
+			TestCapacityDetector.Detect(TestCapacityDetector.MediumCores, Env()).Capacity);
+		Assert.Equal(TestCapacity.Small,
+			TestCapacityDetector.Detect(TestCapacityDetector.MediumCores - 1, Env()).Capacity);
+	}
+
+	[Theory]
+	[InlineData("Small", TestCapacity.Small)]
+	[InlineData("medium", TestCapacity.Medium)]
+	[InlineData("LARGE", TestCapacity.Large)]
+	public void an_override_wins_over_the_cores(string value, TestCapacity expected) {
+		// Cores that would choose a different bucket on their own, so only the override produces this.
+		var cores = expected == TestCapacity.Large ? 1 : 64;
+
+		var (capacity, _, reason) = TestCapacityDetector.Detect(cores, Override(value));
+
+		Assert.Equal(expected, capacity);
+		Assert.Contains("override", reason);
+	}
+
+	/// <summary>The cores are still a real answer; "the override worked" is the costlier thing to believe.</summary>
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData("true")]
+	[InlineData("Ci")]
+	public void an_unrecognized_override_falls_through_to_the_cores(string value) {
+		Assert.Equal(TestCapacity.Large, TestCapacityDetector.Detect(64, Override(value)).Capacity);
+		Assert.Equal(TestCapacity.Small, TestCapacityDetector.Detect(2, Override(value)).Capacity);
+	}
+
+	/// <summary>Naming a CI system is what this replaced: a large runner is not small for being CI.</summary>
+	[Fact]
+	public void a_ci_variable_alone_does_not_shrink_the_bucket() {
+		var (capacity, _, _) = TestCapacityDetector.Detect(64, Env(("GITHUB_ACTIONS", "true"), ("CI", "true")));
+
+		Assert.Equal(TestCapacity.Large, capacity);
+	}
+
+	[Fact]
+	public void the_detected_values_describe_this_process() {
+		Assert.Equal(Environment.ProcessorCount, TestCapacityDetector.Cores);
+		Assert.False(string.IsNullOrWhiteSpace(TestCapacityDetector.Reason));
+		Assert.Equal(TestCapacityDetector.Detected, TestTimeouts.Capacity);
+	}
+}

--- a/src/ReactiveDomain.Testing.Tests/TestTimeoutsTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/TestTimeoutsTests.cs
@@ -2,21 +2,92 @@ using Xunit;
 
 namespace ReactiveDomain.Testing.Tests;
 
+/// <summary>
+/// Every test that assigns <see cref="TestTimeouts.Budget"/> lives in this one class and restores it,
+/// because it is process-wide: xunit serializes tests within a class but runs classes in parallel, so
+/// a reader in another class could otherwise see a budget this one was midway through swapping.
+/// </summary>
 public sealed class TestTimeoutsTests {
-	[Fact]
-	public void values_match_the_environment() {
-		var isCi = string.Equals(
-			Environment.GetEnvironmentVariable("GITHUB_ACTIONS"), "true", StringComparison.OrdinalIgnoreCase);
-
-		Assert.Equal(isCi, TestTimeouts.IsCi);
-		if (isCi) {
-			Assert.Equal(TimeSpan.FromSeconds(5), TestTimeouts.WaitFor);
-			Assert.Equal(TimeSpan.FromSeconds(10), TestTimeouts.CommandTimeout);
-			Assert.Equal(TimeSpan.FromSeconds(10), TestTimeouts.ThrottleWaitFor);
-		} else {
-			Assert.Equal(TimeSpan.FromMilliseconds(500), TestTimeouts.WaitFor);
-			Assert.Equal(TimeSpan.FromMilliseconds(500), TestTimeouts.CommandTimeout);
-			Assert.Equal(TimeSpan.FromSeconds(2), TestTimeouts.ThrottleWaitFor);
+	private static void WithBudget(TestTimeoutBudget budget, Action assert) {
+		var original = TestTimeouts.Budget;
+		try {
+			TestTimeouts.Budget = budget;
+			assert();
+		} finally {
+			TestTimeouts.Budget = original;
 		}
+	}
+
+	[Fact]
+	public void the_budget_defaults_to_the_detected_bucket() {
+		Assert.Equal(TestTimeoutBudget.For(TestTimeouts.Capacity), TestTimeouts.Budget);
+	}
+
+	/// <summary>The three waits read the budget rather than caching it, or tuning would not take.</summary>
+	[Fact]
+	public void assigning_a_budget_retunes_the_waits() {
+		var tuned = new TestTimeoutBudget(
+			TimeSpan.FromSeconds(11), TimeSpan.FromSeconds(22), TimeSpan.FromSeconds(33));
+
+		WithBudget(tuned, () => {
+			Assert.Equal(tuned.WaitFor, TestTimeouts.WaitFor);
+			Assert.Equal(tuned.CommandTimeout, TestTimeouts.CommandTimeout);
+			Assert.Equal(tuned.ThrottleWaitFor, TestTimeouts.ThrottleWaitFor);
+		});
+
+		Assert.Equal(TestTimeoutBudget.For(TestTimeouts.Capacity), TestTimeouts.Budget);
+	}
+
+	[Theory]
+	[InlineData(TestCapacity.Large, 500, 500, 2000)]
+	[InlineData(TestCapacity.Medium, 2000, 5000, 5000)]
+	[InlineData(TestCapacity.Small, 5000, 10_000, 10_000)]
+	public void the_shipped_defaults_are_what_they_say(
+		TestCapacity capacity, int waitForMs, int commandMs, int throttleMs) {
+		var budget = TestTimeoutBudget.For(capacity);
+
+		Assert.Equal(TimeSpan.FromMilliseconds(waitForMs), budget.WaitFor);
+		Assert.Equal(TimeSpan.FromMilliseconds(commandMs), budget.CommandTimeout);
+		Assert.Equal(TimeSpan.FromMilliseconds(throttleMs), budget.ThrottleWaitFor);
+	}
+
+	/// <summary>A smaller bucket never waits less, whatever the numbers are tuned to.</summary>
+	[Fact]
+	public void the_defaults_do_not_shrink_as_the_bucket_does() {
+		var large = TestTimeoutBudget.For(TestCapacity.Large);
+		var medium = TestTimeoutBudget.For(TestCapacity.Medium);
+		var small = TestTimeoutBudget.For(TestCapacity.Small);
+
+		Assert.True(medium.WaitFor >= large.WaitFor && small.WaitFor >= medium.WaitFor);
+		Assert.True(medium.CommandTimeout >= large.CommandTimeout && small.CommandTimeout >= medium.CommandTimeout);
+		Assert.True(medium.ThrottleWaitFor >= large.ThrottleWaitFor && small.ThrottleWaitFor >= medium.ThrottleWaitFor);
+	}
+
+	[Fact]
+	public void the_legacy_flag_tracks_the_smallest_bucket() {
+		Assert.Equal(TestTimeouts.Capacity == TestCapacity.Small, TestTimeouts.IsCi);
+	}
+
+	[Fact]
+	public void the_description_names_the_bucket_and_the_budget_in_force() {
+		var tuned = new TestTimeoutBudget(
+			TimeSpan.FromSeconds(11), TimeSpan.FromSeconds(22), TimeSpan.FromSeconds(33));
+
+		WithBudget(tuned, () => {
+			var description = TestTimeouts.CapacityDescription;
+
+			Assert.Contains(TestTimeouts.Capacity.ToString(), description);
+			Assert.Contains(TestTimeouts.CapacityReason, description);
+			Assert.Contains(tuned.WaitFor.ToString(), description);
+		});
+	}
+
+	[Fact]
+	public void the_description_can_be_written_somewhere_other_than_the_console() {
+		var writer = new StringWriter();
+
+		TestTimeouts.WriteCapacity(writer);
+
+		Assert.Contains(TestTimeouts.CapacityDescription, writer.ToString());
 	}
 }

--- a/src/ReactiveDomain.Testing/TestCapacity.cs
+++ b/src/ReactiveDomain.Testing/TestCapacity.cs
@@ -1,0 +1,20 @@
+namespace ReactiveDomain.Testing;
+
+/// <summary>
+/// How much CPU a test process has to work with, bucketed. <see cref="TestTimeouts"/> picks its
+/// wait budgets from this.
+/// </summary>
+/// <remarks>
+/// A wait fails early because the machine could not schedule the work in time, which depends on
+/// cores — so cores choose the bucket, and a CI runner is whichever size its cores make it.
+/// </remarks>
+public enum TestCapacity {
+	/// <summary>Too few cores to run a suite in parallel; the scheduler sets the pace.</summary>
+	Small,
+
+	/// <summary>Enough cores to make progress, few enough that a parallel suite contends.</summary>
+	Medium,
+
+	/// <summary>Cores to spare, so an expired wait means something is actually wrong.</summary>
+	Large,
+}

--- a/src/ReactiveDomain.Testing/TestCapacityDetector.cs
+++ b/src/ReactiveDomain.Testing/TestCapacityDetector.cs
@@ -1,0 +1,62 @@
+namespace ReactiveDomain.Testing;
+
+/// <summary>
+/// Buckets a test process by the cores available to it, and reports what it decided on.
+/// </summary>
+/// <remarks>
+/// Cores are the signal because cores are the cause: a wait that expires early did so because the
+/// machine could not schedule the work in time. Naming CI providers answered that by proxy, and
+/// answered it wrong for everything off the list — a capped container, a self-hosted runner, an old
+/// laptop. <see cref="Environment.ProcessorCount"/> already reflects a container's CPU cap.
+/// </remarks>
+public static class TestCapacityDetector {
+	/// <summary>
+	/// Forces a bucket regardless of cores, for when the core count is not the whole story — a
+	/// many-core machine running several test jobs at once has the cores but not the capacity.
+	/// Recognized values are the <see cref="TestCapacity"/> names, case-insensitively.
+	/// </summary>
+	public const string OverrideEnvironmentVariable = "REACTIVEDOMAIN_TEST_CAPACITY";
+
+	/// <summary>Default lower bound for <see cref="TestCapacity.Large"/>.</summary>
+	public const int LargeCores = 8;
+
+	/// <summary>Default lower bound for <see cref="TestCapacity.Medium"/>; below it is Small.</summary>
+	public const int MediumCores = 4;
+
+	/// <summary>The bucket this process detected, computed once.</summary>
+	public static TestCapacity Detected { get; }
+
+	/// <summary>Cores this process can use — a container's cap, not the host's total.</summary>
+	public static int Cores { get; }
+
+	/// <summary>What chose <see cref="Detected"/>, so a red run can state the budget it used.</summary>
+	public static string Reason { get; }
+
+	static TestCapacityDetector() =>
+		(Detected, Cores, Reason) = Detect(Environment.ProcessorCount, Environment.GetEnvironmentVariable);
+
+	/// <summary>
+	/// Pure detection core — takes the core count and an environment lookup rather than reading the
+	/// process, so every branch is exercisable without mutating state shared by the whole test run.
+	/// </summary>
+	/// <param name="cores">Cores available to the process.</param>
+	/// <param name="getEnvironmentVariable">Returns the named variable's value, or null.</param>
+	public static (TestCapacity Capacity, int Cores, string Reason) Detect(
+		int cores,
+		Func<string, string?> getEnvironmentVariable) {
+		var overridden = getEnvironmentVariable(OverrideEnvironmentVariable);
+		if (!string.IsNullOrWhiteSpace(overridden)) {
+			foreach (var capacity in Enum.GetValues<TestCapacity>()) {
+				if (string.Equals(overridden, capacity.ToString(), StringComparison.OrdinalIgnoreCase))
+					return (capacity, cores, $"{OverrideEnvironmentVariable}={capacity} (explicit override)");
+			}
+			// Unrecognized: fall through to the cores rather than honour a default nobody asked for.
+		}
+
+		if (cores >= LargeCores)
+			return (TestCapacity.Large, cores, $"{cores} cores available, {LargeCores} or more");
+		if (cores >= MediumCores)
+			return (TestCapacity.Medium, cores, $"{cores} cores available, under {LargeCores}");
+		return (TestCapacity.Small, cores, $"{cores} cores available, under {MediumCores}");
+	}
+}

--- a/src/ReactiveDomain.Testing/TestTimeoutBudget.cs
+++ b/src/ReactiveDomain.Testing/TestTimeoutBudget.cs
@@ -1,0 +1,23 @@
+namespace ReactiveDomain.Testing;
+
+/// <summary>
+/// The three wait budgets a test run uses. Defaults per <see cref="TestCapacity"/> come from
+/// <see cref="For"/>; a consuming project that has measured its own suite replaces them via
+/// <see cref="TestTimeouts.Budget"/>.
+/// </summary>
+/// <param name="WaitFor">Message-arrival waits: <see cref="TestQueue.WaitFor{T}"/>,
+/// <see cref="TestQueue.WaitForMsgId"/>, RepositoryEvents.</param>
+/// <param name="CommandTimeout">Command-response waits (dispatcher Send).</param>
+/// <param name="ThrottleWaitFor">Waits on real-time Rx operators (Throttle, Buffer, Sample),
+/// whose timers run on wall-clock schedulers.</param>
+public sealed record TestTimeoutBudget(TimeSpan WaitFor, TimeSpan CommandTimeout, TimeSpan ThrottleWaitFor) {
+	/// <summary>
+	/// The shipped default for a bucket — a starting point, not a measurement. A suite that trips
+	/// these is telling you what its own numbers should be; set them and move on.
+	/// </summary>
+	public static TestTimeoutBudget For(TestCapacity capacity) => capacity switch {
+		TestCapacity.Large => new(TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(500), TimeSpan.FromSeconds(2)),
+		TestCapacity.Medium => new(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5)),
+		_ => new(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10)),
+	};
+}

--- a/src/ReactiveDomain.Testing/TestTimeouts.cs
+++ b/src/ReactiveDomain.Testing/TestTimeouts.cs
@@ -1,42 +1,59 @@
 namespace ReactiveDomain.Testing;
 
 /// <summary>
-/// CI-aware timeout source for test waits, keyed on the <c>GITHUB_ACTIONS</c> environment
-/// variable. CI runners (typically 2 cores) suffer scheduler starvation that surfaces as
-/// spurious timeouts when tests use locally-tuned values, so waits get generous CI values
-/// while staying fast for the local edit-test loop.
+/// Timeout source for test waits, bucketed by the cores available to the process (see
+/// <see cref="TestCapacityDetector"/>) so a machine that cannot run the suite in parallel is not
+/// held to a budget written for one that can.
 /// </summary>
 /// <remarks>
-/// To reproduce CI-only timing failures locally, launch the test runner restricted to two
-/// cores with the CI flag set, e.g. from cmd:
-/// <c>set GITHUB_ACTIONS=true &amp;&amp; start /affinity 3 dotnet test ...</c>.
+/// <para>The shipped budgets are defaults, not measurements. Tune them per project by assigning
+/// <see cref="Budget"/> once at startup — an xunit assembly fixture, a module initializer — before
+/// any test reads a wait.</para>
+/// <para>To reproduce a smaller machine's timing on a larger one, force the bucket and restrict the
+/// runner to matching cores, e.g. from cmd:
+/// <c>set REACTIVEDOMAIN_TEST_CAPACITY=Small &amp;&amp; start /affinity 3 dotnet test ...</c>.
 /// Run test assemblies sequentially (<c>MaxCpuCount=1</c> in a .runsettings file or
 /// <c>-maxcpucount:1</c>) — concurrent in-process stores starve the thread pool.
-/// See Docs/ci-test-guidance.md.
+/// See Docs/ci-test-guidance.md.</para>
 /// </remarks>
 public static class TestTimeouts {
-	/// <summary>
-	/// True when running under GitHub Actions (<c>GITHUB_ACTIONS</c> = "true"), or under the
-	/// local repro recipe that sets the same variable.
-	/// </summary>
-	public static bool IsCi { get; } =
-		string.Equals(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"), "true", StringComparison.OrdinalIgnoreCase);
+	/// <summary>The detected bucket, and so which defaults <see cref="Budget"/> starts from.</summary>
+	public static TestCapacity Capacity { get; } = TestCapacityDetector.Detected;
+
+	/// <summary>What chose <see cref="Capacity"/>, so a red run can state the budget it used.</summary>
+	public static string CapacityReason { get; } = TestCapacityDetector.Reason;
 
 	/// <summary>
-	/// Timeout for message-arrival waits: <see cref="TestQueue.WaitFor{T}"/>,
-	/// <see cref="TestQueue.WaitForMsgId"/>, and RepositoryEvents waits.
-	/// 500 ms locally, 5 s on CI.
+	/// The budgets in force. Defaults to <see cref="TestTimeoutBudget.For"/> of
+	/// <see cref="Capacity"/>; assign to tune a project's own numbers.
 	/// </summary>
-	public static TimeSpan WaitFor { get; } = IsCi ? TimeSpan.FromSeconds(5) : TimeSpan.FromMilliseconds(500);
+	/// <remarks>Set it once before any test reads a wait — this is process-wide, and nothing
+	/// re-reads a value a wait has already started against.</remarks>
+	public static TestTimeoutBudget Budget { get; set; } = TestTimeoutBudget.For(Capacity);
+
+	/// <inheritdoc cref="TestTimeoutBudget.WaitFor"/>
+	public static TimeSpan WaitFor => Budget.WaitFor;
+
+	/// <inheritdoc cref="TestTimeoutBudget.CommandTimeout"/>
+	public static TimeSpan CommandTimeout => Budget.CommandTimeout;
+
+	/// <inheritdoc cref="TestTimeoutBudget.ThrottleWaitFor"/>
+	public static TimeSpan ThrottleWaitFor => Budget.ThrottleWaitFor;
+
+	/// <summary>True at <see cref="TestCapacity.Small"/> — the bucket, not "a CI system is running".</summary>
+	public static bool IsCi => Capacity == TestCapacity.Small;
 
 	/// <summary>
-	/// Timeout for command-response waits (dispatcher Send). 500 ms locally, 10 s on CI.
+	/// One line naming the bucket, what chose it, and the budgets in force — so a red gate can state
+	/// which budget the run used instead of leaving it to be guessed.
 	/// </summary>
-	public static TimeSpan CommandTimeout { get; } = IsCi ? TimeSpan.FromSeconds(10) : TimeSpan.FromMilliseconds(500);
+	public static string CapacityDescription =>
+		$"ReactiveDomain.Testing capacity: {Capacity} ({CapacityReason}); " +
+		$"{nameof(WaitFor)}={WaitFor}, {nameof(CommandTimeout)}={CommandTimeout}, " +
+		$"{nameof(ThrottleWaitFor)}={ThrottleWaitFor}";
 
-	/// <summary>
-	/// Timeout for waits on real-time Rx operators (Throttle, Buffer, Sample) whose timers
-	/// run on wall-clock schedulers. 2 s locally, 10 s on CI.
-	/// </summary>
-	public static TimeSpan ThrottleWaitFor { get; } = IsCi ? TimeSpan.FromSeconds(10) : TimeSpan.FromSeconds(2);
+	/// <summary>Writes <see cref="CapacityDescription"/>, by default to the console.</summary>
+	/// <param name="output">Where to write; defaults to <see cref="Console.Out"/>.</param>
+	public static void WriteCapacity(TextWriter? output = null) =>
+		(output ?? Console.Out).WriteLine(CapacityDescription);
 }


### PR DESCRIPTION
**What does this pull request do?**

Chooses `TestTimeouts`' wait budgets from the cores available to the test process, instead of from the `GITHUB_ACTIONS` environment variable, and makes the budget values themselves overridable per consuming project.

**How does this pull request accomplish that goal?**

`TestCapacityDetector` buckets the process by `Environment.ProcessorCount` — `Small` under 4 cores, `Medium` 4 to 7, `Large` 8 and over. `ProcessorCount` already reflects a container's CPU cap, so a process limited to two cores on a large host reports two. `REACTIVEDOMAIN_TEST_CAPACITY` forces a bucket for the case the count cannot see, such as a many-core machine running several test jobs at once; an unrecognised value falls through to the cores rather than being honoured as some default.

The budgets are defaults, not measurements. `TestTimeoutBudget` carries the three values, `TestTimeoutBudget.For(bucket)` supplies the shipped default, and `TestTimeouts.Budget` is settable — a project that has measured its own suite assigns its own numbers once at startup. The three wait properties read through it rather than caching, or tuning would not take effect.

| bucket | WaitFor | CommandTimeout | ThrottleWaitFor |
|---|---|---|---|
| Small | 5s | 10s | 10s |
| Medium | 2s | 5s | 5s |
| Large | 500ms | 500ms | 2s |

`Small` and `Large` are the values already in use; `Medium` is new. `TestTimeouts.IsCi` is retained and now reports the `Small` bucket, so a CI runner with the cores to justify it answers false. The three budget property names and their meanings are unchanged.

**Why is this pull request important?**

Keying on one variable meant any runner that did not export it got the fast budget regardless of what it was actually running on — a container, an agent sandbox, or a CI system that advertises itself under a different name. The timeouts that produces look like product flakes and get chased as such. Cores are the cause rather than a proxy for it: a wait expires early because the machine could not schedule the work in time.

Naming CI providers only ever answered that question indirectly, and answered it wrong for everything off the list. Nothing in the library now claims to know where it is running.

**Link to any issues that this resolves**

This does not address any open issues.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports
- [x] Any new code must be covered by at least one unit test
- [x] All public methods must be documented with XML comments

Verified on net8.0 and net10.0: 14/14 project-runs green across three consecutive full-solution runs, `dotnet format --verify-no-changes` clean, and 26 tests over the new surface — the bucket boundaries at their edges, the override path including unrecognised values, the retune path, and a monotonicity check that a smaller bucket never waits less than a larger one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CouwhnZYDFQ1xsfiLiCg2j)_