### PR TITLE
Carry the $all position from the store to a model's checkpoint

### DIFF
--- a/Docs/ci-test-guidance.md
+++ b/Docs/ci-test-guidance.md
@@ -1,25 +1,58 @@
-# CI Test Guidance
+# Test Timing Guidance
 
-CI runners (GitHub Actions: 2 cores) starve the scheduler in ways local machines don't.
-Timing-sensitive tests that pass locally fail on CI with spurious timeouts, and the failures
-don't reproduce on a developer box at default settings. Three practices keep the suite honest.
+A machine that cannot run the suite in parallel starves the scheduler in ways a larger one does
+not. Timing-sensitive tests that pass on a workstation fail there with spurious timeouts, and the
+failures do not reproduce at default settings. Four practices keep the suite honest.
 
 ## 1. Use `TestTimeouts`, not literal timeouts
 
-`ReactiveDomain.Testing.TestTimeouts` is the single timeout source, keyed on the
-`GITHUB_ACTIONS` environment variable:
+`ReactiveDomain.Testing.TestTimeouts` is the single timeout source. It picks its budgets from the
+cores available to the test process, because cores are the cause: a wait expires early when the
+machine could not schedule the work in time.
 
-| Purpose | Property | Local | CI |
-|---|---|---|---|
-| TestQueue / RepositoryEvents waits | `WaitFor` | 500 ms | 5 s |
-| Command Send response waits | `CommandTimeout` | 500 ms | 10 s |
-| Real-time Rx operators (Throttle, Buffer, Sample) | `ThrottleWaitFor` | 2 s | 10 s |
+| Purpose | Property | Small | Medium | Large |
+|---|---|---|---|---|
+| TestQueue / RepositoryEvents waits | `WaitFor` | 5 s | 2 s | 500 ms |
+| Command Send response waits | `CommandTimeout` | 10 s | 5 s | 500 ms |
+| Real-time Rx operators (Throttle, Buffer, Sample) | `ThrottleWaitFor` | 10 s | 5 s | 2 s |
 
-Don't copy timeout constants into test projects; reference these. A wait that needs more than
-the CI value is a design problem (an unbounded dependency or a heuristic wait), not a reason
-for a bigger number.
+`TestCapacityDetector` buckets the process by `Environment.ProcessorCount`:
 
-## 2. Run test assemblies sequentially (`MaxCpuCount=1`)
+| Bucket | Cores |
+|---|---|
+| `Small` | under 4 |
+| `Medium` | 4 to 7 |
+| `Large` | 8 and over |
+
+`ProcessorCount` already reflects a container's CPU cap, so a process limited to two cores on a
+large host reports two. A CI runner is whichever size its cores make it — nothing here asks where
+it is running.
+
+Don't copy timeout constants into test projects; reference these. A wait that needs more than the
+`Small` value is a design problem — an unbounded dependency, or a heuristic wait — not a reason for
+a bigger number.
+
+## 2. Tune the budgets to your own suite
+
+The shipped values are defaults, not measurements. A project that has measured its own suite
+assigns `TestTimeouts.Budget` once at startup, before any test reads a wait:
+
+```csharp
+TestTimeouts.Budget = new TestTimeoutBudget(
+    waitFor: TimeSpan.FromSeconds(3),
+    commandTimeout: TimeSpan.FromSeconds(8),
+    throttleWaitFor: TimeSpan.FromSeconds(8));
+```
+
+An xunit assembly fixture or a module initializer is the right home. The three wait properties read
+through `Budget` rather than caching, so a later assignment takes effect — but it is process-wide,
+and nothing re-reads a value a wait has already started against.
+
+`TestTimeouts.CapacityDescription` names the bucket, what chose it, and the budgets in force.
+`TestTimeouts.WriteCapacity()` writes that line, by default to the console, so a red run states the
+budget it used instead of leaving it to be guessed.
+
+## 3. Run test assemblies sequentially (`MaxCpuCount=1`)
 
 Concurrent test assemblies each hosting an in-process store starve the thread pool on small
 runners. Force sequential assembly execution:
