### PR TITLE
Ship the XML docs in the packages so Intellisense can find them

### DIFF
--- a/src/ReactiveDomain.Debug.nuspec
+++ b/src/ReactiveDomain.Debug.nuspec
@@ -50,43 +50,63 @@
 
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Core.pdb" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Core.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Core.xml" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Core.dll" target="ref\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Core.xml" target="ref\net8.0" />
 
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Core.pdb" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Core.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Core.xml" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Core.dll" target="ref\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Core.xml" target="ref\net10.0" />
 
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Foundation.pdb" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Foundation.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Foundation.xml" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Foundation.dll" target="ref\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Foundation.xml" target="ref\net8.0" />
 
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Foundation.pdb" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Foundation.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Foundation.xml" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Foundation.dll" target="ref\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Foundation.xml" target="ref\net10.0" />
 
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Messaging.pdb" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Messaging.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Messaging.xml" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Messaging.dll" target="ref\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Messaging.xml" target="ref\net8.0" />
 
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Messaging.pdb" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Messaging.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Messaging.xml" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Messaging.dll" target="ref\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Messaging.xml" target="ref\net10.0" />
 
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Persistence.pdb" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Persistence.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Persistence.xml" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Persistence.dll" target="ref\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Persistence.xml" target="ref\net8.0" />
 
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Persistence.pdb" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Persistence.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Persistence.xml" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Persistence.dll" target="ref\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Persistence.xml" target="ref\net10.0" />
 
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Transport.pdb" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Transport.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Transport.xml" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Transport.dll" target="ref\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Transport.xml" target="ref\net8.0" />
 
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Transport.pdb" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Transport.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Transport.xml" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Transport.dll" target="ref\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Transport.xml" target="ref\net10.0" />
 
 		<file src="..\README.md" target="docs\" />
 	</files>