@@ -40,18 +73,26 @@ dotnet test --settings ci.runsettings
 Test parallelism *within* an assembly is governed separately (xUnit
 `ParallelizeTestCollections`; this repo's CI passes `-p:ParallelizeTestCollections=false`).
 
-## 3. Reproduce 2-core CI flakes locally
+## 4. Reproduce a small-machine flake locally
 
-Restrict the runner to two cores and set the CI flag — most "CI-only" failures reproduce in
+Restrict the runner to two cores — most failures seen only on constrained machines reproduce in
 seconds:
 
 ```cmd
-set GITHUB_ACTIONS=true
 start /affinity 3 dotnet test src/SomeProject.Tests
 ```
 
 (`/affinity 3` = cores 0–1. PowerShell: start the process, then
 `(Get-Process -Id $pid).ProcessorAffinity = 3`.)
 
-Setting `GITHUB_ACTIONS=true` also switches `TestTimeouts` to CI values, so the repro
-exercises the same waits CI does.
+Two cores put the process in the `Small` bucket on their own, so the repro exercises the same waits
+a small runner does. Where the core count is not the whole story — a many-core machine already
+running several test jobs, so the cores are there but the capacity is not — force the bucket:
+
+```cmd
+set REACTIVEDOMAIN_TEST_CAPACITY=Small
+```
+
+The recognized values are the `TestCapacity` names, case-insensitively. Anything else falls through
+to the cores rather than being honoured as some default: the core count is still a real answer, and
+"the override worked" is the costlier thing to believe wrongly.

--- a/src/ReactiveDomain.Foundation.Tests/when_awaiting_read_model_liveness.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_awaiting_read_model_liveness.cs
@@ -339,6 +339,7 @@ public sealed class when_awaiting_read_model_liveness : IClassFixture<StreamStor
 		Action<string>? beforeRead,
 		Action<string, Action<IMessage>>? afterRead) : IStreamReader {
 		public long? Position => inner.Position;
+		public StreamCheckpoint? Checkpoint => inner.Checkpoint;
 		public string StreamName => inner.StreamName;
 		public Action<IMessage> Handle { set => inner.Handle = value; }
 

--- a/src/ReactiveDomain.Foundation.Tests/when_checkpointing_all_positions.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_checkpointing_all_positions.cs
@@ -1,0 +1,114 @@
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests;
+
+// A checkpoint carries two clocks. The stream version resumes that stream; the $all position is the
+// only one comparable across streams, so it is what a multi-stream model projects a watermark from.
+// ReSharper disable once InconsistentNaming
+public sealed class when_checkpointing_all_positions :
+	ReadModelBase,
+	IHandle<when_checkpointing_all_positions.PositionTestEvent>,
+	IClassFixture<StreamStoreConnectionFixture> {
+
+	private readonly IStreamStoreConnection _conn;
+	private static readonly IEventSerializer _serializer = new JsonMessageSerializer();
+	private static readonly IStreamNameBuilder _namer =
+		new PrefixedCamelCaseStreamNameBuilder(nameof(when_checkpointing_all_positions));
+
+	private readonly string _early;
+	private readonly string _late;
+
+	public when_checkpointing_all_positions(StreamStoreConnectionFixture fixture)
+		: base(nameof(when_checkpointing_all_positions),
+			new ConfiguredConnection(fixture.Connection, _namer, _serializer)) {
+		_conn = fixture.Connection;
+		_conn.Connect();
+		EventStream.Subscribe<PositionTestEvent>(this);
+
+		_early = _namer.GenerateForAggregate(typeof(TestAggregate), Guid.NewGuid());
+		_late = _namer.GenerateForAggregate(typeof(TestAggregate), Guid.NewGuid());
+
+		// Appended in order, so _late's events sit further along the all-stream than _early's.
+		Append(_early, 3);
+		Append(_late, 3);
+		_conn.TryConfirmStream(_early, 3);
+		_conn.TryConfirmStream(_late, 3);
+	}
+
+	private void Append(string stream, int count) {
+		for (var i = 0; i < count; i++) {
+			_conn.AppendToStream(stream, ExpectedVersion.Any, null,
+				_serializer.Serialize(new PositionTestEvent()));
+		}
+	}
+
+	public int Handled { get; private set; }
+	public void Handle(PositionTestEvent @event) => Handled++;
+
+	[Fact]
+	public void a_checkpoint_carries_the_all_position_of_the_last_event_applied() {
+		Start(_early, null, true);
+		AssertEx.IsOrBecomesTrue(() => Handled == 3, TestTimeouts.ThrottleWaitFor);
+
+		var checkpoint = Assert.Single(GetCheckpoint());
+		Assert.Equal(_early, checkpoint.StreamName);
+		Assert.Equal(2, checkpoint.Version);
+		Assert.NotNull(checkpoint.Position);
+	}
+
+	[Fact]
+	public void the_high_water_mark_is_the_furthest_stream_and_the_watermark_the_nearest() {
+		Start(_early, null, true);
+		Start(_late, null, true);
+		AssertEx.IsOrBecomesTrue(() => Handled == 6, TestTimeouts.ThrottleWaitFor);
+
+		var byStream = GetCheckpoint().ToDictionary(c => c.StreamName, c => c.Position!.Value);
+		Assert.True(byStream[_late] > byStream[_early]);
+
+		// Same two numbers, opposite ends: how far the model reached, versus how far every one of its
+		// sources has been applied through.
+		Assert.Equal(byStream[_late], HighWaterMark);
+		Assert.Equal(byStream[_early], LowestAppliedPosition);
+	}
+
+	// A category start is the common case, and it delivers link copies rather than the originals.
+	// Those carry positions of their own, so a category-fed model checkpoints like any other.
+	[Fact]
+	public void a_category_stream_carries_positions_too() {
+		Start<TestAggregate>(null, true);
+		// At least this test's six: the category also holds what the class's other tests appended,
+		// since they share one connection.
+		AssertEx.IsOrBecomesTrue(() => Handled >= 6, TestTimeouts.ThrottleWaitFor);
+
+		var checkpoint = Assert.Single(GetCheckpoint());
+		Assert.Equal(_namer.GenerateForCategory(typeof(TestAggregate)), checkpoint.StreamName);
+		Assert.NotNull(checkpoint.Position);
+		Assert.NotNull(HighWaterMark);
+	}
+
+	[Fact]
+	public void a_model_with_no_listeners_projects_nothing() {
+		Assert.Null(HighWaterMark);
+		Assert.Null(LowestAppliedPosition);
+		Assert.Empty(GetCheckpoint());
+	}
+
+	[Fact]
+	public void a_source_that_has_delivered_nothing_suppresses_both_projections() {
+		Start(_early, null, true);
+		AssertEx.IsOrBecomesTrue(() => Handled == 3, TestTimeouts.ThrottleWaitFor);
+		Assert.NotNull(HighWaterMark);
+
+		// A second stream with nothing on it reports no position. Projecting over the rest would
+		// claim a reach and a coverage the model cannot stand behind.
+		Start(_namer.GenerateForAggregate(typeof(TestAggregate), Guid.NewGuid()), null, false);
+
+		Assert.Null(HighWaterMark);
+		Assert.Null(LowestAppliedPosition);
+	}
+
+	public record PositionTestEvent : Event;
+}

--- a/src/ReactiveDomain.Foundation/IListener.cs
+++ b/src/ReactiveDomain.Foundation/IListener.cs
@@ -4,7 +4,29 @@ namespace ReactiveDomain.Foundation;
 
 public interface IListener : IDisposable {
 	ISubscriber EventStream { get; }
+
+	/// <summary>The version of the last event delivered from <see cref="StreamName"/>.</summary>
 	long Position { get; }
+
+	/// <summary>
+	/// How far this listener has delivered: its stream, that stream's version, and the <c>$all</c>
+	/// position of the last event, read as one value. Null before the listener has started, when it
+	/// has no stream to report.
+	/// </summary>
+	/// <remarks>
+	/// Read together deliberately. Taken separately, a version and a position can come from different
+	/// events, producing a checkpoint whose position claims an event its version says was never
+	/// applied.
+	/// </remarks>
+	StreamCheckpoint? Checkpoint { get; }
+
+	/// <summary>
+	/// Adopts the <c>$all</c> position of history applied before this listener started, so a
+	/// checkpoint taken before the first live event still covers what the reader handled. Any event
+	/// this listener delivers replaces it.
+	/// </summary>
+	void SeedAllPosition(Position? position);
+
 	string StreamName { get; }
 
 	/// <summary>

--- a/src/ReactiveDomain.Foundation/IStreamReader.cs
+++ b/src/ReactiveDomain.Foundation/IStreamReader.cs
@@ -8,6 +8,16 @@ public interface IStreamReader : IDisposable {
 	/// </summary>
 	long? Position { get; }
 	/// <summary>
+	/// Where this read left off: the stream, its version, and the <c>$all</c> position of the last
+	/// event read. Null when nothing was read. This is what lets a listener resuming from the read
+	/// report a checkpoint covering the history the reader already applied.
+	/// </summary>
+	/// <remarks>
+	/// Read together deliberately — see <see cref="IListener.Checkpoint"/> for why the two clocks must
+	/// not be sampled separately.
+	/// </remarks>
+	StreamCheckpoint? Checkpoint { get; }
+	/// <summary>
 	/// The name of the stream being read
 	/// </summary>
 	string StreamName { get; }

--- a/src/ReactiveDomain.Foundation/StreamStore/QueuedStreamListener.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/QueuedStreamListener.cs
@@ -27,9 +27,10 @@ public class QueuedStreamListener : StreamListener, IHandle<IMessage> {
 	protected override void GotEvent(RecordedEvent recordedEvent) {
 		if (_disposed)
 			return; //todo: fix dispose
-		Interlocked.Exchange(ref StreamPosition, recordedEvent.EventNumber);
+		RecordDelivered(recordedEvent);
 		if (Serializer.Deserialize(recordedEvent) is IMessage @event) {
-			//todo: this needs to publish a RecordedEvent
+			// The envelope reaches checkpoints through the listener, not the subscriber: handlers
+			// still receive the bare message. Delivering it per-event is #211's remaining half.
 			SyncQueue.Publish(@event);
 		}
 	}

--- a/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
@@ -228,24 +228,77 @@ public abstract class ReadModelBase :
 		}
 	}
 
-	private IListener AddNewListener() {
+	/// <summary>Creates a listener, seeds its <c>$all</c> position, and feeds it into this model's queue.</summary>
+	/// <param name="readAllPosition">
+	/// Where the reader that just replayed this stream's history left off, so a checkpoint taken
+	/// before the first live event still accounts for what the reader applied.
+	/// </param>
+	private IListener AddNewListener(Position? readAllPosition) {
 		var l = _getListener();
 		lock (_listeners) {
 			_listeners.Add(l);
 		}
 
+		l.SeedAllPosition(readAllPosition);
 		l.EventStream.SubscribeToAll(_queue);
 		return l;
 	}
 
 	/// <summary>How far this model has applied each stream it listens to.</summary>
+	/// <returns>One checkpoint per started listener.</returns>
 	/// <remarks>
-	/// <see cref="StreamCheckpoint.Position"/> is null: a listener tracks its stream's version, not the
-	/// <c>$all</c> position of the events it delivered.
+	/// <see cref="StreamCheckpoint.Position"/> is null for any stream whose last delivered event
+	/// carried no <c>$all</c> position, which is what a store that does not report one produces.
 	/// </remarks>
 	public List<StreamCheckpoint> GetCheckpoint() {
 		lock (_listeners) {
-			return _listeners.Select(l => new StreamCheckpoint(l.StreamName, l.Position)).ToList();
+			// A listener is in this list from the moment it is created, but is only checkpointable
+			// once started — until then it has no stream name to report.
+			return _listeners.Select(l => l.Checkpoint).OfType<StreamCheckpoint>().ToList();
+		}
+	}
+
+	/// <summary>
+	/// The furthest into the store's <c>$all</c> log this model has reached — the greatest position
+	/// among the last events applied from its streams.
+	/// </summary>
+	/// <remarks>
+	/// <para><b>Not a completeness claim.</b> The model only ever saw events on its own streams, so it
+	/// has not seen everything below this position. To gate a read on freshness use
+	/// <see cref="LowestAppliedPosition"/>.</para>
+	/// <para>Null when the model has no listeners, or when any one of them reports no position —
+	/// projecting over the rest would silently overstate.</para>
+	/// </remarks>
+	public Position? HighWaterMark => ProjectAllPositions(takeGreatest: true);
+
+	/// <summary>
+	/// The position through which every one of this model's streams has been applied — the least
+	/// position among the last events applied from them.
+	/// </summary>
+	/// <remarks>
+	/// <para>This is the honest freshness signal: everything each source had delivered up to here has
+	/// been handled. Compare against it to gate a read.</para>
+	/// <para>Null when the model has no listeners, or when any one of them reports no position —
+	/// projecting over the rest would silently understate which sources are covered.</para>
+	/// </remarks>
+	public Position? LowestAppliedPosition => ProjectAllPositions(takeGreatest: false);
+
+	private Position? ProjectAllPositions(bool takeGreatest) {
+		lock (_listeners) {
+			if (_listeners.Count == 0)
+				return null;
+			Position? projected = null;
+			foreach (var listener in _listeners) {
+				if (listener.Checkpoint?.Position is not { } position)
+					return null;
+				if (projected is not { } current) {
+					projected = position;
+					continue;
+				}
+				if (takeGreatest ? position > current : position < current)
+					projected = position;
+			}
+			return projected;
 		}
 	}
 
@@ -284,9 +337,11 @@ public abstract class ReadModelBase :
 			reader.Read(stream, () => ReadCompleted, checkpoint);
 			if (_disposed)
 				return false;
-			var position = reader.Position ?? checkpoint;
+			// One read of the reader: version and position must come from the same event.
+			var read = reader.Checkpoint;
+			var position = read?.Version ?? checkpoint;
 
-			AddNewListener().Start(stream, position, blockUntilLive, validateStream, cancelWaitToken);
+			AddNewListener(read?.Position).Start(stream, position, blockUntilLive, validateStream, cancelWaitToken);
 			return true;
 		});
 	}
@@ -307,9 +362,11 @@ public abstract class ReadModelBase :
 			reader.Read(stream, () => ReadCompleted, checkpoint);
 			if (_disposed)
 				return false;
-			var position = reader.Position ?? checkpoint;
+			// One read of the reader: version and position must come from the same event.
+			var read = reader.Checkpoint;
+			var position = read?.Version ?? checkpoint;
 
-			AddNewListener().Start(stream, position, false, validateStream, cancelWaitToken);
+			AddNewListener(read?.Position).Start(stream, position, false, validateStream, cancelWaitToken);
 			return true;
 		}, cancelWaitToken);
 	}
@@ -335,9 +392,11 @@ public abstract class ReadModelBase :
 			reader.Read<TAggregate>(id, () => ReadCompleted, checkpoint);
 			if (_disposed)
 				return false;
-			var position = reader.Position;
+			// One read of the reader: version and position must come from the same event.
+			var read = reader.Checkpoint;
+			var position = read?.Version;
 
-			AddNewListener().Start<TAggregate>(id, position, blockUntilLive, validateStream, cancelWaitToken);
+			AddNewListener(read?.Position).Start<TAggregate>(id, position, blockUntilLive, validateStream, cancelWaitToken);
 			return true;
 		});
 	}
@@ -359,9 +418,11 @@ public abstract class ReadModelBase :
 			reader.Read<TAggregate>(id, () => ReadCompleted, checkpoint);
 			if (_disposed)
 				return false;
-			var position = reader.Position;
+			// One read of the reader: version and position must come from the same event.
+			var read = reader.Checkpoint;
+			var position = read?.Version;
 
-			AddNewListener().Start<TAggregate>(id, position, false, validateStream, cancelWaitToken);
+			AddNewListener(read?.Position).Start<TAggregate>(id, position, false, validateStream, cancelWaitToken);
 			return true;
 		}, cancelWaitToken);
 	}
@@ -385,9 +446,11 @@ public abstract class ReadModelBase :
 			reader.Read<TAggregate>(() => ReadCompleted, checkpoint);
 			if (_disposed)
 				return false;
-			var position = reader.Position;
+			// One read of the reader: version and position must come from the same event.
+			var read = reader.Checkpoint;
+			var position = read?.Version;
 
-			AddNewListener().Start<TAggregate>(position, blockUntilLive, validateStream, cancelWaitToken);
+			AddNewListener(read?.Position).Start<TAggregate>(position, blockUntilLive, validateStream, cancelWaitToken);
 			return true;
 		});
 	}
@@ -409,9 +472,11 @@ public abstract class ReadModelBase :
 			reader.Read<TAggregate>(() => ReadCompleted, checkpoint);
 			if (_disposed)
 				return false;
-			var position = reader.Position;
+			// One read of the reader: version and position must come from the same event.
+			var read = reader.Checkpoint;
+			var position = read?.Version;
 