--- a/src/ReactiveDomain.Persistence/EventStore/EventStoreLauncher.cs
+++ b/src/ReactiveDomain.Persistence/EventStore/EventStoreLauncher.cs
@@ -89,7 +89,7 @@ public sealed class EventStoreLauncher : IDisposable {
 	/// Terminate an EventStore instance created by SetupEventStore
 	/// </summary>
 	/// <remarks>
-	/// Yin for the <see cref="SetupEventStore"/> yang.
+	/// Yin for the <see cref="SetupEventStore(EsdbConfig)"/> yang.
 	/// </remarks>
 	/// <param name="leaveRunning">bool: true = close the connection, but leave the process running.</param>
 	public void TeardownEventStore(bool leaveRunning = true) {

--- a/src/ReactiveDomain.Policy.Debug.nuspec
+++ b/src/ReactiveDomain.Policy.Debug.nuspec
@@ -55,27 +55,39 @@
 
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Policy.pdb" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Policy.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Policy.xml" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Policy.dll" target="ref\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Policy.xml" target="ref\net8.0" />
 
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Policy.pdb" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Policy.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Policy.xml" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Policy.dll" target="ref\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Policy.xml" target="ref\net10.0" />
 
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.PolicyStorage.pdb" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.PolicyStorage.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.PolicyStorage.xml" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.PolicyStorage.dll" target="ref\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.PolicyStorage.xml" target="ref\net8.0" />
 
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.PolicyStorage.pdb" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.PolicyStorage.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.PolicyStorage.xml" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.PolicyStorage.dll" target="ref\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.PolicyStorage.xml" target="ref\net10.0" />
 
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.IdentityStorage.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.IdentityStorage.xml" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.IdentityStorage.dll" target="ref\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.IdentityStorage.xml" target="ref\net8.0" />
 
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.IdentityStorage.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.IdentityStorage.xml" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.IdentityStorage.dll" target="ref\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.IdentityStorage.xml" target="ref\net10.0" />
 
 		<file src="..\README.md" target="docs\" />
 	</files>

--- a/src/ReactiveDomain.Policy.nuspec
+++ b/src/ReactiveDomain.Policy.nuspec
@@ -56,27 +56,39 @@
 
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Policy.pdb" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Policy.dll" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Policy.xml" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Policy.dll" target="ref\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Policy.xml" target="ref\net8.0" />
 
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Policy.pdb" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Policy.dll" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Policy.xml" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Policy.dll" target="ref\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Policy.xml" target="ref\net10.0" />
 
 		<file src="..\bld\Release\net8.0\ReactiveDomain.PolicyStorage.pdb" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.PolicyStorage.dll" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.PolicyStorage.xml" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.PolicyStorage.dll" target="ref\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.PolicyStorage.xml" target="ref\net8.0" />
 
 		<file src="..\bld\Release\net10.0\ReactiveDomain.PolicyStorage.pdb" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.PolicyStorage.dll" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.PolicyStorage.xml" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.PolicyStorage.dll" target="ref\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.PolicyStorage.xml" target="ref\net10.0" />
 
 		<file src="..\bld\Release\net8.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.IdentityStorage.dll" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.IdentityStorage.xml" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.IdentityStorage.dll" target="ref\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.IdentityStorage.xml" target="ref\net8.0" />
 
 		<file src="..\bld\Release\net10.0\ReactiveDomain.IdentityStorage.pdb" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.IdentityStorage.dll" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.IdentityStorage.xml" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.IdentityStorage.dll" target="ref\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.IdentityStorage.xml" target="ref\net10.0" />
 
 		<file src="..\README.md" target="docs\" />
 	</files>

--- a/src/ReactiveDomain.PolicyStorage/Messages/ApplicationMsgs.cs
+++ b/src/ReactiveDomain.PolicyStorage/Messages/ApplicationMsgs.cs
@@ -76,6 +76,7 @@ public class ApplicationMsgs {
 	/// <param name="PolicyId">The unique ID of the policy.</param>
 	/// <param name="ClientId">The unique ID of the client to which the policy applies.</param>
 	/// <param name="ApplicationId">The unique ID of the application to which the policy applies.</param>
+	/// <param name="OneRolePerUser">If true, each user may only have a single role.</param>
 	public record PolicyCreated(
 		Guid PolicyId,
 		string ClientId,

--- a/src/ReactiveDomain.Testing.Debug.nuspec
+++ b/src/ReactiveDomain.Testing.Debug.nuspec
@@ -39,11 +39,15 @@
 
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Testing.pdb" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Testing.dll" target="lib\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Testing.xml" target="lib\net8.0" />
 		<file src="..\bld\Debug\net8.0\ReactiveDomain.Testing.dll" target="ref\net8.0" />
+		<file src="..\bld\Debug\net8.0\ReactiveDomain.Testing.xml" target="ref\net8.0" />
 
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Testing.pdb" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Testing.dll" target="lib\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Testing.xml" target="lib\net10.0" />
 		<file src="..\bld\Debug\net10.0\ReactiveDomain.Testing.dll" target="ref\net10.0" />
+		<file src="..\bld\Debug\net10.0\ReactiveDomain.Testing.xml" target="ref\net10.0" />
 
 		<file src="..\README.md" target="docs\" />
 	</files>

--- a/src/ReactiveDomain.Testing.nuspec
+++ b/src/ReactiveDomain.Testing.nuspec
@@ -38,10 +38,14 @@
 		<file src="..\build\ReactiveDomain.Testing.props" target="build" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Testing.pdb" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Testing.dll" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Testing.xml" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Testing.dll" target="ref\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Testing.xml" target="ref\net8.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Testing.pdb" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Testing.dll" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Testing.xml" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Testing.dll" target="ref\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Testing.xml" target="ref\net10.0" />
 		<file src="..\README.md" target="docs\" />
 	</files>
 </package>

--- a/src/ReactiveDomain.Testing/Specifications/MessageListExtensions.cs
+++ b/src/ReactiveDomain.Testing/Specifications/MessageListExtensions.cs
@@ -75,9 +75,9 @@ public static class MessageListExtensions {
 		/// <remarks>This method modifies the input list by removing its first element. Use this method when
 		/// message order and type are important, and ensure that the expected type is at the front of the list.</remarks>
 		/// <typeparam name="TMsg">The type of message to dequeue. Must implement the IMessage interface.</typeparam>
-		/// <returns>The first message in the list if it is of type <see cref="TMsg"/>.</returns>
+		/// <returns>The first message in the list if it is of type <typeparamref name="TMsg"/>.</returns>
 		/// <exception cref="InvalidOperationException">Thrown if the messages list is empty.</exception>
-		/// <exception cref="Exception">Thrown if the first message in the list is not of type <see cref="TMsg"/>.</exception>
+		/// <exception cref="Exception">Thrown if the first message in the list is not of type <typeparamref name="TMsg"/>.</exception>
 		public TMsg DequeueNext<TMsg>() where TMsg : IMessage {
 			if (messages.Count == 0)
 				throw new InvalidOperationException("The list is empty");

--- a/src/ReactiveDomain.Transport/BufferManagement/BufferManager.cs
+++ b/src/ReactiveDomain.Transport/BufferManagement/BufferManager.cs
@@ -155,7 +155,7 @@ public class BufferManager {
 	/// </summary>
 	/// <remarks>
 	/// It is the client's responsibility to return the buffer to the manager by
-	/// calling <see cref="CheckIn"></see> on the buffer
+	/// calling <see cref="CheckIn(ArraySegment{byte})"></see> on the buffer
 	/// </remarks>
 	/// <returns>A <see cref="ArraySegment{T}"></see> that can be used as a buffer</returns>
 	public ArraySegment<byte> CheckOut() {
@@ -174,7 +174,7 @@ public class BufferManager {
 	/// </summary>
 	/// <remarks>
 	/// It is the client's responsibility to return the buffer to the manager by
-	/// calling <see cref="CheckIn"></see> on the buffer
+	/// calling <see cref="CheckIn(IEnumerable{ArraySegment{byte}})"></see> on the buffers
 	/// </remarks>
 	/// <returns>A <see cref="ArraySegment{T}"></see> that can be used as a buffer</returns>
 	public IEnumerable<ArraySegment<byte>> CheckOut(int toGet) {
@@ -200,10 +200,6 @@ public class BufferManager {
 	/// <summary>
 	/// Returns a buffer to the control of the manager
 	/// </summary>
-	/// <remarks>
-	/// It is the client's responsibility to return the buffer to the manager by
-	/// calling <see cref="CheckIn"></see> on the buffer
-	/// </remarks>
 	/// <param name="buffer">The <see cref="ArraySegment{T}"></see> to return to the cache</param>
 	public void CheckIn(ArraySegment<byte> buffer) {
 		CheckBuffer(buffer);
@@ -213,10 +209,6 @@ public class BufferManager {
 	/// <summary>
 	/// Returns a set of buffers to the control of the manager
 	/// </summary>
-	/// <remarks>
-	/// It is the client's responsibility to return the buffer to the manager by
-	/// calling <see cref="CheckIn"></see> on the buffer
-	/// </remarks>
 	/// <param name="buffersToReturn">The <see cref="ArraySegment{T}"></see> to return to the cache</param>
 	public void CheckIn(IEnumerable<ArraySegment<byte>>? buffersToReturn) {
 		ArgumentNullException.ThrowIfNull(buffersToReturn);

--- a/src/ReactiveDomain.Transport/SystemData/UserCredentials.cs
+++ b/src/ReactiveDomain.Transport/SystemData/UserCredentials.cs
@@ -3,8 +3,7 @@
 namespace ReactiveDomain.Transport.SystemData;
 
 /// <summary>
-/// A username/password pair used for authentication and
-/// authorization to perform operations over an <see cref="IEventStoreConnection"/>.
+/// A username/password pair used to authenticate and authorize operations over a connection.
 /// </summary>
 public class UserCredentials {
 	/// <summary>

--- a/src/ReactiveDomain.nuspec
+++ b/src/ReactiveDomain.nuspec
@@ -50,34 +50,54 @@
 		<file src="..\build\ReactiveDomain.props" target="build" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Core.pdb" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Core.dll" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Core.xml" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Core.dll" target="ref\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Core.xml" target="ref\net8.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Core.pdb" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Core.dll" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Core.xml" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Core.dll" target="ref\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Core.xml" target="ref\net10.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Foundation.pdb" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Foundation.dll" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Foundation.xml" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Foundation.dll" target="ref\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Foundation.xml" target="ref\net8.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Foundation.pdb" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Foundation.dll" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Foundation.xml" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Foundation.dll" target="ref\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Foundation.xml" target="ref\net10.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Messaging.pdb" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Messaging.dll" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Messaging.xml" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Messaging.dll" target="ref\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Messaging.xml" target="ref\net8.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Messaging.pdb" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Messaging.dll" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Messaging.xml" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Messaging.dll" target="ref\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Messaging.xml" target="ref\net10.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Persistence.pdb" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Persistence.dll" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Persistence.xml" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Persistence.dll" target="ref\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Persistence.xml" target="ref\net8.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Persistence.pdb" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Persistence.dll" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Persistence.xml" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Persistence.dll" target="ref\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Persistence.xml" target="ref\net10.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Transport.pdb" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Transport.dll" target="lib\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Transport.xml" target="lib\net8.0" />
 		<file src="..\bld\Release\net8.0\ReactiveDomain.Transport.dll" target="ref\net8.0" />
+		<file src="..\bld\Release\net8.0\ReactiveDomain.Transport.xml" target="ref\net8.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Transport.pdb" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Transport.dll" target="lib\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Transport.xml" target="lib\net10.0" />
 		<file src="..\bld\Release\net10.0\ReactiveDomain.Transport.dll" target="ref\net10.0" />
+		<file src="..\bld\Release\net10.0\ReactiveDomain.Transport.xml" target="ref\net10.0" />
 		<file src="..\README.md" target="docs\" />
 	</files>
 </package>

--- a/src/build.props
+++ b/src/build.props
@@ -30,6 +30,11 @@
 		<PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>full</DebugType>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<!-- CS1591 (missing XML comment) is not a build signal: it fires thousands of times and buries
+		     the malformed-doc warnings that are worth acting on. Documentation coverage is enforced by
+		     review, per CONTRIBUTING.md. -->
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 	<PropertyGroup>
 		<OutputPath>$(MSBuildThisFileDirectory)..\bld\$(Configuration)</OutputPath>


### PR DESCRIPTION
Closes #264.

Two independent breaks meant no consumer ever saw a tooltip, and either one alone was enough:

1. **No project set `GenerateDocumentationFile`** — the XML files were never produced.
2. **No nuspec listed an `.xml`** — all six shipped `.dll` + `.pdb` only, so the docs would not have been packaged even if they existed.

## The fix

One property in `src/build.props`, which every project reaches through `ci.build.imports`, and each assembly's `.xml` listed beside its `.dll` in all six nuspecs.

The `.xml` goes in **both `lib\` and `ref\`**. These packages ship reference assemblies; the compiler resolves `ref/` at compile time and looks for docs next to whatever it resolved, so docs in `lib/` alone would have stayed invisible.

Verified by packing all three release nuspecs and diffing the contents — `ReactiveDomain` 20 dll / 20 xml, `ReactiveDomain.Policy` 12 / 12, `ReactiveDomain.Testing` 4 / 4, both target frameworks.

## What generating the docs exposed

Nine malformed comments that had been shipping broken and undetectable, because nothing was compiling them:

- four ambiguous `cref="CheckIn"` in `BufferManager` — two on `CheckOut`, disambiguated to the matching overload; two on the `CheckIn` methods themselves, where the remark was a copy-paste telling the caller of `CheckIn` to call `CheckIn`, now removed
- `UserCredentials` in **Transport** documented as operating over `IEventStoreConnection`, a type from a package Transport does not reference
- `<see cref="TMsg"/>` → `<typeparamref>` ×2 in `MessageListExtensions`
- `PolicyCreated` missing a `<param>` for `OneRolePerUser`, using the wording already on the sibling message
- ambiguous `SetupEventStore` cref in `EventStoreLauncher`

Solution build goes from 5265 warnings to 6, all remaining ones pre-existing `NU1510`.

## One judgment call

`CS1591` (missing XML comment) is suppressed in `build.props`. It fires 5265 times and buries exactly the nine defects above. Documentation *coverage* is enforced by review per `CONTRIBUTING.md`; documentation *correctness* is now enforced by the compiler. Flipping it back on per-project as each assembly gets documented is the natural follow-up if you want the backlog visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)