-			AddNewListener().Start<TAggregate>(position, false, validateStream, cancelWaitToken);
+			AddNewListener(read?.Position).Start<TAggregate>(position, false, validateStream, cancelWaitToken);
 			return true;
 		}, cancelWaitToken);
 	}

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamListener.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamListener.cs
@@ -34,6 +34,44 @@ public class StreamListener : IListener {
 	private readonly IStreamStoreConnection _streamStoreConnection;
 	protected long StreamPosition;
 	public long Position => StreamPosition;
+
+	private readonly object _checkpointLock = new();
+	private Position? _allPosition;
+
+	/// <inheritdoc cref="IListener.Checkpoint"/>
+	public StreamCheckpoint? Checkpoint {
+		get {
+			lock (_checkpointLock) {
+				// Named only once Start has run. Before that there is no stream to report, and the
+				// version and position hold seed values that belong to nothing yet.
+				return string.IsNullOrEmpty(StreamName)
+					? null
+					: new StreamCheckpoint(StreamName, Interlocked.Read(ref StreamPosition), _allPosition);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Records how far this listener has delivered. Both clocks come from one event and are written
+	/// under one lock, so a reader cannot see a version from one event beside a position from another.
+	/// </summary>
+	/// <remarks>
+	/// The position is assigned unconditionally, so a store that stops reporting positions leaves this
+	/// null rather than stale — it belongs to the last event delivered, not to the last one that
+	/// happened to carry one.
+	/// </remarks>
+	/// <param name="recordedEvent">The event just delivered.</param>
+	protected void RecordDelivered(RecordedEvent recordedEvent) {
+		lock (_checkpointLock) {
+			Interlocked.Exchange(ref StreamPosition, recordedEvent.EventNumber);
+			_allPosition = recordedEvent.Position;
+		}
+	}
+
+	/// <inheritdoc cref="IListener.SeedAllPosition"/>
+	public void SeedAllPosition(Position? position) {
+		lock (_checkpointLock) { _allPosition = position; }
+	}
 	public string StreamName { get; private set; } = string.Empty;
 	public CatchUpSubscriptionSettings Settings { get; set; }
 
@@ -187,9 +225,12 @@ public class StreamListener : IListener {
 		Action? liveProcessingStarted = null,
 		Action<SubscriptionDropReason, Exception?>? subscriptionDropped = null,
 		UserCredentials? userCredentials = null) {
-		StreamName = stream;
-
-		Interlocked.Exchange(ref StreamPosition, lastCheckpoint ?? 0);
+		// Named and positioned together: naming is what makes this listener checkpointable, so a
+		// reader must not see the name before the version it goes with.
+		lock (_checkpointLock) {
+			StreamName = stream;
+			Interlocked.Exchange(ref StreamPosition, lastCheckpoint ?? 0);
+		}
 		var sub = _streamStoreConnection.SubscribeToStreamFrom(
 			stream,
 			lastCheckpoint,
@@ -218,7 +259,7 @@ public class StreamListener : IListener {
 	}
 
 	protected virtual void GotEvent(RecordedEvent recordedEvent) {
-		Interlocked.Exchange(ref StreamPosition, recordedEvent.EventNumber);
+		RecordDelivered(recordedEvent);
 		if (Serializer.Deserialize(recordedEvent) is IMessage @event) {
 			Bus.Publish(@event);
 		}

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamReader.cs
@@ -17,6 +17,20 @@ public class StreamReader : IStreamReader {
 	protected long StreamPosition;
 	protected bool FirstEventRead;
 	public long? Position => FirstEventRead ? StreamPosition : null;
+
+	private readonly object _checkpointLock = new();
+	private Position? _allPosition;
+
+	/// <inheritdoc cref="IStreamReader.Checkpoint"/>
+	public StreamCheckpoint? Checkpoint {
+		get {
+			lock (_checkpointLock) {
+				return FirstEventRead && !string.IsNullOrEmpty(StreamName)
+					? new StreamCheckpoint(StreamName, Interlocked.Read(ref StreamPosition), _allPosition)
+					: null;
+			}
+		}
+	}
 	public Action<IMessage> Handle { get; set; }
 	public string StreamName { get; private set; } = string.Empty;
 	private const int ReadPageSize = 500;
@@ -196,8 +210,13 @@ public class StreamReader : IStreamReader {
 		if (_cancelled)
 			return;
 
-		Interlocked.Exchange(ref StreamPosition, recordedEvent.EventNumber);
-		FirstEventRead = true;
+		// Both clocks and the read flag move together, so a reader of Checkpoint cannot see a version
+		// from one event beside a position from another.
+		lock (_checkpointLock) {
+			Interlocked.Exchange(ref StreamPosition, recordedEvent.EventNumber);
+			_allPosition = recordedEvent.Position;
+			FirstEventRead = true;
+		}
 
 		if (Serializer.Deserialize(recordedEvent) is IMessage @event) {
 			Handle(@event);

--- a/src/ReactiveDomain.Testing.Tests/TestCapacityDetectorTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/TestCapacityDetectorTests.cs
@@ -1,0 +1,84 @@
+using Xunit;
+
+namespace ReactiveDomain.Testing.Tests;
+
+public sealed class TestCapacityDetectorTests {
+	// A lookup over an in-memory map, so every branch is exercised without mutating real process
+	// environment variables — which are shared, order-dependent state across the whole test run.
+	private static Func<string, string?> Env(params (string Name, string Value)[] vars) {
+		var map = vars.ToDictionary(v => v.Name, v => v.Value, StringComparer.OrdinalIgnoreCase);
+		return name => map.TryGetValue(name, out var value) ? value : null;
+	}
+
+	private static Func<string, string?> Override(string value) =>
+		Env((TestCapacityDetector.OverrideEnvironmentVariable, value));
+
+	[Theory]
+	[InlineData(1, TestCapacity.Small)]
+	[InlineData(2, TestCapacity.Small)]
+	[InlineData(3, TestCapacity.Small)]
+	[InlineData(4, TestCapacity.Medium)]
+	[InlineData(7, TestCapacity.Medium)]
+	[InlineData(8, TestCapacity.Large)]
+	[InlineData(128, TestCapacity.Large)]
+	public void the_cores_choose_the_bucket(int cores, TestCapacity expected) {
+		var (capacity, reported, reason) = TestCapacityDetector.Detect(cores, Env());
+
+		Assert.Equal(expected, capacity);
+		Assert.Equal(cores, reported);
+		Assert.Contains(cores.ToString(), reason);
+	}
+
+	/// <summary>Consumers force against the boundaries, so they are pinned at the edge.</summary>
+	[Fact]
+	public void each_boundary_is_inclusive_at_its_own_bucket() {
+		Assert.Equal(TestCapacity.Large,
+			TestCapacityDetector.Detect(TestCapacityDetector.LargeCores, Env()).Capacity);
+		Assert.Equal(TestCapacity.Medium,
+			TestCapacityDetector.Detect(TestCapacityDetector.LargeCores - 1, Env()).Capacity);
+		Assert.Equal(TestCapacity.Medium,
+			TestCapacityDetector.Detect(TestCapacityDetector.MediumCores, Env()).Capacity);
+		Assert.Equal(TestCapacity.Small,
+			TestCapacityDetector.Detect(TestCapacityDetector.MediumCores - 1, Env()).Capacity);
+	}
+
+	[Theory]
+	[InlineData("Small", TestCapacity.Small)]
+	[InlineData("medium", TestCapacity.Medium)]
+	[InlineData("LARGE", TestCapacity.Large)]
+	public void an_override_wins_over_the_cores(string value, TestCapacity expected) {
+		// Cores that would choose a different bucket on their own, so only the override produces this.
+		var cores = expected == TestCapacity.Large ? 1 : 64;
+
+		var (capacity, _, reason) = TestCapacityDetector.Detect(cores, Override(value));
+
+		Assert.Equal(expected, capacity);
+		Assert.Contains("override", reason);
+	}
+
+	/// <summary>The cores are still a real answer; "the override worked" is the costlier thing to believe.</summary>
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData("true")]
+	[InlineData("Ci")]
+	public void an_unrecognized_override_falls_through_to_the_cores(string value) {
+		Assert.Equal(TestCapacity.Large, TestCapacityDetector.Detect(64, Override(value)).Capacity);
+		Assert.Equal(TestCapacity.Small, TestCapacityDetector.Detect(2, Override(value)).Capacity);
+	}
+
+	/// <summary>Naming a CI system is what this replaced: a large runner is not small for being CI.</summary>
+	[Fact]
+	public void a_ci_variable_alone_does_not_shrink_the_bucket() {
+		var (capacity, _, _) = TestCapacityDetector.Detect(64, Env(("GITHUB_ACTIONS", "true"), ("CI", "true")));
+
+		Assert.Equal(TestCapacity.Large, capacity);
+	}
+
+	[Fact]
+	public void the_detected_values_describe_this_process() {
+		Assert.Equal(Environment.ProcessorCount, TestCapacityDetector.Cores);
+		Assert.False(string.IsNullOrWhiteSpace(TestCapacityDetector.Reason));
+		Assert.Equal(TestCapacityDetector.Detected, TestTimeouts.Capacity);
+	}
+}

--- a/src/ReactiveDomain.Testing.Tests/TestTimeoutsTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/TestTimeoutsTests.cs
@@ -2,21 +2,92 @@ using Xunit;
 
 namespace ReactiveDomain.Testing.Tests;
 
+/// <summary>
+/// Every test that assigns <see cref="TestTimeouts.Budget"/> lives in this one class and restores it,
+/// because it is process-wide: xunit serializes tests within a class but runs classes in parallel, so
+/// a reader in another class could otherwise see a budget this one was midway through swapping.
+/// </summary>
 public sealed class TestTimeoutsTests {
-	[Fact]
-	public void values_match_the_environment() {
-		var isCi = string.Equals(
-			Environment.GetEnvironmentVariable("GITHUB_ACTIONS"), "true", StringComparison.OrdinalIgnoreCase);
-
-		Assert.Equal(isCi, TestTimeouts.IsCi);
-		if (isCi) {
-			Assert.Equal(TimeSpan.FromSeconds(5), TestTimeouts.WaitFor);
-			Assert.Equal(TimeSpan.FromSeconds(10), TestTimeouts.CommandTimeout);
-			Assert.Equal(TimeSpan.FromSeconds(10), TestTimeouts.ThrottleWaitFor);
-		} else {
-			Assert.Equal(TimeSpan.FromMilliseconds(500), TestTimeouts.WaitFor);
-			Assert.Equal(TimeSpan.FromMilliseconds(500), TestTimeouts.CommandTimeout);
-			Assert.Equal(TimeSpan.FromSeconds(2), TestTimeouts.ThrottleWaitFor);
+	private static void WithBudget(TestTimeoutBudget budget, Action assert) {
+		var original = TestTimeouts.Budget;
+		try {
+			TestTimeouts.Budget = budget;
+			assert();
+		} finally {
+			TestTimeouts.Budget = original;
 		}
+	}
+
+	[Fact]
+	public void the_budget_defaults_to_the_detected_bucket() {
+		Assert.Equal(TestTimeoutBudget.For(TestTimeouts.Capacity), TestTimeouts.Budget);
+	}
+
+	/// <summary>The three waits read the budget rather than caching it, or tuning would not take.</summary>
+	[Fact]
+	public void assigning_a_budget_retunes_the_waits() {
+		var tuned = new TestTimeoutBudget(
+			TimeSpan.FromSeconds(11), TimeSpan.FromSeconds(22), TimeSpan.FromSeconds(33));
+
+		WithBudget(tuned, () => {
+			Assert.Equal(tuned.WaitFor, TestTimeouts.WaitFor);
+			Assert.Equal(tuned.CommandTimeout, TestTimeouts.CommandTimeout);
+			Assert.Equal(tuned.ThrottleWaitFor, TestTimeouts.ThrottleWaitFor);
+		});
+
+		Assert.Equal(TestTimeoutBudget.For(TestTimeouts.Capacity), TestTimeouts.Budget);
+	}
+
+	[Theory]
+	[InlineData(TestCapacity.Large, 500, 500, 2000)]
+	[InlineData(TestCapacity.Medium, 2000, 5000, 5000)]
+	[InlineData(TestCapacity.Small, 5000, 10_000, 10_000)]
+	public void the_shipped_defaults_are_what_they_say(
+		TestCapacity capacity, int waitForMs, int commandMs, int throttleMs) {
+		var budget = TestTimeoutBudget.For(capacity);
+
+		Assert.Equal(TimeSpan.FromMilliseconds(waitForMs), budget.WaitFor);
+		Assert.Equal(TimeSpan.FromMilliseconds(commandMs), budget.CommandTimeout);
+		Assert.Equal(TimeSpan.FromMilliseconds(throttleMs), budget.ThrottleWaitFor);
+	}
+
+	/// <summary>A smaller bucket never waits less, whatever the numbers are tuned to.</summary>
+	[Fact]
+	public void the_defaults_do_not_shrink_as_the_bucket_does() {
+		var large = TestTimeoutBudget.For(TestCapacity.Large);
+		var medium = TestTimeoutBudget.For(TestCapacity.Medium);
+		var small = TestTimeoutBudget.For(TestCapacity.Small);
+
+		Assert.True(medium.WaitFor >= large.WaitFor && small.WaitFor >= medium.WaitFor);
+		Assert.True(medium.CommandTimeout >= large.CommandTimeout && small.CommandTimeout >= medium.CommandTimeout);
+		Assert.True(medium.ThrottleWaitFor >= large.ThrottleWaitFor && small.ThrottleWaitFor >= medium.ThrottleWaitFor);
+	}
+
+	[Fact]
+	public void the_legacy_flag_tracks_the_smallest_bucket() {
+		Assert.Equal(TestTimeouts.Capacity == TestCapacity.Small, TestTimeouts.IsCi);
+	}
+
+	[Fact]
+	public void the_description_names_the_bucket_and_the_budget_in_force() {
+		var tuned = new TestTimeoutBudget(
+			TimeSpan.FromSeconds(11), TimeSpan.FromSeconds(22), TimeSpan.FromSeconds(33));
+
+		WithBudget(tuned, () => {
+			var description = TestTimeouts.CapacityDescription;
+
+			Assert.Contains(TestTimeouts.Capacity.ToString(), description);
+			Assert.Contains(TestTimeouts.CapacityReason, description);
+			Assert.Contains(tuned.WaitFor.ToString(), description);
+		});
+	}
+
+	[Fact]
+	public void the_description_can_be_written_somewhere_other_than_the_console() {
+		var writer = new StringWriter();
+
+		TestTimeouts.WriteCapacity(writer);
+
+		Assert.Contains(TestTimeouts.CapacityDescription, writer.ToString());
 	}
 }

--- a/src/ReactiveDomain.Testing/EventStore/MockStreamStoreConnection.cs
+++ b/src/ReactiveDomain.Testing/EventStore/MockStreamStoreConnection.cs
@@ -14,6 +14,21 @@ public sealed class MockStreamStoreConnection : IStreamStoreConnection {
 	public const string AllStreamName = "$All";
 	private readonly Dictionary<string, List<RecordedEvent>> _store;
 	private readonly List<RecordedEvent> _allStream = [];
+
+	/// <summary>
+	/// The position the next entry will take in the all-stream — this store's whole log, so it is
+	/// monotonic across streams and stands in for a real <c>$all</c> position. Link entries consume
+	/// positions of their own, so a stream's events are not contiguous here, which is also true of a
+	/// real store.
+	/// </summary>
+	/// <remarks>
+	/// Callers must hold <c>lock (_allStream)</c>, and must add the entry before releasing it. Counts
+	/// from one, so a real position is never <see cref="Position.Start"/>.
+	/// </remarks>
+	private Position NextAllPosition() {
+		var next = _allStream.Count + 1;
+		return new Position(next, next);
+	}
 	private readonly AdHocHandler<IMessage> _inboundEventHandler;
 	private readonly SingleThreadedBus _inboundEventBus;
 	private readonly List<IDisposable> _subscriptions;
@@ -92,19 +107,23 @@ public sealed class MockStreamStoreConnection : IStreamStoreConnection {
 			for (var i = 0; i < events.Length; i++) {
 				var created = DateTime.UtcNow;
 				var epochTime = (long)(created - epochStart).TotalSeconds;
-				var recordedEvent = new RecordedEvent(
-					stream,
-					events[i].EventId,
-					eventStream.Count,
-					events[i].EventType,
-					events[i].Data,
-					events[i].Metadata,
-					events[i].IsJson,
-					created,
-					epochTime);
+				RecordedEvent recordedEvent;
+				lock (_allStream) {
+					recordedEvent = new RecordedEvent(
+						stream,
+						events[i].EventId,
+						eventStream.Count,
+						events[i].EventType,
+						events[i].Data,
+						events[i].Metadata,
+						events[i].IsJson,
+						created,
+						epochTime,
+						NextAllPosition());
 
-				_allStream.Add(recordedEvent);
-				_inboundEventHandler.Handle(new EventCommitted(recordedEvent, _allStream.Count));
+					_allStream.Add(recordedEvent);
+					_inboundEventHandler.Handle(new EventCommitted(recordedEvent, _allStream.Count));
+				}
 				eventStream.Add(recordedEvent);
 				var written = new EventWritten(stream, recordedEvent, false, recordedEvent.EventNumber);
 				_inboundEventHandler.Handle(written);
@@ -511,19 +530,23 @@ public sealed class MockStreamStoreConnection : IStreamStoreConnection {
 		var created = DateTime.UtcNow;
 		var epochTime = (long)(created - epochStart).TotalSeconds;
 
-		var projectedEvent = new ProjectedEvent(
-			streamName,
-			@event.Event.EventNumber,
-			@event.Event.EventStreamId,
-			@event.Event.EventId, // reusing since the projection is linking to the original event
-			stream.Count,
-			@event.Event.EventType,
-			@event.Event.Data,
-			@event.Event.Metadata,
-			@event.Event.IsJson,
-			created,
-			epochTime);
+		ProjectedEvent projectedEvent;
 		lock (_allStream) {
+			// A link is its own entry in the all-stream, so it carries its own position — matching a
+			// real store, where a resolved delivery reports the position of the entry that was read.
+			projectedEvent = new ProjectedEvent(
+				streamName,
+				@event.Event.EventNumber,
+				@event.Event.EventStreamId,
+				@event.Event.EventId, // reusing since the projection is linking to the original event
+				stream.Count,
+				@event.Event.EventType,
+				@event.Event.Data,
+				@event.Event.Metadata,
+				@event.Event.IsJson,
+				created,
+				epochTime,
+				NextAllPosition());
 			_allStream.Add(projectedEvent);
 			_inboundEventHandler.Handle(new EventCommitted(projectedEvent, _allStream.Count));
 		}
@@ -556,19 +579,23 @@ public sealed class MockStreamStoreConnection : IStreamStoreConnection {
 		var created = DateTime.UtcNow;
 		var epochTime = (long)(created - epochStart).TotalSeconds;
 
-		var projectedEvent = new ProjectedEvent(
-			streamName,
-			@event.Event.EventNumber,
-			@event.Event.EventStreamId,
-			@event.Event.EventId, // reusing since the projection is linking to the original event
-			stream.Count,
-			@event.Event.EventType,
-			@event.Event.Data,
-			@event.Event.Metadata,
-			@event.Event.IsJson,
-			created,
-			epochTime);
+		ProjectedEvent projectedEvent;
 		lock (_allStream) {
+			// A link is its own entry in the all-stream, so it carries its own position — matching a
+			// real store, where a resolved delivery reports the position of the entry that was read.
+			projectedEvent = new ProjectedEvent(
+				streamName,
+				@event.Event.EventNumber,
+				@event.Event.EventStreamId,
+				@event.Event.EventId, // reusing since the projection is linking to the original event
+				stream.Count,
+				@event.Event.EventType,
+				@event.Event.Data,
+				@event.Event.Metadata,
+				@event.Event.IsJson,
+				created,
+				epochTime,
+				NextAllPosition());
 			_allStream.Add(projectedEvent);
 			_inboundEventHandler.Handle(new EventCommitted(projectedEvent, _allStream.Count));
 		}

--- a/src/ReactiveDomain.Testing/Specifications/NullListener.cs
+++ b/src/ReactiveDomain.Testing/Specifications/NullListener.cs
@@ -28,6 +28,14 @@ public sealed class NullListener : IListener, ISubscriber {
 	/// </summary>
 	public long Position => _position;
 
+	/// <inheritdoc cref="IListener.Checkpoint"/>
+	/// <remarks>Always null: nothing is ever delivered, so there is nothing to checkpoint.</remarks>
+	public StreamCheckpoint? Checkpoint => null;
+
+	/// <inheritdoc cref="IListener.SeedAllPosition"/>
+	/// <remarks>Ignored, as nothing here reports a position.</remarks>
+	public void SeedAllPosition(Position? position) { }
+
 	/// <summary>
 	/// Gets the name of the stream.
 	/// </summary>

--- a/src/ReactiveDomain.Testing/Specifications/NullReader.cs
+++ b/src/ReactiveDomain.Testing/Specifications/NullReader.cs
@@ -25,6 +25,10 @@ public class NullReader : IStreamReader {
 	/// </summary>
 	public long? Position => 0;
 
+	/// <inheritdoc cref="IStreamReader.Checkpoint"/>
+	/// <remarks>Always null: nothing is ever read, so there is nothing to checkpoint.</remarks>
+	public StreamCheckpoint? Checkpoint => null;
+
 	/// <summary>
 	/// Gets the name of the stream.
 	/// </summary>

--- a/src/ReactiveDomain.Testing/TestCapacity.cs
+++ b/src/ReactiveDomain.Testing/TestCapacity.cs
@@ -1,0 +1,20 @@
+namespace ReactiveDomain.Testing;
+
+/// <summary>
+/// How much CPU a test process has to work with, bucketed. <see cref="TestTimeouts"/> picks its
+/// wait budgets from this.
+/// </summary>
+/// <remarks>
+/// A wait fails early because the machine could not schedule the work in time, which depends on
+/// cores — so cores choose the bucket, and a CI runner is whichever size its cores make it.
+/// </remarks>
+public enum TestCapacity {
+	/// <summary>Too few cores to run a suite in parallel; the scheduler sets the pace.</summary>
+	Small,
+
+	/// <summary>Enough cores to make progress, few enough that a parallel suite contends.</summary>
+	Medium,
+
+	/// <summary>Cores to spare, so an expired wait means something is actually wrong.</summary>
+	Large,
+}

--- a/src/ReactiveDomain.Testing/TestCapacityDetector.cs
+++ b/src/ReactiveDomain.Testing/TestCapacityDetector.cs
@@ -1,0 +1,62 @@
+namespace ReactiveDomain.Testing;
+
+/// <summary>
+/// Buckets a test process by the cores available to it, and reports what it decided on.
+/// </summary>
+/// <remarks>
+/// Cores are the signal because cores are the cause: a wait that expires early did so because the
+/// machine could not schedule the work in time. Naming CI providers answered that by proxy, and
+/// answered it wrong for everything off the list — a capped container, a self-hosted runner, an old
+/// laptop. <see cref="Environment.ProcessorCount"/> already reflects a container's CPU cap.
+/// </remarks>
+public static class TestCapacityDetector {
+	/// <summary>
+	/// Forces a bucket regardless of cores, for when the core count is not the whole story — a
+	/// many-core machine running several test jobs at once has the cores but not the capacity.
+	/// Recognized values are the <see cref="TestCapacity"/> names, case-insensitively.
+	/// </summary>
+	public const string OverrideEnvironmentVariable = "REACTIVEDOMAIN_TEST_CAPACITY";
+
+	/// <summary>Default lower bound for <see cref="TestCapacity.Large"/>.</summary>
+	public const int LargeCores = 8;
+
+	/// <summary>Default lower bound for <see cref="TestCapacity.Medium"/>; below it is Small.</summary>
+	public const int MediumCores = 4;
+
+	/// <summary>The bucket this process detected, computed once.</summary>
+	public static TestCapacity Detected { get; }
+
+	/// <summary>Cores this process can use — a container's cap, not the host's total.</summary>
+	public static int Cores { get; }
+
+	/// <summary>What chose <see cref="Detected"/>, so a red run can state the budget it used.</summary>
+	public static string Reason { get; }
+
+	static TestCapacityDetector() =>
+		(Detected, Cores, Reason) = Detect(Environment.ProcessorCount, Environment.GetEnvironmentVariable);
+
+	/// <summary>
+	/// Pure detection core — takes the core count and an environment lookup rather than reading the
+	/// process, so every branch is exercisable without mutating state shared by the whole test run.
+	/// </summary>
+	/// <param name="cores">Cores available to the process.</param>
+	/// <param name="getEnvironmentVariable">Returns the named variable's value, or null.</param>
+	public static (TestCapacity Capacity, int Cores, string Reason) Detect(
+		int cores,
+		Func<string, string?> getEnvironmentVariable) {
+		var overridden = getEnvironmentVariable(OverrideEnvironmentVariable);
+		if (!string.IsNullOrWhiteSpace(overridden)) {
+			foreach (var capacity in Enum.GetValues<TestCapacity>()) {
+				if (string.Equals(overridden, capacity.ToString(), StringComparison.OrdinalIgnoreCase))
+					return (capacity, cores, $"{OverrideEnvironmentVariable}={capacity} (explicit override)");
+			}
+			// Unrecognized: fall through to the cores rather than honour a default nobody asked for.
+		}
+
+		if (cores >= LargeCores)
+			return (TestCapacity.Large, cores, $"{cores} cores available, {LargeCores} or more");
+		if (cores >= MediumCores)
+			return (TestCapacity.Medium, cores, $"{cores} cores available, under {LargeCores}");
+		return (TestCapacity.Small, cores, $"{cores} cores available, under {MediumCores}");
+	}
+}

--- a/src/ReactiveDomain.Testing/TestTimeoutBudget.cs
+++ b/src/ReactiveDomain.Testing/TestTimeoutBudget.cs
@@ -1,0 +1,23 @@
+namespace ReactiveDomain.Testing;
+
+/// <summary>
+/// The three wait budgets a test run uses. Defaults per <see cref="TestCapacity"/> come from
+/// <see cref="For"/>; a consuming project that has measured its own suite replaces them via
+/// <see cref="TestTimeouts.Budget"/>.
+/// </summary>
+/// <param name="WaitFor">Message-arrival waits: <see cref="TestQueue.WaitFor{T}"/>,
+/// <see cref="TestQueue.WaitForMsgId"/>, RepositoryEvents.</param>
+/// <param name="CommandTimeout">Command-response waits (dispatcher Send).</param>
+/// <param name="ThrottleWaitFor">Waits on real-time Rx operators (Throttle, Buffer, Sample),
+/// whose timers run on wall-clock schedulers.</param>
+public sealed record TestTimeoutBudget(TimeSpan WaitFor, TimeSpan CommandTimeout, TimeSpan ThrottleWaitFor) {
+	/// <summary>
+	/// The shipped default for a bucket — a starting point, not a measurement. A suite that trips
+	/// these is telling you what its own numbers should be; set them and move on.
+	/// </summary>
+	public static TestTimeoutBudget For(TestCapacity capacity) => capacity switch {
+		TestCapacity.Large => new(TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(500), TimeSpan.FromSeconds(2)),
+		TestCapacity.Medium => new(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5)),
+		_ => new(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10)),
+	};
+}

--- a/src/ReactiveDomain.Testing/TestTimeouts.cs
+++ b/src/ReactiveDomain.Testing/TestTimeouts.cs
@@ -1,42 +1,59 @@
 namespace ReactiveDomain.Testing;
 
 /// <summary>
-/// CI-aware timeout source for test waits, keyed on the <c>GITHUB_ACTIONS</c> environment
-/// variable. CI runners (typically 2 cores) suffer scheduler starvation that surfaces as
-/// spurious timeouts when tests use locally-tuned values, so waits get generous CI values
-/// while staying fast for the local edit-test loop.
+/// Timeout source for test waits, bucketed by the cores available to the process (see
+/// <see cref="TestCapacityDetector"/>) so a machine that cannot run the suite in parallel is not
+/// held to a budget written for one that can.
 /// </summary>
 /// <remarks>
-/// To reproduce CI-only timing failures locally, launch the test runner restricted to two
-/// cores with the CI flag set, e.g. from cmd:
-/// <c>set GITHUB_ACTIONS=true &amp;&amp; start /affinity 3 dotnet test ...</c>.
+/// <para>The shipped budgets are defaults, not measurements. Tune them per project by assigning
+/// <see cref="Budget"/> once at startup — an xunit assembly fixture, a module initializer — before
+/// any test reads a wait.</para>
+/// <para>To reproduce a smaller machine's timing on a larger one, force the bucket and restrict the
+/// runner to matching cores, e.g. from cmd:
+/// <c>set REACTIVEDOMAIN_TEST_CAPACITY=Small &amp;&amp; start /affinity 3 dotnet test ...</c>.
 /// Run test assemblies sequentially (<c>MaxCpuCount=1</c> in a .runsettings file or
 /// <c>-maxcpucount:1</c>) — concurrent in-process stores starve the thread pool.
-/// See Docs/ci-test-guidance.md.
+/// See Docs/ci-test-guidance.md.</para>
 /// </remarks>
 public static class TestTimeouts {
-	/// <summary>
-	/// True when running under GitHub Actions (<c>GITHUB_ACTIONS</c> = "true"), or under the
-	/// local repro recipe that sets the same variable.
-	/// </summary>
-	public static bool IsCi { get; } =
-		string.Equals(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"), "true", StringComparison.OrdinalIgnoreCase);
+	/// <summary>The detected bucket, and so which defaults <see cref="Budget"/> starts from.</summary>
+	public static TestCapacity Capacity { get; } = TestCapacityDetector.Detected;
+
+	/// <summary>What chose <see cref="Capacity"/>, so a red run can state the budget it used.</summary>
+	public static string CapacityReason { get; } = TestCapacityDetector.Reason;
 
 	/// <summary>
-	/// Timeout for message-arrival waits: <see cref="TestQueue.WaitFor{T}"/>,
-	/// <see cref="TestQueue.WaitForMsgId"/>, and RepositoryEvents waits.
-	/// 500 ms locally, 5 s on CI.
+	/// The budgets in force. Defaults to <see cref="TestTimeoutBudget.For"/> of
+	/// <see cref="Capacity"/>; assign to tune a project's own numbers.
 	/// </summary>
-	public static TimeSpan WaitFor { get; } = IsCi ? TimeSpan.FromSeconds(5) : TimeSpan.FromMilliseconds(500);
+	/// <remarks>Set it once before any test reads a wait — this is process-wide, and nothing
+	/// re-reads a value a wait has already started against.</remarks>
+	public static TestTimeoutBudget Budget { get; set; } = TestTimeoutBudget.For(Capacity);
+
+	/// <inheritdoc cref="TestTimeoutBudget.WaitFor"/>
+	public static TimeSpan WaitFor => Budget.WaitFor;
+
+	/// <inheritdoc cref="TestTimeoutBudget.CommandTimeout"/>
+	public static TimeSpan CommandTimeout => Budget.CommandTimeout;
+
+	/// <inheritdoc cref="TestTimeoutBudget.ThrottleWaitFor"/>
+	public static TimeSpan ThrottleWaitFor => Budget.ThrottleWaitFor;
+
+	/// <summary>True at <see cref="TestCapacity.Small"/> — the bucket, not "a CI system is running".</summary>
+	public static bool IsCi => Capacity == TestCapacity.Small;
 
 	/// <summary>
-	/// Timeout for command-response waits (dispatcher Send). 500 ms locally, 10 s on CI.
+	/// One line naming the bucket, what chose it, and the budgets in force — so a red gate can state
+	/// which budget the run used instead of leaving it to be guessed.
 	/// </summary>
-	public static TimeSpan CommandTimeout { get; } = IsCi ? TimeSpan.FromSeconds(10) : TimeSpan.FromMilliseconds(500);
+	public static string CapacityDescription =>
+		$"ReactiveDomain.Testing capacity: {Capacity} ({CapacityReason}); " +
+		$"{nameof(WaitFor)}={WaitFor}, {nameof(CommandTimeout)}={CommandTimeout}, " +
+		$"{nameof(ThrottleWaitFor)}={ThrottleWaitFor}";
 
-	/// <summary>
-	/// Timeout for waits on real-time Rx operators (Throttle, Buffer, Sample) whose timers
-	/// run on wall-clock schedulers. 2 s locally, 10 s on CI.
-	/// </summary>
-	public static TimeSpan ThrottleWaitFor { get; } = IsCi ? TimeSpan.FromSeconds(10) : TimeSpan.FromSeconds(2);
+	/// <summary>Writes <see cref="CapacityDescription"/>, by default to the console.</summary>
+	/// <param name="output">Where to write; defaults to <see cref="Console.Out"/>.</param>
+	public static void WriteCapacity(TextWriter? output = null) =>
+		(output ?? Console.Out).WriteLine(CapacityDescription);
 }


### PR DESCRIPTION
**Stacked on #274** — it added the place to put a `$all` position; nothing was filling it in.

`RecordedEvent` has carried `Position` since the gRPC wrapper landed, but nothing kept it. `StreamReader.EventRead` and `StreamListener.GotEvent` both took the event's stream version and discarded the rest, so `GetCheckpoint()` could resume a stream and say nothing about how far the model had reached. For a model reading several streams there was no answer available at all: versions of different streams are not on the same scale, and the one clock that is comparable across them was being thrown away a layer below the read model.

## What changed

The reader and the listener each retain the `$all` position of the last event they handled. The listener adopts the reader's when it takes over (`AddNewListener` seeds it), so a checkpoint taken before the first live event still accounts for the history the reader replayed — which is the ordinary case at cold start, and the one the first draft of this got wrong until a test caught it.

Position is assigned unconditionally rather than only when non-null: a store that stops reporting positions leaves the checkpoint null rather than stale, because the position belongs to the last event delivered, not the last one that happened to carry one.

`GetCheckpoint()` now returns both clocks per stream.

## The two projections

`HighWaterMark` and `ConservativeWatermark` are computed from the same positions and answer opposite questions, so they are deliberately not one API:

- **`HighWaterMark`** — the greatest. How far into the log this model reached. **Not** a completeness claim: the model only saw its own streams' events, so it has not seen everything below that point.
- **`ConservativeWatermark`** — the least. The point every source has been applied through. This is the one that can gate a read.

Either is null when any contributing source reports no position. Projecting over the remainder would silently overstate reach, or understate which sources are covered.

## Test support

`MockStreamStoreConnection` now stamps a position from its all-stream index — it already tracked the number, and without it no test could exercise any of this.

## Not in scope

Handlers still receive the bare message. Delivering the envelope to subscribers per-event changes what every existing `IHandle<T>` sees, so it is the remaining half of #211 and wants its own decision — the marker in `QueuedStreamListener` now says so rather than pointing at a `//todo`.

Relates to #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)