### PR TITLE
Make a snapshot describe exactly the events built into it

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -79,7 +79,16 @@ jobs:
       # budget is stated here rather than inferred.
       env:
         REACTIVEDOMAIN_TEST_CAPACITY: Small
-      run: dotnet test ReactiveDomain.sln -f net${{ matrix.dotnet-version }} -p:ParallelizeTestCollections=false -c Release  --no-build 
+      run: dotnet test ReactiveDomain.sln -f net${{ matrix.dotnet-version }} -p:ParallelizeTestCollections=false -c Release  --no-build --logger "trx;LogFileName=test-results.trx" --results-directory ../test-results
+
+    # Named results, because a failure that only shows up under load has to be identifiable from the
+    # run that saw it. The console summary says how many failed, not which.
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results-net${{ matrix.dotnet-version }}
+        path: test-results/
 
     # Format
     - name: Check Formatting

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_a_listener_goes_live_while_delivery_is_held.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_a_listener_goes_live_while_delivery_is_held.cs
@@ -1,0 +1,59 @@
+using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using ReactiveDomain.Testing.EventStore;
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests.StreamListenerTests;
+
+// The live transition reaches subscribers the way an event does and is counted the way one is, so it
+// has to be held the way one is. Published outside the delivery lock it could land in a subscriber's
+// queue while a capture believed delivery was stopped — and no checkpoint names it, so a model that
+// handles it would hold state its own checkpoints disown.
+// ReSharper disable once InconsistentNaming
+public sealed class when_a_listener_goes_live_while_delivery_is_held : IDisposable {
+	private readonly MockStreamStoreConnection _conn;
+	private readonly StreamListener _listener;
+	// Empty, so the only thing the listener has to publish on starting is the transition itself.
+	private readonly string _stream = $"liveHoldTest-{Guid.NewGuid():N}";
+	private readonly ManualResetEventSlim _live = new(false);
+
+	public when_a_listener_goes_live_while_delivery_is_held() {
+		_conn = new MockStreamStoreConnection(nameof(when_a_listener_goes_live_while_delivery_is_held));
+		_conn.Connect();
+		_listener = new StreamListener(nameof(when_a_listener_goes_live_while_delivery_is_held),
+			_conn, new PrefixedCamelCaseStreamNameBuilder(), new JsonMessageSerializer());
+		_listener.EventStream.Subscribe(
+			new AdHocHandler<StreamStoreMsgs.CatchupSubscriptionBecameLive>(_ => _live.Set()));
+	}
+
+	public void Dispose() {
+		_listener.Dispose();
+		_conn.Dispose();
+	}
+
+	[Fact]
+	public async Task the_transition_waits_for_the_hold_that_an_event_would_wait_for() {
+		var entered = new ManualResetEventSlim(false);
+		var hold = _listener.HoldDelivery();
+		Task starting;
+		try {
+			starting = Task.Run(() => {
+				entered.Set();
+				_listener.Start(_stream, null, false);
+			});
+			Assert.True(entered.Wait(TestTimeouts.ThrottleWaitFor), "the start never began");
+
+			// An absence, so it is given long enough to have happened: starting a listener on an empty
+			// stream against an in-memory store is otherwise immediate. Spun rather than awaited
+			// because a hold has to be released by the thread that took it.
+			Assert.False(SpinWait.SpinUntil(() => starting.IsCompleted, TimeSpan.FromMilliseconds(500)),
+				"the listener started through a hold on its delivery");
+			Assert.False(_live.IsSet, "the live transition was published while delivery was held");
+		} finally {
+			hold.Dispose();
+		}
+
+		await starting.WaitAsync(TestTimeouts.ThrottleWaitFor);
+		Assert.True(_live.Wait(TestTimeouts.ThrottleWaitFor), "the live transition never arrived");
+	}
+}

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_a_subscriber_reads_the_checkpoint_while_handling.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_a_subscriber_reads_the_checkpoint_while_handling.cs
@@ -1,0 +1,59 @@
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using ReactiveDomain.Testing.EventStore;
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests.StreamListenerTests;
+
+// A listener publishes an event and only then records it. That ordering is invisible to a capture,
+// which holds delivery and so never sees between the two — which makes it look like it does not
+// matter. It matters to everyone reading the checkpoint the ordinary way, and this is where it shows:
+// a subscriber handling an event must not find the checkpoint already claiming that event, or a
+// snapshot taken from a handler would name an event whose own handling had not finished.
+// ReSharper disable once InconsistentNaming
+public sealed class when_a_subscriber_reads_the_checkpoint_while_handling : IDisposable {
+	private readonly MockStreamStoreConnection _conn;
+	private readonly JsonMessageSerializer _serializer = new();
+	private readonly string _stream = $"checkpointOrderTest-{Guid.NewGuid():N}";
+	private readonly StreamListener _listener;
+
+	// What the listener reported as its own position while it was handing each event over, in order.
+	private readonly List<long?> _seenWhileHandling = [];
+
+	public when_a_subscriber_reads_the_checkpoint_while_handling() {
+		_conn = new MockStreamStoreConnection(nameof(when_a_subscriber_reads_the_checkpoint_while_handling));
+		_conn.Connect();
+		for (var i = 0; i < 4; i++) {
+			_conn.AppendToStream(_stream, ExpectedVersion.Any, null, _serializer.Serialize(new OrderTestEvent()));
+		}
+
+		_listener = new StreamListener(nameof(when_a_subscriber_reads_the_checkpoint_while_handling),
+			_conn, new PrefixedCamelCaseStreamNameBuilder(), _serializer);
+		// Subscribed directly rather than through a queue, so this runs inside the publish and can see
+		// what a checkpoint reader would see at that instant.
+		_listener.EventStream.Subscribe(new AdHocHandler<OrderTestEvent>(
+			_ => _seenWhileHandling.Add(_listener.Checkpoint?.Version)));
+		_listener.Start(_stream, null, true);
+		AssertEx.IsOrBecomesTrue(() => _seenWhileHandling.Count == 4, TestTimeouts.ThrottleWaitFor);
+	}
+
+	public void Dispose() {
+		_listener.Dispose();
+		_conn.Dispose();
+	}
+
+	[Fact]
+	public void the_checkpoint_never_names_the_event_being_handled() {
+		// Handling event n, the checkpoint is still at n-1 — and at nothing at all for the first,
+		// which is the whole reason a version of 0 cannot stand in for "none".
+		Assert.Equal([null, 0L, 1L, 2L], _seenWhileHandling);
+	}
+
+	[Fact]
+	public void the_checkpoint_names_every_event_once_handing_over_is_done() {
+		Assert.Equal(3, _listener.Checkpoint?.Version);
+	}
+
+	public record OrderTestEvent : Event;
+}

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_holding_delivery_mid_flight.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_holding_delivery_mid_flight.cs
@@ -1,0 +1,87 @@
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using ReactiveDomain.Testing.EventStore;
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests.StreamListenerTests;
+
+// A listener publishes an event and then records it, and a hold exists to make sure nobody samples
+// between the two — where a subscriber already has an event the checkpoint does not name. Driving a
+// model's handler apart from its listener does not open that window; only stopping inside the publish
+// does, which is what these do.
+// ReSharper disable once InconsistentNaming
+public sealed class when_holding_delivery_mid_flight : IDisposable {
+	private readonly MockStreamStoreConnection _conn;
+	private readonly JsonMessageSerializer _serializer = new();
+	private readonly string _stream = $"midFlightTest-{Guid.NewGuid():N}";
+	private readonly ManualResetEventSlim _publishing = new(false);
+	private readonly ManualResetEventSlim _release = new(false);
+	private readonly List<IListener> _listeners = [];
+
+	public when_holding_delivery_mid_flight() {
+		_conn = new MockStreamStoreConnection(nameof(when_holding_delivery_mid_flight));
+		_conn.Connect();
+	}
+
+	public void Dispose() {
+		_release.Set();
+		_listeners.ForEach(l => l.Dispose());
+		_conn.Dispose();
+	}
+
+	public record MidFlightEvent : Event;
+
+	private T Started<T>(T listener) where T : IListener {
+		_listeners.Add(listener);
+		// Stops the delivery inside the publish, so the event is in the subscriber's hands while the
+		// listener has not yet recorded it.
+		listener.EventStream.Subscribe(new AdHocHandler<MidFlightEvent>(_ => {
+			_publishing.Set();
+			_release.Wait();
+		}));
+		listener.Start(_stream, null, false);
+		return listener;
+	}
+
+	private void Append() =>
+		_conn.AppendToStream(_stream, ExpectedVersion.Any, null, _serializer.Serialize(new MidFlightEvent()));
+
+	private async Task AssertHoldWaitsForTheDelivery(IListener listener) {
+		// Off-thread: the store dispatches an append on the calling thread, so appending here would
+		// block this test inside the very handler it is trying to observe.
+		var appending = Task.Run(Append);
+		Assert.True(_publishing.Wait(TestTimeouts.ThrottleWaitFor), "the delivery never reached a subscriber");
+
+		var acquired = new ManualResetEventSlim(false);
+		var holding = Task.Run(() => {
+			using var hold = listener.HoldDelivery();
+			acquired.Set();
+		});
+
+		// An absence, given long enough to have happened. A hold taken here would sample a checkpoint
+		// that disowns an event a subscriber already has.
+		Assert.False(acquired.Wait(TimeSpan.FromMilliseconds(500)),
+			"delivery was held while an event sat between its publish and its record");
+
+		_release.Set();
+		await holding.WaitAsync(TestTimeouts.ThrottleWaitFor);
+		await appending.WaitAsync(TestTimeouts.ThrottleWaitFor);
+		Assert.True(acquired.IsSet);
+		Assert.Equal(0, listener.Checkpoint?.Version);
+	}
+
+	[Fact]
+	public Task a_listener_holds_only_once_the_delivery_it_started_is_recorded() =>
+		AssertHoldWaitsForTheDelivery(Started(new StreamListener(
+			nameof(when_holding_delivery_mid_flight), _conn,
+			new PrefixedCamelCaseStreamNameBuilder(), _serializer)));
+
+	// The queued listener delivers from its own queue thread, so its publish and its record are a
+	// different pair of statements from the base listener's, and need holding on their own account.
+	[Fact]
+	public Task a_queued_listener_holds_only_once_the_delivery_it_started_is_recorded() =>
+		AssertHoldWaitsForTheDelivery(Started(new QueuedStreamListener(
+			nameof(when_holding_delivery_mid_flight), _conn,
+			new PrefixedCamelCaseStreamNameBuilder(), _serializer)));
+}

--- a/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_releasing_a_delivery_hold.cs
+++ b/src/ReactiveDomain.Foundation.Tests/StreamListenerTests/when_releasing_a_delivery_hold.cs
@@ -1,0 +1,97 @@
+using ReactiveDomain.Testing;
+using ReactiveDomain.Testing.EventStore;
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests.StreamListenerTests;
+
+/// <summary>
+/// A hold stops the listener's delivery thread, so a release that does not happen is a listener that
+/// never delivers again. These pin that a release either happens or says it did not.
+/// </summary>
+/// <remarks>
+/// Every off-thread step runs on a dedicated <see cref="Thread"/>. A task blocked on with
+/// <c>Wait</c> can be inlined onto the waiting thread, which for a thread-affine lock is the one
+/// thing these tests must not let happen.
+/// </remarks>
+// ReSharper disable once InconsistentNaming
+public sealed class when_releasing_a_delivery_hold : IDisposable {
+	private readonly MockStreamStoreConnection _conn;
+	private readonly StreamListener _listener;
+
+	public when_releasing_a_delivery_hold() {
+		_conn = new MockStreamStoreConnection(nameof(when_releasing_a_delivery_hold));
+		_conn.Connect();
+		_listener = new StreamListener(
+			nameof(when_releasing_a_delivery_hold),
+			_conn,
+			new PrefixedCamelCaseStreamNameBuilder(nameof(when_releasing_a_delivery_hold)),
+			new JsonMessageSerializer());
+	}
+
+	public void Dispose() {
+		_listener.Dispose();
+		_conn.Dispose();
+	}
+
+	/// <summary>Whatever <paramref name="work"/> threw, run on a thread of its own.</summary>
+	private static Exception? ThrownOffThread(Action work) {
+		Exception? thrown = null;
+		var thread = new Thread(() => {
+			try { work(); } catch (Exception ex) { thrown = ex; }
+		}) { IsBackground = true };
+		thread.Start();
+		Assert.True(thread.Join(TestTimeouts.ThrottleWaitFor), "The off-thread step did not finish.");
+		return thrown;
+	}
+
+	/// <summary>
+	/// Whether a fresh hold can be taken, which is true only if the last one was released. Probed from
+	/// another thread, since the lock is re-entrant and its holder would always succeed.
+	/// </summary>
+	private bool DeliveryIsFree() {
+		using var acquired = new ManualResetEventSlim(false);
+		// Released as soon as it is taken, so a probe that is still blocked when this returns false
+		// cannot hold anything up once the real holder lets go.
+		new Thread(() => {
+			using (_listener.HoldDelivery()) { acquired.Set(); }
+		}) { IsBackground = true }.Start();
+		return acquired.Wait(TestTimeouts.WaitFor);
+	}
+
+	[Fact]
+	public void releasing_on_the_holding_thread_frees_delivery() {
+		var hold = _listener.HoldDelivery();
+		hold.Dispose();
+
+		Assert.True(DeliveryIsFree());
+	}
+
+	[Fact]
+	public void releasing_twice_on_the_holding_thread_is_a_no_op() {
+		var hold = _listener.HoldDelivery();
+		hold.Dispose();
+		hold.Dispose();
+
+		Assert.True(DeliveryIsFree());
+	}
+
+	/// <summary>
+	/// The failure this guards is silent: a swallowed release reports success and leaves the listener
+	/// holding its delivery lock for good, with nothing downstream able to tell.
+	/// </summary>
+	[Fact]
+	public void releasing_on_another_thread_throws_and_keeps_the_hold() {
+		var hold = _listener.HoldDelivery();
+		try {
+			Assert.IsType<SynchronizationLockException>(ThrownOffThread(hold.Dispose));
+
+			// Still held, so the failed release did not quietly half-succeed.
+			Assert.False(DeliveryIsFree());
+		} finally {
+			// And still releasable by its owner, so the throw did not spend the handle either.
+			hold.Dispose();
+		}
+
+		Assert.True(DeliveryIsFree());
+	}
+}

--- a/src/ReactiveDomain.Foundation.Tests/when_capturing_a_consistent_snapshot.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_capturing_a_consistent_snapshot.cs
@@ -1,0 +1,335 @@
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using ReactiveDomain.Testing.EventStore;
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests;
+
+// The invariant under test: the state a snapshot carries is the fold of exactly the events its
+// checkpoint names. Every case here is a way of asking whether the two can be made to disagree —
+// with the handler wedged, under live traffic, and across two streams at once.
+// ReSharper disable once InconsistentNaming
+public sealed class when_capturing_a_consistent_snapshot : IDisposable {
+	private readonly MockStreamStoreConnection _conn;
+	private readonly IEventSerializer _serializer = new JsonMessageSerializer();
+	private readonly IStreamNameBuilder _namer =
+		new PrefixedCamelCaseStreamNameBuilder(nameof(when_capturing_a_consistent_snapshot));
+	private readonly IConfiguredConnection _configured;
+
+	public when_capturing_a_consistent_snapshot() {
+		_conn = new MockStreamStoreConnection(nameof(when_capturing_a_consistent_snapshot));
+		_conn.Connect();
+		_configured = new ConfiguredConnection(_conn, _namer, _serializer);
+	}
+
+	public void Dispose() => _conn.Dispose();
+
+	private string NewStream() => _namer.GenerateForAggregate(typeof(TestAggregate), Guid.NewGuid());
+
+	private void Append(string stream, int count) {
+		for (var i = 0; i < count; i++) {
+			_conn.AppendToStream(stream, ExpectedVersion.Any, null, _serializer.Serialize(new CountedEvent()));
+		}
+	}
+
+	public record CountedEvent : Event;
+
+	private sealed class CountingModel : SnapshotReadModel, IHandle<CountedEvent> {
+		private readonly ManualResetEventSlim _gate = new(true);
+		public CountingModel(IConfiguredConnection c, ReadModelState? restore = null)
+			: base(nameof(CountingModel), c) {
+			EventStream.Subscribe<CountedEvent>(this);
+			if (restore is not null) { Restore(restore); }
+		}
+
+		public long Applied { get; private set; }
+		public void Wedge() => _gate.Reset();
+		public void Unwedge() => _gate.Set();
+
+		// Enough work per event that a writer outruns the queue, so a capture under live traffic
+		// actually meets a non-empty queue. Without it the queue is drained by the time the capture
+		// is asked for and the case being tested never arises.
+		public bool Deliberate { get; set; }
+
+		void IHandle<CountedEvent>.Handle(CountedEvent e) {
+			_gate.Wait();
+			if (Deliberate) { Thread.SpinWait(2_000); }
+			Applied++;
+		}
+
+		protected override void ApplyState(ReadModelState snapshot) => Applied = (long)snapshot.State;
+		public override ReadModelState GetState() =>
+			new(nameof(CountingModel), GetCheckpoint(), Applied, GetExternalCheckpoints());
+
+		protected override void Dispose(bool disposing) {
+			_gate.Set();
+			base.Dispose(disposing);
+		}
+	}
+
+	// A checkpoint resumes *after* its version, so a state holding n events must be checkpointed at
+	// version n-1. Any other pairing is a snapshot that loses or repeats events on restore.
+	private static void AssertDescribesState(ReadModelState snapshot, long applied) {
+		Assert.Equal(applied, (long)snapshot.State);
+		AssertSelfConsistent(snapshot);
+	}
+
+	// A version is the index of a stream's last applied event, so one more than it is that prefix's
+	// length. Summed over the streams, that has to be exactly what the state counted.
+	// A capture taken against an empty queue cannot distinguish a cut from a checkpoint re-read
+	// afterwards, so these tests wait until there is something in flight to be wrong about.
+	private static bool AwaitQueueDepth(CountingModel rm, Task writer) =>
+		SpinWait.SpinUntil(() => rm.MessageCount > 0 || writer.IsCompleted, TestTimeouts.ThrottleWaitFor)
+		&& rm.MessageCount > 0;
+
+	private static void AssertSelfConsistent(ReadModelState snapshot) =>
+		Assert.Equal(snapshot.Checkpoints!.Sum(c => (c.Version ?? -1) + 1), (long)snapshot.State);
+
+	[Fact]
+	public async Task the_checkpoint_describes_the_state_it_was_captured_with() {
+		var stream = NewStream();
+		Append(stream, 10);
+		using var rm = new CountingModel(_configured);
+		rm.Start(stream, null, true);
+		await rm.IsLive;
+
+		AssertDescribesState(await rm.CaptureConsistentState(), rm.Applied);
+	}
+
+	[Fact]
+	public async Task a_capture_waits_for_what_the_listener_already_handed_over() {
+		var stream = NewStream();
+		using var rm = new CountingModel(_configured);
+		rm.Start(stream, null, false);
+		await rm.IsLive;
+
+		// Wedged, so the listener delivers into the queue while nothing can be applied. This is the
+		// state in which reading the checkpoint from the side reports 3 events against a state that
+		// holds none.
+		rm.Wedge();
+		Append(stream, 3);
+		AssertEx.IsOrBecomesTrue(
+			() => rm.GetCheckpoint().FirstOrDefault()?.Version == 2, TestTimeouts.ThrottleWaitFor);
+		Assert.Equal(0, rm.Applied);
+
+		var capturing = rm.CaptureConsistentState();
+		Assert.False(capturing.IsCompleted, "captured a cut the model had not reached");
+
+		rm.Unwedge();
+		AssertDescribesState(await capturing, 3);
+	}
+
+	[Fact]
+	public async Task a_capture_taken_under_live_traffic_describes_its_own_cut() {
+		var stream = NewStream();
+		Append(stream, 5);
+		using var rm = new CountingModel(_configured) { Deliberate = true };
+		rm.Start(stream, null, true);
+		await rm.IsLive;
+
+		// Appending throughout, so the cut lands somewhere in the middle of delivery rather than at a
+		// quiet point chosen to suit it.
+		// A bounded burst: the handler is slower than the writer, so captures meet a queue with events
+		// in it, but the queue still drains — an endless writer would outrun it and no cut would ever
+		// be reached, since a capture completes only when its marker does.
+		var writer = Task.Run(() => Append(stream, 150));
+		var captures = 0;
+		while (!writer.IsCompleted) {
+			if (!AwaitQueueDepth(rm, writer)) { break; }
+			AssertSelfConsistent(await rm.CaptureConsistentState());
+			captures++;
+		}
+		await writer;
+		AssertSelfConsistent(await rm.CaptureConsistentState());
+		Assert.True(captures > 0, "no capture was taken while the writer was running");
+	}
+
+	[Fact]
+	public async Task restoring_a_capture_taken_across_a_stalled_cut_neither_loses_nor_repeats_an_event() {
+		var stream = NewStream();
+		Append(stream, 5);
+		using var rm = new CountingModel(_configured);
+		rm.Start(stream, null, true);
+		await rm.IsLive;
+
+		// Wedged, so delivery and application are driven apart on purpose rather than by racing a
+		// writer. Everything appended from here is handed to the queue and none of it is applied.
+		rm.Wedge();
+		Append(stream, 10);
+		AssertEx.IsOrBecomesTrue(
+			() => rm.GetCheckpoint()[0].Version == 14, TestTimeouts.ThrottleWaitFor);
+		Assert.Equal(5, rm.Applied);
+
+		// The barrier goes in behind those ten and ahead of the next five, so the cut is known before
+		// anything drains: state of 15, checkpointed at 14.
+		var capturing = rm.CaptureConsistentState();
+		Append(stream, 5);
+		AssertEx.IsOrBecomesTrue(
+			() => rm.GetCheckpoint()[0].Version == 19, TestTimeouts.ThrottleWaitFor);
+
+		rm.Unwedge();
+		var snapshot = await capturing;
+		AssertDescribesState(snapshot, 15);
+
+		// Restore resumes after 14 and applies the last five. Short means the capture named events it
+		// had not applied; over means it applied events it did not name.
+		using var restored = new CountingModel(_configured, snapshot);
+		AssertEx.IsOrBecomesTrue(() => restored.Applied == 20, TestTimeouts.ThrottleWaitFor,
+			$"restored {restored.Applied} of 20 appended");
+	}
+
+	[Fact]
+	public async Task a_capture_spans_every_listener_at_one_cut() {
+		var first = NewStream();
+		var second = NewStream();
+		Append(first, 4);
+		Append(second, 6);
+
+		using var rm = new CountingModel(_configured) { Deliberate = true };
+		rm.Start(first, null, true);
+		rm.Start(second, null, true);
+		await rm.IsLive;
+
+		var writer = Task.Run(() => { for (var i = 0; i < 75; i++) { Append(first, 1); Append(second, 1); } });
+		var captures = 0;
+		while (!writer.IsCompleted) {
+			if (!AwaitQueueDepth(rm, writer)) { break; }
+			// Both streams at one cut: the state has to be the sum of the two prefixes, so a listener
+			// that kept delivering past the sample shows up here as a state ahead of its checkpoints.
+			AssertSelfConsistent(await rm.CaptureConsistentState());
+			captures++;
+		}
+		await writer;
+		AssertSelfConsistent(await rm.CaptureConsistentState());
+		Assert.True(captures > 0, "no capture was taken while the writer was running");
+	}
+
+	[Fact]
+	public async Task a_capture_leaves_the_listeners_delivering() {
+		var stream = NewStream();
+		var other = NewStream();
+		Append(stream, 2);
+		Append(other, 2);
+		using var rm = new CountingModel(_configured);
+		rm.Start(stream, null, true);
+		rm.Start(other, null, true);
+		await rm.IsLive;
+
+		// Two listeners means the capture holds them; the hold has to be released whether or not the
+		// capture succeeded, or the model is deaf from here on.
+		await rm.CaptureConsistentState();
+
+		Append(stream, 1);
+		AssertEx.IsOrBecomesTrue(() => rm.Applied == 5, TestTimeouts.ThrottleWaitFor,
+			"a listener was left held after the capture completed");
+	}
+
+	[Fact]
+	public async Task successive_captures_of_a_model_order_by_what_they_cover() {
+		var stream = NewStream();
+		Append(stream, 3);
+		using var rm = new CountingModel(_configured);
+		rm.Start(stream, null, true);
+		await rm.IsLive;
+
+		var earlier = await rm.CaptureConsistentState();
+		Append(stream, 4);
+		AssertEx.IsOrBecomesTrue(() => rm.Applied == 7, TestTimeouts.ThrottleWaitFor);
+		var later = await rm.CaptureConsistentState();
+
+		Assert.Equal(CheckpointOrder.Before, earlier.Compare(later));
+		Assert.Equal(CheckpointOrder.After, later.Compare(earlier));
+		Assert.Equal(CheckpointOrder.Equal, earlier.Compare(earlier));
+	}
+
+	[Fact]
+	public async Task a_model_fed_outside_its_listeners_refuses_to_capture() {
+		var stream = NewStream();
+		Append(stream, 3);
+		using var rm = new CountingModel(_configured);
+		rm.Start(stream, null, true);
+		await rm.IsLive;
+		Assert.False(rm.HasUnreplayableInput);
+
+		rm.DirectApply(new CountedEvent());
+
+		Assert.True(rm.HasUnreplayableInput);
+		// Synchronously, not as a faulted task: a caller that never awaits still has to hear it.
+		Assert.Throws<InvalidOperationException>(() => { _ = rm.CaptureConsistentState(); });
+	}
+
+	[Fact]
+	public async Task publishing_into_a_model_is_the_same_refusal() {
+		var stream = NewStream();
+		Append(stream, 3);
+		using var rm = new CountingModel(_configured);
+		rm.Start(stream, null, true);
+		await rm.IsLive;
+
+		rm.Publish(new CountedEvent());
+
+		Assert.True(rm.HasUnreplayableInput);
+		// Synchronously, not as a faulted task: a caller that never awaits still has to hear it.
+		Assert.Throws<InvalidOperationException>(() => { _ = rm.CaptureConsistentState(); });
+	}
+
+	[Fact]
+	public async Task a_model_with_a_stream_still_reading_has_no_cut_to_capture() {
+		var stream = NewStream();
+		Append(stream, 5);
+		using var rm = new CountingModel(_configured);
+		try {
+			// Wedged, so the read cannot drain and the model does not go live. Its events are already
+			// reaching the queue through the model's own Handle, named by no listener checkpoint.
+			rm.Wedge();
+			rm.StartAsync(stream);
+
+			Assert.Throws<InvalidOperationException>(() => { _ = rm.CaptureConsistentState(); });
+			Assert.False(rm.IsLive.IsCompleted);
+		} finally {
+			rm.Unwedge();
+		}
+
+		await rm.IsLive;
+		AssertDescribesState(await rm.CaptureConsistentState(), 5);
+	}
+
+	[Fact]
+	public async Task a_stream_cannot_be_started_inside_the_capture_window() {
+		var stream = NewStream();
+		Append(stream, 3);
+		using var rm = new CountingModel(_configured);
+		rm.Start(stream, null, true);
+		await rm.IsLive;
+
+		// Wedged after going live, so the capture is outstanding while the model is otherwise idle.
+		rm.Wedge();
+		Append(stream, 1);
+		var capturing = rm.CaptureConsistentState();
+		Assert.False(capturing.IsCompleted);
+
+		Assert.Throws<InvalidOperationException>(() => rm.Start(NewStream(), null, false));
+
+		rm.Unwedge();
+		AssertDescribesState(await capturing, 4);
+		// The refused start left nothing behind: the model still captures once the window closes.
+		AssertDescribesState(await rm.CaptureConsistentState(), 4);
+	}
+
+	[Fact]
+	public async Task a_disposed_model_releases_a_capture_it_can_no_longer_finish() {
+		var stream = NewStream();
+		Append(stream, 2);
+		using var rm = new CountingModel(_configured);
+		rm.Start(stream, null, true);
+		await rm.IsLive;
+
+		// The queue is stopped, so the barrier that would answer this can never be dequeued. The
+		// caller has to be let go rather than left waiting on a cut nothing will reach.
+		rm.Dispose();
+		var capturing = rm.CaptureConsistentState();
+
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => capturing);
+	}
+}

--- a/src/ReactiveDomain.Foundation.Tests/when_capturing_off_the_beaten_path.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_capturing_off_the_beaten_path.cs
@@ -1,0 +1,254 @@
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using ReactiveDomain.Testing.EventStore;
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests;
+
+// Capture is covered against the listener a ConfiguredConnection hands out and against one stream at
+// a time. These are the paths that were not: the queued listener, which is what MockRepositorySpecification
+// gives a read model and which has a queue of its own between the store and the model; captures that
+// overlap; a model with nothing to capture; and the window where a model is being disposed but does
+// not yet say so.
+// ReSharper disable once InconsistentNaming
+public sealed class when_capturing_off_the_beaten_path : IDisposable {
+	private readonly MockStreamStoreConnection _conn;
+	private readonly IEventSerializer _serializer = new JsonMessageSerializer();
+	private readonly IStreamNameBuilder _namer =
+		new PrefixedCamelCaseStreamNameBuilder(nameof(when_capturing_off_the_beaten_path));
+	private readonly IConfiguredConnection _configured;
+
+	public when_capturing_off_the_beaten_path() {
+		_conn = new MockStreamStoreConnection(nameof(when_capturing_off_the_beaten_path));
+		_conn.Connect();
+		_configured = new ConfiguredConnection(_conn, _namer, _serializer);
+	}
+
+	public void Dispose() => _conn.Dispose();
+
+	private string NewStream() => _namer.GenerateForAggregate(typeof(TestAggregate), Guid.NewGuid());
+
+	private void Append(string stream, int count) {
+		for (var i = 0; i < count; i++) {
+			_conn.AppendToStream(stream, ExpectedVersion.Any, null, _serializer.Serialize(new CountedEvent()));
+		}
+	}
+
+	public record CountedEvent : Event;
+
+	/// <summary>Hands out the queued listener where a read model asks for a listener.</summary>
+	private sealed class QueuedListenerConnection(IConfiguredConnection inner) : IConfiguredConnection {
+		public IStreamStoreConnection Connection => inner.Connection;
+		public IStreamNameBuilder StreamNamer => inner.StreamNamer;
+		public IEventSerializer Serializer => inner.Serializer;
+		public IListener GetListener(string name) => inner.GetQueuedListener(name);
+		public IListener GetQueuedListener(string name) => inner.GetQueuedListener(name);
+		public IStreamReader GetReader(string name, Action<IMessage> handle) => inner.GetReader(name, handle);
+		public IRepository GetRepository(bool caching = false, Func<Guid>? currentPolicyUserId = null) =>
+			inner.GetRepository(caching, currentPolicyUserId);
+		public ICorrelatedRepository GetCorrelatedRepository(
+			IRepository? baseRepository = null, bool caching = false, Func<Guid>? currentPolicyUserId = null) =>
+			inner.GetCorrelatedRepository(baseRepository, caching, currentPolicyUserId);
+	}
+
+	private sealed class CountingModel : SnapshotReadModel, IHandle<CountedEvent> {
+		private readonly ManualResetEventSlim _gate = new(true);
+		private readonly ManualResetEventSlim _disposing = new(false);
+		private readonly ManualResetEventSlim _finishDisposing = new(true);
+
+		public CountingModel(IConfiguredConnection c, ReadModelState? restore = null)
+			: base(nameof(CountingModel), c) {
+			EventStream.Subscribe<CountedEvent>(this);
+			if (restore is not null) { Restore(restore); }
+		}
+
+		public long Applied { get; private set; }
+		public void Wedge() => _gate.Reset();
+		public void Unwedge() => _gate.Set();
+
+		/// <summary>Stops inside Dispose after the base has torn the pump down but before it is marked
+		/// disposed, which is the window a capture can be registered into.</summary>
+		public void HoldOpenDispose() => _finishDisposing.Reset();
+		public bool WaitForDisposeWindow() => _disposing.Wait(TestTimeouts.ThrottleWaitFor);
+		public void LetDisposeFinish() => _finishDisposing.Set();
+
+		void IHandle<CountedEvent>.Handle(CountedEvent e) {
+			_gate.Wait();
+			Applied++;
+		}
+
+		public void SeeExternal(string stream, long version) => SetExternalCheckpoint(stream, version);
+
+		protected override void ApplyState(ReadModelState snapshot) => Applied = (long)snapshot.State;
+		public override ReadModelState GetState() =>
+			new(nameof(CountingModel), GetCheckpoint(), Applied, GetExternalCheckpoints());
+
+		protected override void Dispose(bool disposing) {
+			_gate.Set();
+			_disposing.Set();
+			_finishDisposing.Wait();
+			base.Dispose(disposing);
+		}
+	}
+
+	private static void AssertSelfConsistent(ReadModelState snapshot) =>
+		Assert.Equal(snapshot.Checkpoints!.Sum(c => (c.Version ?? -1) + 1), (long)snapshot.State);
+
+	[Fact]
+	public async Task a_queued_listener_captures_at_a_cut_like_any_other() {
+		var stream = NewStream();
+		Append(stream, 5);
+		using var rm = new CountingModel(new QueuedListenerConnection(_configured));
+		rm.Start(stream, null, true);
+		await rm.IsLive;
+
+		// The queued listener holds events in a queue of its own, so drive delivery and application
+		// apart the same way and check the cut still lands between them.
+		rm.Wedge();
+		Append(stream, 6);
+		AssertEx.IsOrBecomesTrue(
+			() => rm.GetCheckpoint().FirstOrDefault()?.Version == 10, TestTimeouts.ThrottleWaitFor);
+		Assert.Equal(5, rm.Applied);
+
+		var capturing = rm.CaptureConsistentState();
+		rm.Unwedge();
+		var snapshot = await capturing;
+
+		Assert.Equal(11, (long)snapshot.State);
+		AssertSelfConsistent(snapshot);
+	}
+
+	[Fact]
+	public async Task a_queued_listener_restores_what_it_captured() {
+		var stream = NewStream();
+		Append(stream, 4);
+		var queued = new QueuedListenerConnection(_configured);
+		using var rm = new CountingModel(queued);
+		rm.Start(stream, null, true);
+		await rm.IsLive;
+		var snapshot = await rm.CaptureConsistentState();
+
+		Append(stream, 3);
+
+		using var restored = new CountingModel(queued, snapshot);
+		AssertEx.IsOrBecomesTrue(() => restored.Applied == 7, TestTimeouts.ThrottleWaitFor,
+			$"restored {restored.Applied} of 7 appended");
+	}
+
+	[Fact]
+	public async Task captures_that_overlap_each_describe_their_own_cut() {
+		var stream = NewStream();
+		Append(stream, 3);
+		using var rm = new CountingModel(_configured);
+		rm.Start(stream, null, true);
+		await rm.IsLive;
+
+		rm.Wedge();
+		Append(stream, 2);
+		AssertEx.IsOrBecomesTrue(
+			() => rm.GetCheckpoint().FirstOrDefault()?.Version == 4, TestTimeouts.ThrottleWaitFor);
+
+		var first = rm.CaptureConsistentState();
+		Append(stream, 2);
+		AssertEx.IsOrBecomesTrue(
+			() => rm.GetCheckpoint().FirstOrDefault()?.Version == 6, TestTimeouts.ThrottleWaitFor);
+		var second = rm.CaptureConsistentState();
+
+		rm.Unwedge();
+		var earlier = await first;
+		var later = await second;
+
+		AssertSelfConsistent(earlier);
+		AssertSelfConsistent(later);
+		Assert.Equal(5, (long)earlier.State);
+		Assert.Equal(7, (long)later.State);
+		Assert.Equal(CheckpointOrder.Before, earlier.Compare(later));
+	}
+
+	[Fact]
+	public async Task a_model_with_nothing_started_captures_an_empty_cut() {
+		using var rm = new CountingModel(_configured);
+		await rm.IsLive; // vacuously live
+
+		var snapshot = await rm.CaptureConsistentState();
+
+		Assert.Empty(snapshot.Checkpoints!);
+		Assert.Equal(0L, (long)snapshot.State);
+	}
+
+	[Fact]
+	public async Task recording_where_relayed_input_came_from_makes_a_model_capturable_again() {
+		var stream = NewStream();
+		Append(stream, 2);
+		using var rm = new CountingModel(_configured);
+		rm.Start(stream, null, true);
+		await rm.IsLive;
+
+		rm.DirectApply(new CountedEvent());
+		Assert.True(rm.HasUnreplayableInput);
+
+		rm.SeeExternal("relayed-stream", 0);
+
+		Assert.False(rm.HasUnreplayableInput);
+		var snapshot = await rm.CaptureConsistentState();
+		Assert.Equal("relayed-stream", Assert.Single(snapshot.ExternalCheckpoints!).StreamName);
+	}
+
+	// A model that rebuilds its state through DirectApply is doing what Restore asks of it, and the
+	// checkpoints restored beside that state describe it exactly — so it is snapshottable, and was not.
+	private sealed class RebuildingModel : SnapshotReadModel, IHandle<CountedEvent> {
+		public RebuildingModel(IConfiguredConnection c, ReadModelState restore)
+			: base(nameof(RebuildingModel), c) {
+			EventStream.Subscribe<CountedEvent>(this);
+			Restore(restore);
+		}
+		public long Applied { get; private set; }
+		void IHandle<CountedEvent>.Handle(CountedEvent e) => Applied++;
+
+		protected override void ApplyState(ReadModelState snapshot) {
+			for (var i = 0; i < (long)snapshot.State; i++) { DirectApply(new CountedEvent()); }
+		}
+		public override ReadModelState GetState() =>
+			new(nameof(RebuildingModel), GetCheckpoint(), Applied, GetExternalCheckpoints());
+	}
+
+	[Fact]
+	public async Task a_model_that_rebuilds_its_state_while_restoring_can_still_be_captured() {
+		var stream = NewStream();
+		Append(stream, 4);
+		using var built = new CountingModel(_configured);
+		built.Start(stream, null, true);
+		await built.IsLive;
+		var snapshot = await built.CaptureConsistentState();
+
+		using var rebuilt = new RebuildingModel(_configured, snapshot);
+		await rebuilt.IsLive;
+
+		Assert.False(rebuilt.HasUnreplayableInput);
+		Assert.Equal(4, rebuilt.Applied);
+		AssertSelfConsistent(await rebuilt.CaptureConsistentState());
+	}
+
+	[Fact]
+	public async Task a_capture_registered_while_a_model_is_being_disposed_is_released() {
+		var stream = NewStream();
+		Append(stream, 2);
+		var rm = new CountingModel(_configured);
+		rm.Start(stream, null, true);
+		await rm.IsLive;
+
+		rm.HoldOpenDispose();
+		var disposing = Task.Run(rm.Dispose);
+		Assert.True(rm.WaitForDisposeWindow(), "dispose never reached its window");
+
+		// The pump is down and outstanding captures have been abandoned, but the model does not yet
+		// report itself disposed — so this one is registered against a queue that will never run it.
+		var capturing = rm.CaptureConsistentState();
+
+		rm.LetDisposeFinish();
+		await disposing;
+
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => capturing);
+	}
+}

--- a/src/ReactiveDomain.Foundation.Tests/when_checkpointing_all_positions.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_checkpointing_all_positions.cs
@@ -46,7 +46,7 @@ public sealed class when_checkpointing_all_positions :
 	}
 
 	public int Handled { get; private set; }
-	public void Handle(PositionTestEvent @event) => Handled++;
+	void IHandle<PositionTestEvent>.Handle(PositionTestEvent @event) => Handled++;
 
 	[Fact]
 	public void a_checkpoint_carries_the_all_position_of_the_last_event_applied() {
@@ -97,17 +97,45 @@ public sealed class when_checkpointing_all_positions :
 	}
 
 	[Fact]
-	public void a_source_that_has_delivered_nothing_suppresses_both_projections() {
+	public void a_source_that_has_delivered_nothing_suppresses_only_the_watermark() {
 		Start(_early, null, true);
 		AssertEx.IsOrBecomesTrue(() => Handled == 3, TestTimeouts.ThrottleWaitFor);
-		Assert.NotNull(HighWaterMark);
+		var reached = HighWaterMark;
+		Assert.NotNull(reached);
 
-		// A second stream with nothing on it reports no position. Projecting over the rest would
-		// claim a reach and a coverage the model cannot stand behind.
+		// A second stream with nothing on it reports no position. The two projections part company
+		// here: the model still reached everything it reached, so leaving the silent source out can
+		// only understate the reach — but claiming coverage through the nearest of the rest would
+		// speak for a source that has said nothing.
 		Start(_namer.GenerateForAggregate(typeof(TestAggregate), Guid.NewGuid()), null, false);
 
-		Assert.Null(HighWaterMark);
+		Assert.Equal(reached, HighWaterMark);
 		Assert.Null(LowestAppliedPosition);
+	}
+
+	[Fact]
+	public void a_stream_that_has_delivered_nothing_checkpoints_no_version() {
+		var empty = _namer.GenerateForAggregate(typeof(TestAggregate), Guid.NewGuid());
+		Start(empty, null, false);
+
+		var checkpoint = Assert.Single(GetCheckpoint());
+		Assert.Equal(empty, checkpoint.StreamName);
+		// Not 0. Version 0 is this stream's first event, and it has not been delivered — resuming
+		// from it would step over the event the checkpoint is meant to precede.
+		Assert.Null(checkpoint.Version);
+		Assert.Null(checkpoint.Position);
+	}
+
+	[Fact]
+	public void a_resumed_stream_reports_its_resume_point_before_it_delivers_anything() {
+		// _early's last event is version 2, so resuming from there delivers nothing. The resume point
+		// is still a version this stream reached — unlike the zero that stands in for no resume point
+		// — so it is reportable straight away.
+		Start(_early, 2, true);
+
+		var checkpoint = Assert.Single(GetCheckpoint());
+		Assert.Equal(2, checkpoint.Version);
+		Assert.Equal(0, Handled);
 	}
 
 	public record PositionTestEvent : Event;

--- a/src/ReactiveDomain.Foundation.Tests/when_ordering_checkpoints.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_ordering_checkpoints.cs
@@ -1,0 +1,104 @@
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests;
+
+// Checkpoints over several streams form a partial order, not a sequence. These are the laws that
+// makes it one, and the case that stops it being one if the comparison goes through a single number.
+// ReSharper disable once InconsistentNaming
+public sealed class when_ordering_checkpoints {
+	private static List<StreamCheckpoint> At(params (string Stream, long? Version)[] streams) =>
+		streams.Select(s => new StreamCheckpoint(s.Stream, s.Version)).ToList();
+
+	private static CheckpointOrder Compare(
+		IEnumerable<StreamCheckpoint>? first, IEnumerable<StreamCheckpoint>? second) =>
+		StreamCheckpoint.Compare(first, second);
+
+	[Fact]
+	public void a_set_is_equal_to_itself() {
+		var checkpoints = At(("a", 3), ("b", 7));
+		Assert.Equal(CheckpointOrder.Equal, Compare(checkpoints, checkpoints));
+	}
+
+	[Fact]
+	public void covering_nothing_is_equal_however_it_is_expressed() {
+		Assert.Equal(CheckpointOrder.Equal, Compare(null, []));
+		Assert.Equal(CheckpointOrder.Equal, Compare([], null));
+		// A stream that has delivered nothing covers what a stream nobody mentioned covers.
+		Assert.Equal(CheckpointOrder.Equal, Compare(At(("a", null)), []));
+	}
+
+	[Fact]
+	public void further_along_a_stream_is_later() {
+		Assert.Equal(CheckpointOrder.Before, Compare(At(("a", 3)), At(("a", 4))));
+		Assert.Equal(CheckpointOrder.After, Compare(At(("a", 4)), At(("a", 3))));
+	}
+
+	[Fact]
+	public void nothing_applied_precedes_the_first_event() {
+		// Null is not zero: zero covers the first event, null covers none of them.
+		Assert.Equal(CheckpointOrder.Before, Compare(At(("a", null)), At(("a", 0))));
+	}
+
+	[Fact]
+	public void a_stream_the_other_does_not_mention_is_a_stream_it_covers_nothing_of() {
+		// So starting another stream moves a model strictly forward rather than out of the order.
+		Assert.Equal(CheckpointOrder.Before, Compare(At(("a", 3)), At(("a", 3), ("b", 0))));
+		Assert.Equal(CheckpointOrder.After, Compare(At(("a", 3), ("b", 0)), At(("a", 3))));
+	}
+
+	[Fact]
+	public void ahead_on_one_stream_and_behind_on_another_is_neither() {
+		// The case a single projected position cannot express, and would report as an order.
+		Assert.Equal(CheckpointOrder.Concurrent, Compare(At(("a", 5), ("b", 1)), At(("a", 1), ("b", 5))));
+	}
+
+	[Fact]
+	public void the_order_is_antisymmetric() {
+		(List<StreamCheckpoint> First, List<StreamCheckpoint> Second)[] pairs = [
+			(At(("a", 1)), At(("a", 2))),
+			(At(("a", 1), ("b", 1)), At(("a", 2), ("b", 2))),
+			(At(("a", 5), ("b", 1)), At(("a", 1), ("b", 5))),
+			(At(("a", 1)), At(("a", 1))),
+			(At(("a", null)), At(("a", 0)))
+		];
+		foreach (var (first, second) in pairs) {
+			var forward = Compare(first, second);
+			var backward = Compare(second, first);
+			var expected = forward switch {
+				CheckpointOrder.Before => CheckpointOrder.After,
+				CheckpointOrder.After => CheckpointOrder.Before,
+				_ => forward // Equal and Concurrent each read the same from either side
+			};
+			Assert.Equal(expected, backward);
+		}
+	}
+
+	[Fact]
+	public void the_order_is_transitive() {
+		var first = At(("a", 1), ("b", 1));
+		var second = At(("a", 2), ("b", 1));
+		var third = At(("a", 2), ("b", 9));
+
+		Assert.Equal(CheckpointOrder.Before, Compare(first, second));
+		Assert.Equal(CheckpointOrder.Before, Compare(second, third));
+		Assert.Equal(CheckpointOrder.Before, Compare(first, third));
+	}
+
+	[Fact]
+	public void a_position_is_not_needed_to_order_a_stream() {
+		// Versions are dense and always present; positions are neither, and within a stream they agree.
+		var withPosition = new List<StreamCheckpoint> { new("a", 3, new Position(512, 512)) };
+		var without = At(("a", 4));
+		Assert.Equal(CheckpointOrder.Before, Compare(withPosition, without));
+	}
+
+	[Fact]
+	public void a_snapshot_orders_by_every_stream_that_reached_it() {
+		var earlier = new ReadModelState("m", At(("own", 3)), new object(), At(("relayed", 1)));
+		var later = new ReadModelState("m", At(("own", 3)), new object(), At(("relayed", 2)));
+
+		// The relay having fed more of its stream is later, however that stream reached the model.
+		Assert.Equal(CheckpointOrder.Before, earlier.Compare(later));
+		Assert.Equal(CheckpointOrder.After, later.Compare(earlier));
+	}
+}

--- a/src/ReactiveDomain.Foundation.Tests/when_reading_subscriber_state_under_the_reader_lock.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_reading_subscriber_state_under_the_reader_lock.cs
@@ -126,6 +126,38 @@ public sealed class when_reading_subscriber_state_under_the_reader_lock {
 		public void Handle(ReaderLockTestEvent message) => Interlocked.Increment(ref Handled);
 	}
 
+	/// <summary>One object can be both sorts of handler for one message, and each sort needs its own
+	/// wrapper. Finding the wrong sort must not count as not having found one — the sort that looks
+	/// second would then make a new wrapper every time, and the bus, which matches on the wrapper,
+	/// would register each as another handler.</summary>
+	[Fact]
+	public void subscribing_a_handler_that_is_both_sorts_registers_each_once() {
+		using var bus = new Dispatcher(nameof(when_reading_subscriber_state_under_the_reader_lock));
+		using var sut = new DualRoleSubscriber(bus);
+
+		bus.Publish(new ReaderLockTestCommand());
+
+		Assert.Equal(1, sut.Handled);
+	}
+
+	private sealed class DualRoleSubscriber :
+		TransientSubscriber, IHandle<ReaderLockTestCommand>, IHandleCommand<ReaderLockTestCommand> {
+		public int Handled;
+
+		public DualRoleSubscriber(IDispatcher bus) : base(bus) {
+			// The command sort first, so the event sort's lookup meets it. A command takes one handler
+			// and the bus says so, which is why only the event sort is subscribed twice.
+			Subscribe<ReaderLockTestCommand>((IHandleCommand<ReaderLockTestCommand>)this);
+			Subscribe<ReaderLockTestCommand>((IHandle<ReaderLockTestCommand>)this);
+			Subscribe<ReaderLockTestCommand>((IHandle<ReaderLockTestCommand>)this);
+		}
+
+		public void Handle(ReaderLockTestCommand message) => Interlocked.Increment(ref Handled);
+
+		CommandResponse IHandleCommand<ReaderLockTestCommand>.Handle(ReaderLockTestCommand command) =>
+			command.Succeed();
+	}
+
 	private sealed class PairSubscriber : TransientSubscriber, IHandle<ReaderLockTestEvent> {
 		private readonly ManualResetEventSlim _entered;
 		private readonly ManualResetEventSlim _release;

--- a/src/ReactiveDomain.Foundation.Tests/when_restoring_from_a_position.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_restoring_from_a_position.cs
@@ -1,0 +1,251 @@
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Messaging.Bus;
+using ReactiveDomain.Testing;
+using ReactiveDomain.Testing.EventStore;
+using Xunit;
+
+namespace ReactiveDomain.Foundation.Tests;
+
+// A checkpoint carries a version and a position, and restoring uses the version. This asks whether
+// the position names the same place — replaying $all from it here rather than in the library, so the
+// equivalence is established before anything is built on it. What the replay has to get right is the
+// part that would sink a real implementation, and it is not the position: it is which entry belongs
+// to the subscription being resumed.
+// ReSharper disable once InconsistentNaming
+public sealed class when_restoring_from_a_position : IDisposable {
+	private readonly MockStreamStoreConnection _conn;
+	private readonly IEventSerializer _serializer = new JsonMessageSerializer();
+	private readonly IStreamNameBuilder _namer =
+		new PrefixedCamelCaseStreamNameBuilder(nameof(when_restoring_from_a_position));
+	private readonly IConfiguredConnection _configured;
+	private readonly string _stream;
+
+	public when_restoring_from_a_position() {
+		_conn = new MockStreamStoreConnection(nameof(when_restoring_from_a_position));
+		_conn.Connect();
+		_configured = new ConfiguredConnection(_conn, _namer, _serializer);
+		_stream = _namer.GenerateForAggregate(typeof(TestAggregate), Guid.NewGuid());
+	}
+
+	public void Dispose() => _conn.Dispose();
+
+	private void Append(int count) {
+		for (var i = 0; i < count; i++) {
+			_conn.AppendToStream(_stream, ExpectedVersion.Any, null, _serializer.Serialize(new CountedEvent()));
+		}
+	}
+
+	public record CountedEvent : Event;
+
+	private sealed class CountingModel : SnapshotReadModel, IHandle<CountedEvent> {
+		public CountingModel(IConfiguredConnection c, ReadModelState? restore = null)
+			: base(nameof(CountingModel), c) {
+			EventStream.Subscribe<CountedEvent>(this);
+			if (restore is not null) { Restore(restore); }
+		}
+		public long Applied { get; private set; }
+		void IHandle<CountedEvent>.Handle(CountedEvent e) => Applied++;
+		protected override void ApplyState(ReadModelState snapshot) => Applied = (long)snapshot.State;
+		public override ReadModelState GetState() =>
+			new(nameof(CountingModel), GetCheckpoint(), Applied, GetExternalCheckpoints());
+	}
+
+	/// <summary>
+	/// The stream an entry was delivered on, which is what a subscription resuming from $all has to
+	/// match against. For a link this is the projection it lives in; <see cref="RecordedEvent.EventStreamId"/>
+	/// is the stream the link points at, and is the same for the original and for every copy of it.
+	/// </summary>
+	private static string DeliveredOn(RecordedEvent recorded) =>
+		recorded is ProjectedEvent projected ? projected.ProjectedStream : recorded.EventStreamId;
+
+	// Replays $all from where a checkpoint left off, taking only what that checkpoint's own
+	// subscription would have been handed.
+	private long ReplayFrom(StreamCheckpoint checkpoint, Func<RecordedEvent, string> belongsTo) =>
+		ReplayFrom(checkpoint.Position!.Value, checkpoint.StreamName, belongsTo);
+
+	private long ReplayFrom(Position from, string stream, Func<RecordedEvent, string> belongsTo) {
+		var applied = 0L;
+		using var subscription = _conn.SubscribeToAllFrom(
+			from,
+			recorded => {
+				if (belongsTo(recorded) == stream && _serializer.Deserialize(recorded) is CountedEvent) {
+					applied++;
+				}
+			});
+		return applied;
+	}
+
+	private StreamCheckpoint Checkpoint(ReadModelState snapshot, string stream) =>
+		Assert.Single(snapshot.Checkpoints!, c => c.StreamName == stream);
+
+	// A model on all three kinds at once: the aggregate's own stream, the category it belongs to, and
+	// the stream of its event type. Every append reaches this model three times, once per
+	// subscription, which is what independent streams means — they are not three views of one feed to
+	// be deduplicated, they are three feeds.
+	private CountingModel StartOnEveryKind(out string category, out string eventType) {
+		category = _namer.GenerateForCategory(typeof(TestAggregate));
+		eventType = _namer.GenerateForEventType(nameof(CountedEvent));
+		var rm = new CountingModel(_configured);
+		rm.Start(_stream, null, true);
+		rm.Start(category, null, true);
+		rm.Start(eventType, null, true);
+		return rm;
+	}
+
+	[Fact]
+	public async Task a_version_and_a_position_name_the_same_place_in_a_stream() {
+		Append(6);
+		using var rm = new CountingModel(_configured);
+		rm.Start(_stream, null, true);
+		await rm.IsLive;
+		var snapshot = await rm.CaptureConsistentState();
+		var checkpoint = Assert.Single(snapshot.Checkpoints!);
+		Assert.NotNull(checkpoint.Position);
+
+		Append(4);
+
+		// By version: restore the state and resume the stream after it.
+		using var byVersion = new CountingModel(_configured, snapshot);
+		AssertEx.IsOrBecomesTrue(() => byVersion.Applied == 10, TestTimeouts.ThrottleWaitFor);
+
+		// By position: restore the same state and replay $all from where it left off.
+		var byPosition = (long)snapshot.State + ReplayFrom(checkpoint, DeliveredOn);
+
+		Assert.Equal(byVersion.Applied, byPosition);
+	}
+
+	[Fact]
+	public async Task a_category_checkpoint_names_the_same_place_as_its_version_does() {
+		Append(6);
+		using var rm = new CountingModel(_configured);
+		rm.Start<TestAggregate>(null, true);
+		await rm.IsLive;
+		var snapshot = await rm.CaptureConsistentState();
+		var checkpoint = Assert.Single(snapshot.Checkpoints!);
+		Assert.Equal(_namer.GenerateForCategory(typeof(TestAggregate)), checkpoint.StreamName);
+
+		Append(4);
+
+		using var byVersion = new CountingModel(_configured, snapshot);
+		AssertEx.IsOrBecomesTrue(() => byVersion.Applied == 10, TestTimeouts.ThrottleWaitFor);
+
+		var byPosition = (long)snapshot.State + ReplayFrom(checkpoint, DeliveredOn);
+
+		Assert.Equal(byVersion.Applied, byPosition);
+	}
+
+	[Fact]
+	public async Task a_position_resumes_after_the_entry_it_names() {
+		Append(3);
+		using var rm = new CountingModel(_configured);
+		rm.Start(_stream, null, true);
+		await rm.IsLive;
+		var checkpoint = Assert.Single((await rm.CaptureConsistentState()).Checkpoints!);
+
+		// Everything was applied, so resuming from here must find nothing — a position that included
+		// the entry it names would re-apply the last event on every restore.
+		Assert.Equal(0, ReplayFrom(checkpoint, DeliveredOn));
+	}
+
+	[Fact]
+	public async Task matching_an_entry_by_the_stream_it_points_at_counts_it_once_per_copy() {
+		// The trap that would sink an $all-based restore. One appended event is three entries in $all
+		// — the original, the category link, the event-type link — and all three report the stream the
+		// original lives on. Matching on that applies each event once per projection that copied it,
+		// while the category-fed case below matches nothing at all: opposite errors, one filter.
+		Append(3);
+		using var rm = new CountingModel(_configured);
+		rm.Start(_stream, null, true);
+		await rm.IsLive;
+		var snapshot = await rm.CaptureConsistentState();
+		var checkpoint = Assert.Single(snapshot.Checkpoints!);
+
+		Append(2);
+
+		Assert.Equal(2, ReplayFrom(checkpoint, DeliveredOn));
+
+		// Eight, not the six the two new events copied three ways would suggest. A link is written
+		// after the event it points at, so a position naming an original sits *before* that same
+		// event's own copies: the wrong filter re-applies an event the snapshot had already applied,
+		// as well as counting the new ones three times over.
+		Assert.Equal(8, ReplayFrom(checkpoint, recorded => recorded.EventStreamId));
+	}
+
+	[Fact]
+	public async Task matching_a_category_entry_by_the_stream_it_points_at_finds_nothing() {
+		Append(3);
+		using var rm = new CountingModel(_configured);
+		rm.Start<TestAggregate>(null, true);
+		await rm.IsLive;
+		var checkpoint = Assert.Single((await rm.CaptureConsistentState()).Checkpoints!);
+
+		Append(2);
+
+		Assert.Equal(2, ReplayFrom(checkpoint, DeliveredOn));
+		// A link's EventStreamId is the aggregate stream, never the category it was copied into.
+		Assert.Equal(0, ReplayFrom(checkpoint, recorded => recorded.EventStreamId));
+	}
+
+	[Fact]
+	public async Task every_subscribed_stream_is_checkpointed_independently() {
+		Append(3);
+		using var rm = StartOnEveryKind(out var category, out var eventType);
+		await rm.IsLive;
+		AssertEx.IsOrBecomesTrue(() => rm.Applied == 9, TestTimeouts.ThrottleWaitFor);
+
+		var snapshot = await rm.CaptureConsistentState();
+
+		Assert.Equal(3, snapshot.Checkpoints!.Count);
+		foreach (var stream in new[] { _stream, category, eventType }) {
+			var checkpoint = Checkpoint(snapshot, stream);
+			Assert.Equal(2, checkpoint.Version);
+			Assert.NotNull(checkpoint.Position);
+		}
+
+		// Same version on each, and three different places in the log: a projection's copy is its own
+		// entry, written after the one it points at. One position could not stand for all three.
+		var positions = snapshot.Checkpoints!.Select(c => c.Position!.Value).ToList();
+		Assert.Equal(3, positions.Distinct().Count());
+	}
+
+	[Fact]
+	public async Task each_stream_replays_from_its_own_position_to_the_same_state() {
+		Append(3);
+		using var rm = StartOnEveryKind(out var category, out var eventType);
+		await rm.IsLive;
+		AssertEx.IsOrBecomesTrue(() => rm.Applied == 9, TestTimeouts.ThrottleWaitFor);
+		var snapshot = await rm.CaptureConsistentState();
+
+		Append(2);
+
+		using var byVersion = new CountingModel(_configured, snapshot);
+		AssertEx.IsOrBecomesTrue(() => byVersion.Applied == 15, TestTimeouts.ThrottleWaitFor);
+
+		// What a consumer restoring from $all has to do: take each recorded stream on its own terms,
+		// resume it from its own position, and keep them apart. Summed, that is the model's state.
+		var byPosition = (long)snapshot.State + snapshot.Checkpoints!.Sum(c => ReplayFrom(c, DeliveredOn));
+
+		Assert.Equal(byVersion.Applied, byPosition);
+	}
+
+	[Fact]
+	public async Task one_streams_position_does_not_resume_another() {
+		Append(3);
+		using var rm = StartOnEveryKind(out var category, out _);
+		await rm.IsLive;
+		AssertEx.IsOrBecomesTrue(() => rm.Applied == 9, TestTimeouts.ThrottleWaitFor);
+		var snapshot = await rm.CaptureConsistentState();
+
+		Append(2);
+
+		// The category resumed from its own position sees the two new copies.
+		Assert.Equal(2, ReplayFrom(Checkpoint(snapshot, category), DeliveredOn));
+
+		// Resumed from the aggregate stream's position instead, it sees three: the link for the event
+		// the aggregate stream had already reached sits after that event's own entry, so a position
+		// borrowed from one stream re-applies an event on another. Independent streams, independent
+		// positions.
+		Assert.Equal(3,
+			ReplayFrom(Checkpoint(snapshot, _stream).Position!.Value, category, DeliveredOn));
+	}
+}

--- a/src/ReactiveDomain.Foundation.Tests/when_using_external_snapshot_positions.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_external_snapshot_positions.cs
@@ -222,7 +222,9 @@ public sealed class when_using_external_snapshot_positions : IClassFixture<Strea
 			Count = state.Count;
 			Sum = state.Sum;
 			if (TryGetExternalCheckpoint(_relayedStream, out var checkpoint)) {
-				PositionSeenWhileRestoring = checkpoint.Version;
+				// An external source records a checkpoint only when it has fed something, so the
+				// version is always there; -1 keeps the "nothing seen" reading in one place either way.
+				PositionSeenWhileRestoring = checkpoint!.Version ?? -1;
 			}
 		}
 

--- a/src/ReactiveDomain.Foundation.Tests/when_using_snapshot_read_model.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_snapshot_read_model.cs
@@ -69,6 +69,20 @@ public sealed class when_using_snapshot_read_model : IClassFixture<StreamStoreCo
 		AssertEx.IsOrBecomesTrue(() => rm.Sum == 25, TestTimeouts.ThrottleWaitFor);
 	}
 	[Fact]
+	public void a_checkpoint_with_no_version_restores_from_the_first_event() {
+		// What a stream that had delivered nothing when the snapshot was taken records. A version of
+		// 0 would resume *after* the first event and lose it; no version resumes from the start.
+		var snapshot = new ReadModelState(
+			nameof(TestSnapShotReadModel),
+			[new StreamCheckpoint(_stream, null)],
+			new TestSnapShotReadModel.MyState { Count = 0, Sum = 0 });
+
+		var rm = new TestSnapShotReadModel(_aggId, _configuredConnection, snapshot);
+		AssertEx.IsOrBecomesTrue(() => rm.Count == 10, TestTimeouts.ThrottleWaitFor);
+		AssertEx.IsOrBecomesTrue(() => rm.Sum == 20, TestTimeouts.ThrottleWaitFor);
+	}
+
+	[Fact]
 	[SuppressMessage("ReSharper", "AccessToDisposedClosure")]
 	public void can_snapshot_and_recover_read_model() {
 		var rm = new TestSnapShotReadModel(_aggId, _configuredConnection, null);

--- a/src/ReactiveDomain.Foundation/CatchUpConnection.cs
+++ b/src/ReactiveDomain.Foundation/CatchUpConnection.cs
@@ -19,7 +19,7 @@ namespace ReactiveDomain.Foundation;
 /// listener positions and the read-model queue check below cover.
 /// </remarks>
 public sealed class CatchUpConnection(IConfiguredConnection inner) : IConfiguredConnection {
-	private readonly List<TrackedStreamListener> _tracked = [];
+	private readonly List<IListener> _tracked = [];
 
 	public IStreamStoreConnection Connection => inner.Connection;
 	public IStreamNameBuilder StreamNamer => inner.StreamNamer;
@@ -29,17 +29,20 @@ public sealed class CatchUpConnection(IConfiguredConnection inner) : IConfigured
 	/// Returns a listener whose delivered-through position feeds <see cref="WaitForCatchUp"/>.
 	/// </summary>
 	public IListener GetListener(string name) {
-		var listener = new TrackedStreamListener(name, inner.Connection, inner.StreamNamer, inner.Serializer);
+		// Constructed rather than delegated: what this barrier promises rests on the listener being
+		// this one, not on whatever the wrapped connection hands out.
+		var listener = new StreamListener(name, inner.Connection, inner.StreamNamer, inner.Serializer);
 		lock (_tracked) { _tracked.Add(listener); }
 		return listener;
 	}
 
 	/// <summary>
-	/// Deliberately NOT tracked: <see cref="QueuedStreamListener"/>'s internal queue
-	/// buffers events after receipt, so a tracked position would over-report delivery —
-	/// "received by the listener" is not "handed to the subscriber". Do not "fix" this by
-	/// tracking it.
+	/// The wrapped connection's queued listener, which this barrier does not track.
 	/// </summary>
+	/// <remarks>
+	/// <see cref="WaitForCatchUp"/> spans the listeners handed out by <see cref="GetListener"/>. A
+	/// model fed from a queued listener is outside it and needs a barrier of its own.
+	/// </remarks>
 	public IListener GetQueuedListener(string name) => inner.GetQueuedListener(name);
 
 	public IStreamReader GetReader(string name, Action<IMessage> handle) => inner.GetReader(name, handle);
@@ -93,16 +96,20 @@ public sealed class CatchUpConnection(IConfiguredConnection inner) : IConfigured
 	// Checked in causal order each pass: store delivery first, then read-model queues.
 	private List<string> ListLaggards(ReadModelBase[] readModels) {
 		var laggards = new List<string>();
-		TrackedStreamListener[] tracked;
+		IListener[] tracked;
 		lock (_tracked) { tracked = _tracked.ToArray(); }
 		foreach (var listener in tracked) {
-			if (string.IsNullOrEmpty(listener.StreamName)) { continue; } // not started yet
-			var slice = inner.Connection.ReadStreamBackward(listener.StreamName, -1, 1);
+			// A checkpoint arrives with the stream name, so an unnamed listener has not started.
+			if (listener.Checkpoint is not { } checkpoint) { continue; }
+			var slice = inner.Connection.ReadStreamBackward(checkpoint.StreamName, -1, 1);
 			if (slice is null or StreamNotFoundSlice || slice.Events.Length == 0) { continue; }
 			var target = slice.LastEventNumber;
-			var delivered = listener.DeliveredThrough;
+			// Recorded once the event is in the subscriber's queue, and null until there is one, so
+			// this is "in the read model's queue or applied" — never "in flight", never a seed 0
+			// passing for event 0. -1 is before every event, which is what no version means here.
+			var delivered = checkpoint.Version ?? -1;
 			if (delivered < target) {
-				laggards.Add($"{listener.StreamName} delivered {delivered} of {target}");
+				laggards.Add($"{checkpoint.StreamName} delivered {delivered} of {target}");
 			}
 		}
 		if (laggards.Count > 0) { return laggards; }
@@ -114,39 +121,4 @@ public sealed class CatchUpConnection(IConfiguredConnection inner) : IConfigured
 		return laggards;
 	}
 
-	/// <summary>
-	/// Exposes DeliveredThrough = max(startCheckpoint, lastDelivered), with lastDelivered
-	/// recorded after the base publishes into the subscriber's queue — so DeliveredThrough >= N
-	/// means "event N is in the read model's queue or applied", never "in flight". This fixes two
-	/// ambiguities in the base <see cref="StreamListener.Position"/>: it advances at receipt
-	/// (before the subscriber sees the event) and initializes to 0 (indistinguishable from
-	/// "applied event 0").
-	/// </summary>
-	private sealed class TrackedStreamListener(
-		string listenerName,
-		IStreamStoreConnection connection,
-		IStreamNameBuilder streamNameBuilder,
-		IEventSerializer serializer)
-		: StreamListener(listenerName, connection, streamNameBuilder, serializer) {
-		private long _startCheckpoint = -1;
-		private long _lastDelivered = -1;
-
-		public long DeliveredThrough =>
-			Math.Max(Interlocked.Read(ref _startCheckpoint), Interlocked.Read(ref _lastDelivered));
-
-		public override void Start(
-			string streamName,
-			long? checkpoint = null,
-			bool blockUntilLive = false,
-			bool validateStream = false,
-			CancellationToken cancelWaitToken = default) {
-			Interlocked.Exchange(ref _startCheckpoint, checkpoint ?? -1);
-			base.Start(streamName, checkpoint, blockUntilLive, validateStream, cancelWaitToken);
-		}
-
-		protected override void GotEvent(RecordedEvent recordedEvent) {
-			base.GotEvent(recordedEvent); // deliver first, then record
-			Interlocked.Exchange(ref _lastDelivered, recordedEvent.EventNumber);
-		}
-	}
 }

--- a/src/ReactiveDomain.Foundation/IListener.cs
+++ b/src/ReactiveDomain.Foundation/IListener.cs
@@ -3,9 +3,19 @@
 namespace ReactiveDomain.Foundation;
 
 public interface IListener : IDisposable {
+	/// <summary>The events this listener delivers, and its live transition.</summary>
+	/// <remarks>
+	/// A subscriber's handler runs inside the delivery, holding whatever
+	/// <see cref="HoldDelivery"/> takes — that is what lets a checkpoint be sampled without a delivery
+	/// half-done. So a handler here must not block on anything that waits on this listener, a capture
+	/// of a model reading it, or another thread that might. Subscribe a queue rather than work.
+	/// </remarks>
 	ISubscriber EventStream { get; }
 
-	/// <summary>The version of the last event delivered from <see cref="StreamName"/>.</summary>
+	/// <summary>
+	/// The version of the last event delivered from <see cref="StreamName"/>, or 0 when none has
+	/// been. Use <see cref="Checkpoint"/> to tell those two apart.
+	/// </summary>
 	long Position { get; }
 
 	/// <summary>
@@ -14,9 +24,12 @@ public interface IListener : IDisposable {
 	/// has no stream to report.
 	/// </summary>
 	/// <remarks>
-	/// Read together deliberately. Taken separately, a version and a position can come from different
-	/// events, producing a checkpoint whose position claims an event its version says was never
-	/// applied.
+	/// <para>Read together deliberately. Taken separately, a version and a position can come from
+	/// different events, producing a checkpoint whose position claims an event its version says was
+	/// never applied.</para>
+	/// <para>Delivered means handed on, not handled: an implementation records a checkpoint only once
+	/// it has published the event, but what it publishes to is a queue, and everything downstream of
+	/// that queue is behind this.</para>
 	/// </remarks>
 	StreamCheckpoint? Checkpoint { get; }
 
@@ -26,6 +39,26 @@ public interface IListener : IDisposable {
 	/// this listener delivers replaces it.
 	/// </summary>
 	void SeedAllPosition(Position? position);
+
+	/// <summary>
+	/// Holds this listener's delivery, so that nothing is published to <see cref="EventStream"/> and
+	/// <see cref="Checkpoint"/> cannot move, until the returned handle is disposed.
+	/// </summary>
+	/// <remarks>
+	/// <para>What it excludes is a delivery <i>in progress</i>, not merely the next one. An
+	/// implementation publishes an event and then records it, so a delivery caught between the two has
+	/// already handed a subscriber an event that its checkpoint does not yet name; a reader that saw
+	/// that would take a checkpoint behind its own subscriber. Holding delivery means no such straddle
+	/// is in flight, so what has been published and what is checkpointed agree.</para>
+	/// <para>Meant to be held across a sample and whatever the sampler does with it, and no longer:
+	/// the listener's delivery thread is stopped for the duration. A caller holding several must take
+	/// them in a consistent order.</para>
+	/// <para><b>Release it on the thread that took it</b>, and so do not await while holding one — a
+	/// continuation can resume elsewhere. Releasing from another thread throws and leaves the hold
+	/// held, rather than reporting a release that did not happen.</para>
+	/// <para>Releasing twice from the owning thread is a no-op.</para>
+	/// </remarks>
+	IDisposable HoldDelivery();
 
 	string StreamName { get; }
 

--- a/src/ReactiveDomain.Foundation/IStreamReader.cs
+++ b/src/ReactiveDomain.Foundation/IStreamReader.cs
@@ -9,8 +9,10 @@ public interface IStreamReader : IDisposable {
 	long? Position { get; }
 	/// <summary>
 	/// Where this read left off: the stream, its version, and the <c>$all</c> position of the last
-	/// event read. Null when nothing was read. This is what lets a listener resuming from the read
-	/// report a checkpoint covering the history the reader already applied.
+	/// event read. Null when nothing was read — a reader reports no checkpoint at all rather than one
+	/// with no version, since a read that reached nothing has no stream to resume either. This is what
+	/// lets a listener resuming from the read report a checkpoint covering the history the reader
+	/// already applied.
 	/// </summary>
 	/// <remarks>
 	/// Read together deliberately — see <see cref="IListener.Checkpoint"/> for why the two clocks must

--- a/src/ReactiveDomain.Foundation/StreamStore/CheckpointOrder.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/CheckpointOrder.cs
@@ -1,0 +1,25 @@
+// ReSharper disable once CheckNamespace
+namespace ReactiveDomain.Foundation;
+
+/// <summary>
+/// How one set of checkpoints stands to another: the four answers a partial order can give.
+/// </summary>
+/// <remarks>
+/// Checkpoints over several streams are not totally ordered, so <see cref="Concurrent"/> is an
+/// answer and not a failure to produce one. Collapsing it into <see cref="Before"/> or
+/// <see cref="After"/> — by comparing a single projected position, say — reports an order that does
+/// not hold.
+/// </remarks>
+public enum CheckpointOrder {
+	/// <summary>Both cover exactly the same events on every stream.</summary>
+	Equal,
+
+	/// <summary>Covered by the other on every stream, and short of it on at least one.</summary>
+	Before,
+
+	/// <summary>Covers the other on every stream, and goes beyond it on at least one.</summary>
+	After,
+
+	/// <summary>Ahead on one stream and behind on another, so neither covers the other.</summary>
+	Concurrent
+}

--- a/src/ReactiveDomain.Foundation/StreamStore/QueuedStreamListener.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/QueuedStreamListener.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reactive;
 using ReactiveDomain.Messaging;
 using ReactiveDomain.Messaging.Bus;
@@ -24,20 +25,41 @@ public class QueuedStreamListener : StreamListener, IHandle<IMessage> {
 		SyncQueue = new QueuedHandler(this, "SyncListenerQueue");
 	}
 
+	// One entry per event off the store, in stream order, carrying the clocks the message itself
+	// cannot until #211 gives it an envelope. This listener has a queue of its own between the store
+	// and the model, so recording at GotEvent would checkpoint events that have not left this
+	// listener yet; the entries wait here until the queue thread reaches them.
+	private readonly ConcurrentQueue<(RecordedEvent Event, bool Published)> _delivering = new();
+
 	protected override void GotEvent(RecordedEvent recordedEvent) {
 		if (_disposed)
 			return; //todo: fix dispose
-		RecordDelivered(recordedEvent);
-		if (Serializer.Deserialize(recordedEvent) is IMessage @event) {
-			// The envelope reaches checkpoints through the listener, not the subscriber: handlers
-			// still receive the bare message. Delivering it per-event is #211's remaining half.
+		var @event = Serializer.Deserialize(recordedEvent) as IMessage;
+		// Enqueued before the publish: the queue thread must never dequeue a message whose clocks
+		// have not arrived. An event that deserializes to nothing publishable still gets an entry —
+		// it is real history, and dropping it would leave a hole the checkpoint has to skip over.
+		_delivering.Enqueue((recordedEvent, @event is not null));
+		if (@event is not null)
 			SyncQueue.Publish(@event);
-		}
 	}
 	public void Handle(IMessage @event) {
 		_running.Wait();
-		//todo: this needs to take a RecordedEvent
-		Bus.Publish(@event);
+		// Taken here rather than in GotEvent: this listener's own queue sits between the store and the
+		// subscriber, so this thread is where it delivers, and this is the publish a holder has to be
+		// able to exclude.
+		lock (DeliveryLock) {
+			//todo: this needs to take a RecordedEvent
+			Bus.Publish(@event);
+			// After the publish, so the checkpoint follows the model's queue rather than leading it.
+			// Unpublishable events ahead of this one are recorded on the way past: nothing waits behind
+			// them. A trailing run of them holds the checkpoint back until the next message, which costs
+			// a replay of events that deserialize to nothing anyway.
+			while (_delivering.TryDequeue(out var delivered)) {
+				RecordDelivered(delivered.Event);
+				if (delivered.Published)
+					break;
+			}
+		}
 
 		if (!_isLive.IsSet) {
 			Interlocked.Decrement(ref _pendingCount);

--- a/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/ReadModelBase.cs
@@ -90,26 +90,45 @@ public abstract class ReadModelBase :
 		return source;
 	}
 
+	// Captures in flight, guarded by _liveLock along with _pendingStreams: a start and a capture
+	// decide against each other, so they must decide under one lock or both can pass.
+	private int _capturing;
+
+	// Bumped whenever the outstanding streams are abandoned wholesale, so a sentinel queued before
+	// that cannot be counted against the streams started after it.
+	private int _generation;
+
 	/// <summary>
 	/// Records a stream as outstanding, arming a fresh task if none were.
 	/// Called synchronously from every Start overload, so a caller that reads
 	/// <see cref="IsLive"/> after starting cannot see the previous, completed task.
 	/// </summary>
-	private void RegisterStream() {
+	/// <exception cref="InvalidOperationException">A capture is in flight.</exception>
+	private int RegisterStream() {
 		lock (_liveLock) {
+			if (_capturing > 0) {
+				throw new InvalidOperationException(
+					$"{GetType().Name} is being captured, so a stream cannot be started: its read would " +
+					"deliver events into the model ahead of the cut being captured, and no checkpoint " +
+					"would name them. Await the capture, then start the stream.");
+			}
 			if (_pendingStreams == 0)
 				_live = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 			_pendingStreams++;
+			return _generation;
 		}
 	}
 
 	/// <summary>
 	/// Retires one outstanding stream; completes the armed task when the last one drains.
 	/// </summary>
-	private void RetireStream() {
+	private void RetireStream(int generation) {
 		TaskCompletionSource? drained = null;
 		lock (_liveLock) {
-			if (_pendingStreams == 0)
+			// A sentinel outlives the streams it was queued alongside when one of them fails, and the
+			// count it would decrement by then belongs to whatever started next. Stamping it keeps it
+			// from retiring a stream it never described.
+			if (generation != _generation || _pendingStreams == 0)
 				return;
 			if (--_pendingStreams == 0)
 				drained = _live;
@@ -130,6 +149,7 @@ public abstract class ReadModelBase :
 			if (_pendingStreams == 0)
 				return;
 			_pendingStreams = 0;
+			_generation++; // sentinels already queued describe streams that are no longer outstanding
 			armed = _live;
 		}
 		// Signalled outside the lock, as in RetireStream.
@@ -144,10 +164,10 @@ public abstract class ReadModelBase :
 	/// A body returning false did not attach a listener (the model was disposed mid-read).
 	/// </summary>
 	private void RunStart(Func<bool> start) {
-		RegisterStream();
+		var generation = RegisterStream();
 		try {
 			if (start())
-				MarkReadDrained();
+				MarkReadDrained(generation);
 			else
 				RetireAllStreams(null);
 		} catch (Exception ex) {
@@ -162,9 +182,10 @@ public abstract class ReadModelBase :
 	/// because that check reads the queue's starving flag and can see it set before the queue thread
 	/// has picked up the work just enqueued.
 	/// </summary>
-	private void MarkReadDrained() => ((IHandle<IMessage>)_queue).Handle(new ReadDrained());
+	private void MarkReadDrained(int generation) =>
+		((IHandle<IMessage>)_queue).Handle(new ReadDrained(generation));
 
-	private sealed record ReadDrained : IMessage {
+	private sealed record ReadDrained(int Generation) : IMessage {
 		public Guid MsgId { get; } = Guid.NewGuid();
 	}
 
@@ -173,11 +194,11 @@ public abstract class ReadModelBase :
 	/// the work so the registration is visible to the calling thread on return.
 	/// </summary>
 	private void RunStartAsync(Func<bool> start, CancellationToken cancelWaitToken) {
-		RegisterStream();
+		var generation = RegisterStream();
 		var readTask = Task.Run(() => {
 			try {
 				if (start())
-					MarkReadDrained();
+					MarkReadDrained(generation);
 				else
 					RetireAllStreams(null);
 			} catch (Exception ex) {
@@ -218,13 +239,148 @@ public abstract class ReadModelBase :
 	/// </summary>
 	private void DequeueMessage(IMessage message) {
 		// Not published to handlers and not counted: it is this model's own bookkeeping, not an event.
-		if (message is ReadDrained) {
-			RetireStream();
+		if (message is ReadDrained drained) {
+			RetireStream(drained.Generation);
+			return;
+		}
+		if (message is CaptureBarrier barrier) {
+			RunCapture(barrier);
 			return;
 		}
 		lock (ReaderLock) {
 			_bus.Handle(message);
 			Version++;
+		}
+	}
+
+	private readonly List<CaptureBarrier> _captures = [];
+
+	/// <summary>
+	/// Carries the checkpoints sampled where it was enqueued, so that reaching it on the queue is
+	/// proof that they describe what has been applied.
+	/// </summary>
+	private sealed class CaptureBarrier : IMessage {
+		public Guid MsgId { get; } = Guid.NewGuid();
+		public required IReadOnlyList<StreamCheckpoint> Checkpoints { get; init; }
+		public required Action<IReadOnlyList<StreamCheckpoint>> Complete { get; init; }
+		public required Action<Exception?> Abandon { get; init; }
+	}
+
+	/// <summary>
+	/// Reads this model at a cut: <paramref name="read"/> runs against the exact state the supplied
+	/// checkpoints describe, with nothing applied that they do not name.
+	/// </summary>
+	/// <param name="read">
+	/// Reads the model's state. Runs on the queue thread under <see cref="ReaderLock"/> at the point
+	/// the checkpoints describe, so it must not block, start a stream, or wait on this model.
+	/// </param>
+	/// <returns>Whatever <paramref name="read"/> returned, once the cut has been reached.</returns>
+	/// <exception cref="InvalidOperationException">A stream is still reading, so there is no cut yet.</exception>
+	/// <remarks>
+	/// <para>Every listener's delivery is held while the checkpoints are sampled and a barrier is
+	/// enqueued, so nothing can be published in between: everything the sample names is already ahead
+	/// of the barrier, and nothing past the sample is. Reaching the barrier on the queue is therefore
+	/// proof that exactly the sampled events have been applied. The hold spans two operations, not the
+	/// wait — the queue drains afterwards, on its own.</para>
+	/// <para>The returned task is cancelled if the model is disposed before the barrier is reached.
+	/// Calling this from a handler and blocking on the result would deadlock: the barrier is behind
+	/// the message being handled, on the thread that is waiting.</para>
+	/// <para>Starting a stream is refused while a cut is being taken, and taking one is refused while
+	/// a stream is still reading: a read in flight publishes through this model's own
+	/// <see cref="Handle(IMessage)"/> rather than through a listener, so its events would be in the
+	/// state with no checkpoint naming them.</para>
+	/// </remarks>
+	protected Task<T> ReadAtConsistentCut<T>(Func<IReadOnlyList<StreamCheckpoint>, T> read) {
+		Ensure.NotNull(read, nameof(read));
+		var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		// Checked and claimed together, so a start cannot slip between them.
+		lock (_liveLock) {
+			if (_pendingStreams > 0) {
+				throw new InvalidOperationException(
+					$"{GetType().Name} has a stream still reading, so there is no cut to capture yet. " +
+					"Await IsLive first.");
+			}
+			_capturing++;
+		}
+
+		IListener[] listeners;
+		lock (_listeners) {
+			listeners = _listeners.ToArray();
+		}
+
+		var holds = new List<IDisposable>(listeners.Length);
+		CaptureBarrier? pending = null;
+		try {
+			// In list order, and nothing else takes more than one, so no two callers can take them in
+			// opposite orders.
+			foreach (var listener in listeners) {
+				holds.Add(listener.HoldDelivery());
+			}
+			var barrier = new CaptureBarrier {
+				Checkpoints = listeners.Select(l => l.Checkpoint).OfType<StreamCheckpoint>().ToList(),
+				Complete = checkpoints => completion.TrySetResult(read(checkpoints)),
+				Abandon = error => {
+					if (error is null) { completion.TrySetCanceled(); } else { completion.TrySetException(error); }
+				}
+			};
+			lock (_captures) {
+				_captures.Add(pending = barrier);
+			}
+			((IHandle<IMessage>)_queue).Handle(barrier);
+		} catch {
+			// Exactly one path releases the capture, and it is whoever takes the barrier off the list.
+			// Nothing can have taken it if it never went on.
+			if (pending is null || Claim(pending))
+				ReleaseCapture();
+			throw;
+		} finally {
+			for (var i = holds.Count - 1; i >= 0; i--) {
+				holds[i].Dispose();
+			}
+		}
+		// A queue already stopped, or on its way there, will never dequeue the barrier.
+		if (_closing)
+			AbandonCaptures(null);
+		return completion.Task;
+	}
+
+	private bool Claim(CaptureBarrier barrier) {
+		lock (_captures) {
+			return _captures.Remove(barrier);
+		}
+	}
+
+	// Taken under _liveLock alone and never nested inside _captures, so the two have no order to get
+	// wrong.
+	private void ReleaseCapture() {
+		lock (_liveLock) {
+			_capturing--;
+		}
+	}
+
+	private void RunCapture(CaptureBarrier barrier) {
+		if (!Claim(barrier))
+			return; // already abandoned
+		ReleaseCapture();
+		try {
+			lock (ReaderLock) {
+				barrier.Complete(barrier.Checkpoints);
+			}
+		} catch (Exception ex) {
+			barrier.Abandon(ex);
+		}
+	}
+
+	private void AbandonCaptures(Exception? error) {
+		CaptureBarrier[] outstanding;
+		lock (_captures) {
+			outstanding = _captures.ToArray();
+			_captures.Clear();
+		}
+		foreach (var barrier in outstanding) {
+			ReleaseCapture();
+			barrier.Abandon(error);
 		}
 	}
 
@@ -244,11 +400,21 @@ public abstract class ReadModelBase :
 		return l;
 	}
 
-	/// <summary>How far this model has applied each stream it listens to.</summary>
+	/// <summary>How far each stream this model listens to has been delivered to it.</summary>
 	/// <returns>One checkpoint per started listener.</returns>
 	/// <remarks>
-	/// <see cref="StreamCheckpoint.Position"/> is null for any stream whose last delivered event
-	/// carried no <c>$all</c> position, which is what a store that does not report one produces.
+	/// <para><b>Delivered, not applied.</b> A listener records an event once it has handed it to this
+	/// model's queue, so under live traffic this runs ahead of the state the handlers have built, by
+	/// whatever is still queued. The error is one-directional and it is the dangerous direction:
+	/// anything that pairs these checkpoints with a reading of the model claims events the handlers
+	/// have not run yet. Read the two together with <see cref="ReadAtConsistentCut{T}"/>, or take
+	/// both where nothing is in flight — after <see cref="IsLive"/> on a model whose streams are
+	/// quiet, or once <see cref="Idle"/> holds and stays held. Pairing them per event needs the
+	/// checkpoint to travel with the message
+	/// (<a href="https://github.com/ReactiveDomain/reactive-domain/issues/211">#211</a>).</para>
+	/// <para><see cref="StreamCheckpoint.Version"/> is null for a stream that has delivered nothing,
+	/// and <see cref="StreamCheckpoint.Position"/> is null for any stream whose last delivered event
+	/// carried no <c>$all</c> position, which is what a store that does not report one produces.</para>
 	/// </remarks>
 	public List<StreamCheckpoint> GetCheckpoint() {
 		lock (_listeners) {
@@ -260,45 +426,70 @@ public abstract class ReadModelBase :
 
 	/// <summary>
 	/// The furthest into the store's <c>$all</c> log this model has reached — the greatest position
-	/// among the last events applied from its streams.
+	/// among the last events delivered from its streams.
 	/// </summary>
 	/// <remarks>
 	/// <para><b>Not a completeness claim.</b> The model only ever saw events on its own streams, so it
 	/// has not seen everything below this position. To gate a read on freshness use
 	/// <see cref="LowestAppliedPosition"/>.</para>
-	/// <para>Null when the model has no listeners, or when any one of them reports no position —
-	/// projecting over the rest would silently overstate.</para>
+	/// <para>Sources reporting no position are skipped rather than suppressing the answer: a greatest
+	/// position over some of them is still a position this model reached, and leaving one out can only
+	/// understate the reach. Null when no source reports one at all.</para>
+	/// <para>Delivered, not applied — see <see cref="GetCheckpoint"/>.</para>
+	/// <para><b>Not a way to compare models.</b> See <see cref="LowestAppliedPosition"/>.</para>
 	/// </remarks>
-	public Position? HighWaterMark => ProjectAllPositions(takeGreatest: true);
+	public Position? HighWaterMark {
+		get {
+			lock (_listeners) {
+				Position? furthest = null;
+				foreach (var listener in _listeners) {
+					if (listener.Checkpoint?.Position is not { } position)
+						continue;
+					if (furthest is not { } current || position > current)
+						furthest = position;
+				}
+				return furthest;
+			}
+		}
+	}
 
 	/// <summary>
-	/// The position through which every one of this model's streams has been applied — the least
-	/// position among the last events applied from them.
+	/// The position through which every one of this model's streams has been delivered — the least
+	/// position among the last events delivered from them.
 	/// </summary>
 	/// <remarks>
-	/// <para>This is the honest freshness signal: everything each source had delivered up to here has
-	/// been handled. Compare against it to gate a read.</para>
-	/// <para>Null when the model has no listeners, or when any one of them reports no position —
-	/// projecting over the rest would silently understate which sources are covered.</para>
+	/// <para>This is the freshness signal to gate a read on: every source has handed over everything it
+	/// had up to here.</para>
+	/// <para>Null when the model has no listeners, or when any one of them reports no position. Unlike
+	/// <see cref="HighWaterMark"/> this one cannot skip a source: a least position over some of them
+	/// claims coverage for the ones left out, which is the overstatement this signal exists to
+	/// avoid.</para>
+	/// <para>Delivered, not applied — see <see cref="GetCheckpoint"/>. This is a lower bound on reach,
+	/// not proof of application, so a reader gated on it can still be one queue depth early.</para>
+	/// <para><b>A freshness reading, not a state comparison.</b> Two models that have applied the very
+	/// same events report different watermarks when they read them by different routes: a projected
+	/// stream's link entry sits at its own place in <c>$all</c>, later than the event it points at, so
+	/// a category-fed model reports a greater position than a stream-fed one at the identical state.
+	/// The skew is small and bounded, which is why this still answers "how far behind is this model",
+	/// but equal watermarks are not equal states and a greater one is not a later one. To order what a
+	/// model has applied, compare the checkpoints — <see cref="StreamCheckpoint.Compare"/>, which is
+	/// per stream and can say <see cref="CheckpointOrder.Concurrent"/> where a single position cannot.
+	/// </para>
 	/// </remarks>
-	public Position? LowestAppliedPosition => ProjectAllPositions(takeGreatest: false);
-
-	private Position? ProjectAllPositions(bool takeGreatest) {
-		lock (_listeners) {
-			if (_listeners.Count == 0)
-				return null;
-			Position? projected = null;
-			foreach (var listener in _listeners) {
-				if (listener.Checkpoint?.Position is not { } position)
+	public Position? LowestAppliedPosition {
+		get {
+			lock (_listeners) {
+				if (_listeners.Count == 0)
 					return null;
-				if (projected is not { } current) {
-					projected = position;
-					continue;
+				Position? nearest = null;
+				foreach (var listener in _listeners) {
+					if (listener.Checkpoint?.Position is not { } position)
+						return null;
+					if (nearest is not { } current || position < current)
+						nearest = position;
 				}
-				if (takeGreatest ? position > current : position < current)
-					projected = position;
+				return nearest;
 			}
-			return projected;
 		}
 	}
 
@@ -491,6 +682,7 @@ public abstract class ReadModelBase :
 	}
 
 	private bool _disposed;
+	private volatile bool _closing;
 
 	/// <summary>
 	/// Stops message intake and processing: disposes the listeners, then joins the queue
@@ -499,6 +691,9 @@ public abstract class ReadModelBase :
 	/// disposed. Idempotent.
 	/// </summary>
 	private void StopMessagePump() {
+		// Set before anything is torn down, so a capture registered at any point from here on abandons
+		// itself. Until now this held only because Dispose happens to run this method twice.
+		_closing = true;
 		lock (_listeners) {
 			_listeners.ForEach(l => l.Dispose());
 		}
@@ -507,6 +702,9 @@ public abstract class ReadModelBase :
 		// The queue is stopped, so a sentinel still in it will never be dequeued; release anyone
 		// awaiting IsLive rather than leave them on a stream that can no longer drain.
 		RetireAllStreams(null);
+		// Same for a capture waiting on a marker that can no longer arrive. After the listeners are
+		// disposed, so a hold this releases cannot be retaken.
+		AbandonCaptures(null);
 	}
 
 	protected virtual void Dispose(bool disposing) {
@@ -525,7 +723,7 @@ public abstract class ReadModelBase :
 	/// is respected and bypasses both the queue and listeners. This is primarily useful in tests.
 	/// </summary>
 	/// <param name="message">The message to apply.</param>
-	public void DirectApply(IMessage message) {
+	public virtual void DirectApply(IMessage message) {
 		DequeueMessage(message);
 	}
 
@@ -543,7 +741,7 @@ public abstract class ReadModelBase :
 	/// is respected. All messages will be processed in order from the queue thread.
 	/// </summary>
 	/// <param name="message">The message to publish.</param>
-	public void Publish(IMessage message) {
+	public virtual void Publish(IMessage message) {
 		((IPublisher)_queue).Publish(message);
 	}
 }

--- a/src/ReactiveDomain.Foundation/StreamStore/ReadModelState.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/ReadModelState.cs
@@ -3,12 +3,18 @@
 // ReSharper disable once CheckNamespace
 namespace ReactiveDomain.Foundation;
 
+/// <summary>
+/// A read model's state and the checkpoints it was taken at. Persisting one is the caller's job:
+/// nothing here serializes itself.
+/// </summary>
 public class ReadModelState {
 	public readonly string ModelName;
 
 	/// <summary>
 	/// Checkpoints for the streams the model reads itself. <see cref="SnapshotReadModel.Restore"/>
-	/// starts a listener for each of these, resuming from its <see cref="StreamCheckpoint.Version"/>.
+	/// starts a listener for each of these, resuming after its <see cref="StreamCheckpoint.Version"/>
+	/// — or from the beginning of the stream when that is null, which is what is recorded by a stream that had
+	/// delivered nothing when the snapshot was taken.
 	/// </summary>
 	public readonly List<StreamCheckpoint>? Checkpoints;
 
@@ -21,6 +27,26 @@ public class ReadModelState {
 	public readonly List<StreamCheckpoint>? ExternalCheckpoints;
 
 	public readonly object State;
+
+	/// <summary>
+	/// How the events built into this snapshot stand to those built into another: whether it is the
+	/// same, earlier, later, or neither.
+	/// </summary>
+	/// <param name="other">The snapshot to compare against.</param>
+	/// <remarks>
+	/// <para>Spans <see cref="Checkpoints"/> and <see cref="ExternalCheckpoints"/> together — a relay
+	/// having fed more of a stream is later, however the stream reached the model.</para>
+	/// <para>Meaningful between snapshots of one model. See <see cref="StreamCheckpoint.Compare"/> for
+	/// why comparing two different models' snapshots is not, and why the answer can be
+	/// <see cref="CheckpointOrder.Concurrent"/>.</para>
+	/// </remarks>
+	public CheckpointOrder Compare(ReadModelState other) {
+		Ensure.NotNull(other, nameof(other));
+		return StreamCheckpoint.Compare(Covered(this), Covered(other));
+
+		static IEnumerable<StreamCheckpoint> Covered(ReadModelState state) =>
+			(state.Checkpoints ?? []).Concat(state.ExternalCheckpoints ?? []);
+	}
 
 	public ReadModelState(
 		string modelName,

--- a/src/ReactiveDomain.Foundation/StreamStore/SnapshotReadModel.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/SnapshotReadModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using ReactiveDomain.Messaging;
 using ReactiveDomain.Util;
 
 // ReSharper disable once CheckNamespace
@@ -46,10 +47,17 @@ public abstract class SnapshotReadModel : ReadModelBase {
 			}
 		}
 		ApplyState(StartingState);
+		// ApplyState is the one place DirectApply is expected: rebuilding state from a snapshot is not
+		// input from outside, it is the snapshot's own, and the checkpoints restored alongside it
+		// describe exactly that. Anything applied after this is unaccounted for again.
+		MarkInputReplayable();
 		if (!startListeners || StartingState.Checkpoints == null)
 			return;
 
 		foreach (var stream in StartingState.Checkpoints) {
+			// A null version passes straight through as "no checkpoint", which starts the stream from
+			// its first event — the only reading of a checkpoint that never delivered one that does
+			// not skip that event.
 			Start(stream.StreamName, stream.Version, block, validateStreams, cancelWaitToken);
 		}
 	}
@@ -87,6 +95,9 @@ public abstract class SnapshotReadModel : ReadModelBase {
 		lock (_externalCheckpoints) {
 			_externalCheckpoints[streamName] = new StreamCheckpoint(streamName, version, position);
 		}
+		// Input that arrived through DirectApply or Publish now has somewhere to be replayed from,
+		// which is what makes the model snapshottable again.
+		MarkInputReplayable();
 	}
 
 	/// <summary>
@@ -103,7 +114,91 @@ public abstract class SnapshotReadModel : ReadModelBase {
 
 	protected abstract void ApplyState(ReadModelState snapshot);
 
+	/// <summary>
+	/// The model's state and checkpoints, read on the calling thread.
+	/// </summary>
+	/// <remarks>
+	/// Under live traffic the two are read at different moments, so the checkpoints can name events the
+	/// state does not yet contain — restoring such a snapshot resumes past them and never applies them.
+	/// Use <see cref="CaptureConsistentState"/> for a snapshot to persist; this remains for reading a
+	/// model that is quiet, and for supplying the state that capture pairs with a checkpoint.
+	/// </remarks>
 	public abstract ReadModelState GetState();
+
+	/// <summary>
+	/// Captures a snapshot whose checkpoints describe exactly the events built into its state.
+	/// </summary>
+	/// <returns>
+	/// <see cref="GetState"/>'s result with its <see cref="ReadModelState.Checkpoints"/> replaced by the
+	/// ones true at the point the state was read. Cancelled if the model is disposed while capturing.
+	/// </returns>
+	/// <exception cref="InvalidOperationException">
+	/// The model has input no checkpoint accounts for — see <see cref="HasUnreplayableInput"/>.
+	/// </exception>
+	/// <remarks>
+	/// <see cref="GetState"/> runs on the queue thread, so an implementation of it must not block or
+	/// wait on this model. The checkpoints it collects itself are discarded in favour of the captured
+	/// ones; everything else it returns is kept.
+	/// </remarks>
+	public Task<ReadModelState> CaptureConsistentState() {
+		if (HasUnreplayableInput) {
+			throw new InvalidOperationException(
+				$"{GetType().Name} has had messages applied through DirectApply or Publish that no " +
+				"checkpoint accounts for, so a snapshot of it could not be restored. A model fed from " +
+				"outside its own listeners must record where that input came from — see " +
+				$"{nameof(SetExternalCheckpoint)}.");
+		}
+		return ReadAtConsistentCut(checkpoints => {
+			var state = GetState();
+			return new ReadModelState(
+				state.ModelName,
+				checkpoints.ToList(),
+				state.State,
+				state.ExternalCheckpoints);
+		});
+	}
+
+	/// <summary>
+	/// True once a message has reached this model through <see cref="DirectApply"/> or
+	/// <see cref="Publish"/> without anything recording where it came from, which makes the model's
+	/// state unreachable by replay and so unsafe to snapshot.
+	/// </summary>
+	/// <remarks>
+	/// <para>A checkpoint describes what the model's listeners delivered. Input from anywhere else is
+	/// in the state and in no checkpoint, so restoring would silently produce a different model — not
+	/// a stale one, a wrong one. <see cref="CaptureConsistentState"/> refuses rather than hand back a
+	/// snapshot with that in it.</para>
+	/// <para>Cleared by <see cref="SetExternalCheckpoint"/>: a relay that says where its input came
+	/// from has made it replayable, which is the whole point of an external checkpoint. A model that
+	/// feeds itself and records nothing stays unsnapshottable, which is correct.</para>
+	/// </remarks>
+	public bool HasUnreplayableInput { get; private set; }
+
+	/// <summary>
+	/// Records that input reaching this model from outside its listeners has been accounted for, and
+	/// can be replayed from what the next snapshot will carry.
+	/// </summary>
+	protected void MarkInputReplayable() => HasUnreplayableInput = false;
+
+	/// <inheritdoc cref="ReadModelBase.DirectApply"/>
+	/// <remarks>
+	/// No listener saw this, so no checkpoint will describe it: this sets
+	/// <see cref="HasUnreplayableInput"/> until something records where the message came from.
+	/// </remarks>
+	public override void DirectApply(IMessage message) {
+		HasUnreplayableInput = true;
+		base.DirectApply(message);
+	}
+
+	/// <inheritdoc cref="ReadModelBase.Publish"/>
+	/// <remarks>
+	/// No listener saw this, so no checkpoint will describe it: this sets
+	/// <see cref="HasUnreplayableInput"/> until something records where the message came from.
+	/// </remarks>
+	public override void Publish(IMessage message) {
+		HasUnreplayableInput = true;
+		base.Publish(message);
+	}
 
 	private bool _disposed;
 	protected override void Dispose(bool disposing) {

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamCheckpoint.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamCheckpoint.cs
@@ -4,8 +4,8 @@
 namespace ReactiveDomain.Foundation;
 
 /// <summary>
-/// How far a read model has applied one stream: the stream's own version, and where that event sits
-/// in the store's global <c>$all</c> log.
+/// How far a stream has been delivered to a read model: the stream's own version, and where that
+/// event sits in the store's global <c>$all</c> log.
 /// </summary>
 /// <remarks>
 /// <para>The two are different clocks and answer different questions. <see cref="Version"/> is dense
@@ -15,27 +15,98 @@ namespace ReactiveDomain.Foundation;
 /// versions are not.</para>
 /// <para><see cref="Position"/> is null when the store does not report one, and is meaningful only
 /// within the store that issued it. Positions from two stores have no defined ordering.</para>
+/// <para><b>Delivered, not applied.</b> A checkpoint is recorded when an event is handed to the
+/// model's queue, which is ahead of where its handlers have run — see
+/// <see cref="ReadModelBase.GetCheckpoint"/> for what that costs a snapshot.</para>
 /// </remarks>
 public sealed record StreamCheckpoint {
 	/// <summary>The stream this checkpoint is for.</summary>
 	public string StreamName { get; }
 
-	/// <summary>The version of the last event applied from that stream.</summary>
-	public long Version { get; }
+	/// <summary>
+	/// The version of the last event delivered from that stream, or null when none has been: a
+	/// stream that is being listened to but has produced nothing yet.
+	/// </summary>
+	/// <remarks>
+	/// Null and 0 are not interchangeable. A version resumes a subscription <i>after</i> it, so
+	/// restoring a stream whose first event was never delivered from version 0 would skip that
+	/// event. Null resumes from the beginning of the stream, which is what such a checkpoint means.
+	/// </remarks>
+	public long? Version { get; }
 
 	/// <summary>
-	/// The <c>$all</c> position of the last event applied from that stream, when the store reports one.
+	/// The <c>$all</c> position of the last event delivered from that stream, when the store reports one.
 	/// </summary>
 	public Position? Position { get; }
 
-	/// <summary>Records how far a stream has been applied.</summary>
+	/// <summary>Records how far a stream has been delivered.</summary>
 	/// <param name="streamName">The stream this checkpoint is for.</param>
-	/// <param name="version">The version of the last event applied from that stream.</param>
+	/// <param name="version">The version of the last event delivered from that stream, or null when
+	/// none has been.</param>
 	/// <param name="position">That event's <c>$all</c> position, when the store reports one.</param>
-	public StreamCheckpoint(string streamName, long version, Position? position = null) {
+	public StreamCheckpoint(string streamName, long? version, Position? position = null) {
 		Ensure.NotNullOrEmpty(streamName, nameof(streamName));
 		StreamName = streamName;
 		Version = version;
 		Position = position;
+	}
+
+	// Before every version, including 0, which is what a stream that has delivered nothing covers.
+	private const long Nothing = -1;
+
+	/// <summary>
+	/// How the events covered by one set of checkpoints stand to those covered by another.
+	/// </summary>
+	/// <param name="first">A set of checkpoints. Null and empty both cover nothing.</param>
+	/// <param name="second">The set to compare it against.</param>
+	/// <remarks>
+	/// <para>Compared per stream and combined, never through a single projected number. Ahead on one
+	/// stream and behind on another is <see cref="CheckpointOrder.Concurrent"/>, which a scalar cannot
+	/// express — see <see cref="ReadModelBase.LowestAppliedPosition"/> for what those are and are not
+	/// for.</para>
+	/// <para><see cref="Version"/> is the only clock this reads. Within a stream it and
+	/// <see cref="Position"/> order alike, and versions are dense where positions are not, so a
+	/// checkpoint without a position compares as well as one with.</para>
+	/// <para>A stream in one set and not the other counts as covering nothing there, so a model that
+	/// starts another stream moves strictly forward rather than becoming incomparable. That also means
+	/// this answers about the checkpoints handed to it, not about the models they came from:
+	/// comparing snapshots of two <i>different</i> models is arithmetic on unrelated streams, and the
+	/// answer means nothing even when it is not <see cref="CheckpointOrder.Concurrent"/>.</para>
+	/// </remarks>
+	public static CheckpointOrder Compare(
+		IEnumerable<StreamCheckpoint>? first,
+		IEnumerable<StreamCheckpoint>? second) {
+		var left = Covered(first);
+		var right = Covered(second);
+		var behind = false;
+		var ahead = false;
+		foreach (var stream in left.Keys.Union(right.Keys)) {
+			var l = left.GetValueOrDefault(stream, Nothing);
+			var r = right.GetValueOrDefault(stream, Nothing);
+			if (l < r) { behind = true; } else if (l > r) { ahead = true; }
+		}
+		return (behind, ahead) switch {
+			(false, false) => CheckpointOrder.Equal,
+			(true, false) => CheckpointOrder.Before,
+			(false, true) => CheckpointOrder.After,
+			_ => CheckpointOrder.Concurrent
+		};
+	}
+
+	/// <summary>
+	/// The version each stream is covered through. Two checkpoints for one stream would be a caller's
+	/// mistake; the further of them is taken rather than whichever was enumerated last.
+	/// </summary>
+	private static Dictionary<string, long> Covered(IEnumerable<StreamCheckpoint>? checkpoints) {
+		var covered = new Dictionary<string, long>(StringComparer.Ordinal);
+		if (checkpoints is null)
+			return covered;
+		foreach (var checkpoint in checkpoints) {
+			var version = checkpoint.Version ?? Nothing;
+			covered[checkpoint.StreamName] = covered.TryGetValue(checkpoint.StreamName, out var seen)
+				? Math.Max(seen, version)
+				: version;
+		}
+		return covered;
 	}
 }

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamListener.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamListener.cs
@@ -38,6 +38,11 @@ public class StreamListener : IListener {
 	private readonly object _checkpointLock = new();
 	private Position? _allPosition;
 
+	// False while StreamPosition still holds its seed rather than a version anything reached: a
+	// listener started on a stream with no events on it. Zero cannot say that — see
+	// StreamCheckpoint.Version.
+	private bool _versioned;
+
 	/// <inheritdoc cref="IListener.Checkpoint"/>
 	public StreamCheckpoint? Checkpoint {
 		get {
@@ -46,7 +51,10 @@ public class StreamListener : IListener {
 				// version and position hold seed values that belong to nothing yet.
 				return string.IsNullOrEmpty(StreamName)
 					? null
-					: new StreamCheckpoint(StreamName, Interlocked.Read(ref StreamPosition), _allPosition);
+					: new StreamCheckpoint(
+						StreamName,
+						_versioned ? Interlocked.Read(ref StreamPosition) : null,
+						_allPosition);
 			}
 		}
 	}
@@ -56,21 +64,66 @@ public class StreamListener : IListener {
 	/// under one lock, so a reader cannot see a version from one event beside a position from another.
 	/// </summary>
 	/// <remarks>
-	/// The position is assigned unconditionally, so a store that stops reporting positions leaves this
-	/// null rather than stale — it belongs to the last event delivered, not to the last one that
-	/// happened to carry one.
+	/// <para>Call this <b>after</b> handing the event on, never before: until the publish returns, the
+	/// event is in no queue, and a checkpoint naming it would claim an event nothing downstream can
+	/// still reach.</para>
+	/// <para>The position is assigned unconditionally, so a store that stops reporting positions leaves
+	/// this null rather than stale — it belongs to the last event delivered, not to the last one that
+	/// happened to carry one.</para>
 	/// </remarks>
 	/// <param name="recordedEvent">The event just delivered.</param>
 	protected void RecordDelivered(RecordedEvent recordedEvent) {
 		lock (_checkpointLock) {
 			Interlocked.Exchange(ref StreamPosition, recordedEvent.EventNumber);
 			_allPosition = recordedEvent.Position;
+			_versioned = true;
 		}
 	}
 
 	/// <inheritdoc cref="IListener.SeedAllPosition"/>
 	public void SeedAllPosition(Position? position) {
 		lock (_checkpointLock) { _allPosition = position; }
+	}
+
+	/// <summary>
+	/// Serializes publishing an event with recording it. The store already delivers to one
+	/// subscription sequentially, so in the steady state this is uncontended: it exists so that a
+	/// holder can be sure no delivery is caught between its publish and its record, where the
+	/// checkpoint does not yet name an event a subscriber already has.
+	/// </summary>
+	protected readonly object DeliveryLock = new();
+
+	/// <inheritdoc cref="IListener.HoldDelivery"/>
+	public IDisposable HoldDelivery() => new DeliveryHold(this);
+
+	/// <summary>A held delivery lock, released once, by the thread that took it.</summary>
+	/// <remarks>
+	/// Deliberately not a <see cref="Disposer"/>. That swallows whatever its dispose function throws,
+	/// so a release from the wrong thread would report success and leave delivery held for the life of
+	/// the listener — the one failure here that nothing downstream could detect.
+	/// </remarks>
+	private sealed class DeliveryHold : IDisposable {
+		private readonly object _lock;
+		private readonly int _heldBy = Environment.CurrentManagedThreadId;
+		private bool _released;
+
+		public DeliveryHold(StreamListener listener) {
+			_lock = listener.DeliveryLock;
+			Monitor.Enter(_lock);
+		}
+
+		public void Dispose() {
+			if (_released)
+				return;
+			if (Environment.CurrentManagedThreadId != _heldBy) {
+				throw new SynchronizationLockException(
+					$"A delivery hold must be released by the thread that took it ({_heldBy}), and this is " +
+					$"thread {Environment.CurrentManagedThreadId}. The hold is still held.");
+			}
+			// Flagged after the release, so a throw leaves the hold usable rather than spent.
+			Monitor.Exit(_lock);
+			_released = true;
+		}
 	}
 	public string StreamName { get; private set; } = string.Empty;
 	public CatchUpSubscriptionSettings Settings { get; set; }
@@ -201,14 +254,22 @@ public class StreamListener : IListener {
 				throw new InvalidOperationException("Listener already started.");
 			if (validateStream && !ValidateStreamName(streamName))
 				throw new ArgumentException("Stream not found.", streamName);
-			StreamName = streamName;
+			// Not named here: SubscribeToStreamFrom names it under the checkpoint lock, together with
+			// the version it goes with. Naming it first publishes a listener that reports no version
+			// for a stream being resumed at a real one.
 			_subscription =
 				SubscribeToStreamFrom(
 					streamName,
 					checkpoint,
 					eventAppeared: GotEvent,
 					liveProcessingStarted: () => {
-						Bus.Publish(new StreamStoreMsgs.CatchupSubscriptionBecameLive());
+						// Under the delivery lock like an event, because it reaches subscribers the same
+						// way and is counted the same way. Published outside it, it could land in a
+						// subscriber's queue while a holder believed delivery was stopped — no checkpoint
+						// names it, so a model that handles it would hold state its checkpoints disown.
+						lock (DeliveryLock) {
+							Bus.Publish(new StreamStoreMsgs.CatchupSubscriptionBecameLive());
+						}
 						_liveLock.Set();
 						_liveProcessingStarted?.Invoke(Unit.Default);
 					});
@@ -229,7 +290,10 @@ public class StreamListener : IListener {
 		// reader must not see the name before the version it goes with.
 		lock (_checkpointLock) {
 			StreamName = stream;
+			// A resume point is a version this stream reached; the zero standing in for "no resume
+			// point" is not, and must not be checkpointed as one.
 			Interlocked.Exchange(ref StreamPosition, lastCheckpoint ?? 0);
+			_versioned = lastCheckpoint.HasValue;
 		}
 		var sub = _streamStoreConnection.SubscribeToStreamFrom(
 			stream,
@@ -259,9 +323,15 @@ public class StreamListener : IListener {
 	}
 
 	protected virtual void GotEvent(RecordedEvent recordedEvent) {
-		RecordDelivered(recordedEvent);
-		if (Serializer.Deserialize(recordedEvent) is IMessage @event) {
-			Bus.Publish(@event);
+		lock (DeliveryLock) {
+			if (Serializer.Deserialize(recordedEvent) is IMessage @event) {
+				Bus.Publish(@event);
+			}
+			// After the publish, and under the same lock. The bus hands the event to the subscriber's
+			// queue synchronously, so once this runs the event is queued; recording first left a window
+			// where the checkpoint named an event that had not been handed on at all, and recording
+			// outside the lock leaves one where a subscriber has an event the checkpoint disowns.
+			RecordDelivered(recordedEvent);
 		}
 	}
 

--- a/src/ReactiveDomain.Foundation/TransientSubscriber.cs
+++ b/src/ReactiveDomain.Foundation/TransientSubscriber.cs
@@ -71,7 +71,7 @@ public abstract class TransientSubscriber : IMessageRegistry, IDisposable {
 	/// </remarks>
 	private IHandle<T> Serialized<T>(IHandle<T> handler) where T : class, IMessage {
 		lock (_wrappers) {
-			if (Existing<T>(handler) is SerializedHandler<T> existing)
+			if (Existing<T, SerializedHandler<T>>(handler) is { } existing)
 				return existing;
 			var wrapper = new SerializedHandler<T>(this, handler);
 			// An event subscription takes the bus's default, which routes the derived types too.
@@ -82,7 +82,7 @@ public abstract class TransientSubscriber : IMessageRegistry, IDisposable {
 
 	private IHandleCommand<T> Serialized<T>(IHandleCommand<T> handler) where T : Command {
 		lock (_wrappers) {
-			if (Existing<T>(handler) is SerializedCommandHandler<T> existing)
+			if (Existing<T, SerializedCommandHandler<T>>(handler) is { } existing)
 				return existing;
 			var wrapper = new SerializedCommandHandler<T>(this, handler);
 			// A command subscription is registered for its exact type: one handler per command.
@@ -91,11 +91,23 @@ public abstract class TransientSubscriber : IMessageRegistry, IDisposable {
 		}
 	}
 
-	/// <remarks>Callers hold <c>_wrappers</c>.</remarks>
-	private object? Existing<T>(object handler) {
+	/// <summary>
+	/// The wrapper of the wanted kind for this handler and message type, if one was already made.
+	/// </summary>
+	/// <remarks>
+	/// Matched on kind as well as on handler and type: one object can be both an
+	/// <see cref="IHandle{T}"/> and an <see cref="IHandleCommand{T}"/> of the same message, and the
+	/// two need a wrapper each. Matching without the kind returns whichever was registered first, so
+	/// the second sort never finds its own and makes a new one on every subscription.
+	/// <para>Callers hold <c>_wrappers</c>.</para>
+	/// </remarks>
+	private TWrapper? Existing<T, TWrapper>(object handler) where TWrapper : class {
 		foreach (var entry in _wrappers)
-			if (ReferenceEquals(entry.Handler, handler) && entry.MessageType == typeof(T))
-				return entry.Wrapper;
+			if (ReferenceEquals(entry.Handler, handler) &&
+				entry.MessageType == typeof(T) &&
+				entry.Wrapper is TWrapper wrapper) {
+				return wrapper;
+			}
 		return null;
 	}
 

--- a/src/ReactiveDomain.Persistence/Position.cs
+++ b/src/ReactiveDomain.Persistence/Position.cs
@@ -4,7 +4,13 @@
 /// A structure referring to a potential logical record position in the Store Main transaction file.
 /// While this is based on the Event Store implementation, keep in mind not all stores use the prepare position.
 /// </summary>
-public struct Position {
+/// <remarks>
+/// Ordered as the store orders them, which is unsigned. The components are carried in a signed
+/// <see cref="long"/>, so <see cref="End"/>'s -1 is the same bit pattern as the store's largest
+/// position — and that is how it round-trips through the connection wrappers. Compared as signed it
+/// would sort below <see cref="Start"/>, putting the end of the log before the beginning of it.
+/// </remarks>
+public struct Position : IEquatable<Position>, IComparable<Position>, IComparable {
 	/// <summary>
 	/// Position representing the start of the transaction file
 	/// </summary>
@@ -32,49 +38,56 @@ public struct Position {
 		PreparePosition = preparePosition;
 	}
 
+	/// <summary>
+	/// Orders two positions, unsigned, commit position first. See the note on <see cref="Position"/>
+	/// for why signed comparison puts <see cref="End"/> in the wrong place.
+	/// </summary>
+	private static int Order(Position p1, Position p2) {
+		var commit = ((ulong)p1.CommitPosition).CompareTo((ulong)p2.CommitPosition);
+		return commit != 0
+			? commit
+			: ((ulong)p1.PreparePosition).CompareTo((ulong)p2.PreparePosition);
+	}
+
 	/// <summary>Compares whether p1 &lt; p2.</summary>
 	/// <param name="p1">A <see cref="Position" />.</param>
 	/// <param name="p2">A <see cref="Position" />.</param>
 	/// <returns>True if p1 &lt; p2.</returns>
-	public static bool operator <(Position p1, Position p2) {
-		if (p1.CommitPosition < p2.CommitPosition)
-			return true;
-		if (p1.CommitPosition == p2.CommitPosition)
-			return p1.PreparePosition < p2.PreparePosition;
-		return false;
-	}
+	public static bool operator <(Position p1, Position p2) => Order(p1, p2) < 0;
 
 	/// <summary>Compares whether p1 &gt; p2.</summary>
 	/// <param name="p1">A <see cref="Position" />.</param>
 	/// <param name="p2">A <see cref="Position" />.</param>
 	/// <returns>True if p1 &gt; p2.</returns>
-	public static bool operator >(Position p1, Position p2) {
-		if (p1.CommitPosition > p2.CommitPosition)
-			return true;
-		if (p1.CommitPosition == p2.CommitPosition)
-			return p1.PreparePosition > p2.PreparePosition;
-		return false;
-	}
+	public static bool operator >(Position p1, Position p2) => Order(p1, p2) > 0;
 
 	/// <summary>Compares whether p1 &gt;= p2.</summary>
 	/// <param name="p1">A <see cref="Position" />.</param>
 	/// <param name="p2">A <see cref="Position" />.</param>
 	/// <returns>True if p1 &gt;= p2.</returns>
-	public static bool operator >=(Position p1, Position p2) {
-		if (!(p1 > p2))
-			return p1 == p2;
-		return true;
-	}
+	public static bool operator >=(Position p1, Position p2) => Order(p1, p2) >= 0;
 
 	/// <summary>Compares whether p1 &lt;= p2.</summary>
 	/// <param name="p1">A <see cref="Position" />.</param>
 	/// <param name="p2">A <see cref="Position" />.</param>
 	/// <returns>True if p1 &lt;= p2.</returns>
-	public static bool operator <=(Position p1, Position p2) {
-		if (!(p1 < p2))
-			return p1 == p2;
-		return true;
-	}
+	public static bool operator <=(Position p1, Position p2) => Order(p1, p2) <= 0;
+
+	/// <summary>Orders this position against another, so positions can be sorted.</summary>
+	/// <param name="other">The position to compare against.</param>
+	/// <returns>Negative, zero or positive as this precedes, matches or follows <paramref name="other"/>.</returns>
+	public int CompareTo(Position other) => Order(this, other);
+
+	/// <inheritdoc cref="CompareTo(Position)"/>
+	/// <param name="obj">A <see cref="Position"/>, or null, which every position follows.</param>
+	/// <exception cref="ArgumentException"><paramref name="obj"/> is not a <see cref="Position"/>.</exception>
+	public int CompareTo(object? obj) =>
+		obj switch {
+			null => 1,
+			Position other => Order(this, other),
+			_ => throw new ArgumentException($"Cannot compare a {nameof(Position)} to a {obj.GetType().Name}.",
+				nameof(obj))
+		};
 
 	/// <summary>Compares p1 and p2 for equality.</summary>
 	/// <param name="p1">A <see cref="Position" />.</param>

--- a/src/ReactiveDomain.Testing.Tests/StreamStore/when_ordering_positions.cs
+++ b/src/ReactiveDomain.Testing.Tests/StreamStore/when_ordering_positions.cs
@@ -1,0 +1,74 @@
+using ReactiveDomain;
+using Xunit;
+
+namespace ReactiveDomain.Testing.Tests.StreamStore;
+
+// Positions are unsigned in the store and carried here in a signed long, so End's -1 is the store's
+// largest position wearing a minus sign. Ordering them as signed puts the end of the log first.
+// ReSharper disable once InconsistentNaming
+public sealed class when_ordering_positions {
+	private static readonly Position Early = new(512, 512);
+	private static readonly Position Late = new(4096, 4096);
+
+	[Fact]
+	public void the_end_of_the_log_follows_the_start_of_it() {
+		Assert.True(Position.End > Position.Start);
+		Assert.False(Position.End < Position.Start);
+		Assert.True(Position.Start < Position.End);
+	}
+
+	[Fact]
+	public void the_end_of_the_log_follows_every_real_position() {
+		Assert.True(Position.End > Early);
+		Assert.True(Position.End > Late);
+		Assert.True(Late < Position.End);
+	}
+
+	[Fact]
+	public void the_start_of_the_log_precedes_every_real_position() {
+		Assert.True(Position.Start < Early);
+		Assert.True(Early > Position.Start);
+	}
+
+	[Fact]
+	public void real_positions_order_by_commit_then_prepare() {
+		Assert.True(Early < Late);
+		Assert.True(new Position(512, 8) < new Position(512, 9));
+		Assert.True(new Position(512, 9) > new Position(512, 8));
+	}
+
+	[Fact]
+	public void a_position_is_neither_before_nor_after_its_equal() {
+		var same = new Position(Early.CommitPosition, Early.PreparePosition);
+		Assert.False(Early < same);
+		Assert.False(Early > same);
+		Assert.True(Early <= same);
+		Assert.True(Early >= same);
+	}
+
+	[Fact]
+	public void positions_can_be_sorted() {
+		// Comparer<Position>.Default has nothing to work with unless Position says how it orders, so
+		// this threw rather than sorting wrongly.
+		var sorted = new List<Position> { Position.End, Late, Position.Start, Early };
+		sorted.Sort();
+
+		Assert.Equal([Position.Start, Early, Late, Position.End], sorted);
+	}
+
+	[Fact]
+	public void ordering_agrees_with_equality() {
+		Assert.Equal(0, Early.CompareTo(Early));
+		Assert.True(Early.CompareTo(Late) < 0);
+		Assert.True(Late.CompareTo(Early) > 0);
+		Assert.Equal(0, Position.End.CompareTo(Position.End));
+	}
+
+	[Fact]
+	public void the_end_sentinel_is_the_store_encoding_it_round_trips_as() {
+		// The reason ordering has to be unsigned: this is ulong.MaxValue in the wrappers' cast, which
+		// is the store's own end-of-log, not a position below zero.
+		Assert.Equal(-1L, Position.End.CommitPosition);
+		Assert.Equal(ulong.MaxValue, (ulong)Position.End.CommitPosition);
+	}
+}

--- a/src/ReactiveDomain.Testing.Tests/StreamStore/when_subscribing_to_all_from_a_position.cs
+++ b/src/ReactiveDomain.Testing.Tests/StreamStore/when_subscribing_to_all_from_a_position.cs
@@ -1,0 +1,95 @@
+using ReactiveDomain.Foundation;
+using ReactiveDomain.Messaging;
+using ReactiveDomain.Testing.EventStore;
+using Xunit;
+
+namespace ReactiveDomain.Testing.Tests.StreamStore;
+
+// A position resumes the log the way a checkpoint resumes a stream: it names what has been seen, so
+// what comes back is what follows it. Nothing exercised this before — the only caller in the tree
+// passes Position.Start, where every arithmetic error here happens to cancel out.
+// ReSharper disable once InconsistentNaming
+public class when_subscribing_to_all_from_a_position {
+	private readonly MockStreamStoreConnection _conn;
+	private readonly JsonMessageSerializer _serializer = new();
+	private readonly string _stream = $"allPositionTest-{Guid.NewGuid():N}";
+
+	public when_subscribing_to_all_from_a_position() {
+		_conn = new MockStreamStoreConnection(nameof(when_subscribing_to_all_from_a_position));
+		_conn.Connect();
+		for (var i = 0; i < 4; i++) {
+			_conn.AppendToStream(_stream, ExpectedVersion.Any, null,
+				_serializer.Serialize(new AllPositionTestEvent(i)));
+		}
+	}
+
+	private List<RecordedEvent> ReadAllFrom(Position from) {
+		var seen = new List<RecordedEvent>();
+		using (_conn.SubscribeToAllFrom(from, e => seen.Add(e))) { }
+		return seen;
+	}
+
+	private List<RecordedEvent> Everything() {
+		var seen = new List<RecordedEvent>();
+		using (_conn.SubscribeToAll(e => seen.Add(e))) { }
+		return seen;
+	}
+
+	[Fact]
+	public void the_start_of_the_log_yields_every_entry() {
+		Assert.Equal(Everything().Count, ReadAllFrom(Position.Start).Count);
+	}
+
+	[Fact]
+	public void a_position_yields_exactly_the_entries_after_it() {
+		var all = Everything();
+
+		// Every prefix, so an off-by-one anywhere in the log shows up rather than hiding at an end.
+		for (var i = 0; i < all.Count; i++) {
+			var resumed = ReadAllFrom(all[i].Position!.Value);
+			Assert.Equal(all.Count - (i + 1), resumed.Count);
+			if (resumed.Count > 0) {
+				Assert.Equal(all[i + 1].Position, resumed[0].Position);
+			}
+		}
+	}
+
+	[Fact]
+	public void the_last_position_yields_nothing() {
+		var all = Everything();
+		Assert.Empty(ReadAllFrom(all[^1].Position!.Value));
+	}
+
+	[Fact]
+	public void the_end_of_the_log_yields_nothing_already_written() {
+		Assert.Empty(ReadAllFrom(Position.End));
+	}
+
+	[Fact]
+	public void entries_come_back_in_log_order() {
+		var resumed = ReadAllFrom(Position.Start);
+		for (var i = 1; i < resumed.Count; i++) {
+			Assert.True(resumed[i].Position > resumed[i - 1].Position,
+				$"entry {i} at {resumed[i].Position} does not follow {resumed[i - 1].Position}");
+		}
+	}
+
+	[Fact]
+	public void resuming_never_skips_and_never_repeats_an_entry() {
+		var all = Everything();
+
+		// Walk the log one entry at a time, as a consumer resuming from its own checkpoint would.
+		var walked = new List<Position>();
+		var cursor = Position.Start;
+		while (true) {
+			var next = ReadAllFrom(cursor).FirstOrDefault();
+			if (next is null) { break; }
+			walked.Add(next.Position!.Value);
+			cursor = next.Position!.Value;
+		}
+
+		Assert.Equal(all.Select(e => e.Position!.Value), walked);
+	}
+
+	public record AllPositionTestEvent(int Number) : Event;
+}

--- a/src/ReactiveDomain.Testing/EventStore/MockStreamStoreConnection.cs
+++ b/src/ReactiveDomain.Testing/EventStore/MockStreamStoreConnection.cs
@@ -423,25 +423,24 @@ public sealed class MockStreamStoreConnection : IStreamStoreConnection {
 			throw new ObjectDisposedException(nameof(MockStreamStoreConnection));
 
 		lock (_readerWriterLock) {
-			var current = (int)from.CommitPosition;
-			RecordedEvent[] currentEvents = [];
+			RecordedEvent[] currentEvents;
+			long lastDelivered;
 			lock (_allStream) {
-				if (from == Position.End) {
-					current = _allStream.Count - 1;
-				}
-
-				if (current < _allStream.Count - 1) {
-					var events = new RecordedEvent[_allStream.Count - current];
-					_allStream.CopyTo(events, current);
-					currentEvents = events;
-				}
+				// Positions count from one, so the entry at position p sits at index p-1 and the next
+				// one to deliver is at index p: `from` names what the caller has already seen and is
+				// not re-delivered. Position.End asks for live traffic only, which is one past the end.
+				var start = from == Position.End ? _allStream.Count : (int)from.CommitPosition;
+				currentEvents = _allStream.Skip(Math.Clamp(start, 0, _allStream.Count)).ToArray();
+				lastDelivered = _allStream.Count;
 			}
 
 			for (int i = 0; i < currentEvents.Length; i++) {
 				eventAppeared(currentEvents[i]);
 			}
 
-			var subscription = new AllStreamSubscription(current, subscriptionDropped, eventAppeared);
+			// Seeded with what the catch-up delivered, so a live event already replayed above is not
+			// handed over a second time.
+			var subscription = new AllStreamSubscription(lastDelivered, subscriptionDropped, eventAppeared);
 			subscription.BusSubscription = _inboundEventBus.Subscribe(subscription);
 			_subscriptions.Add(subscription);
 			liveProcessingStarted?.Invoke();

--- a/src/ReactiveDomain.Testing/Specifications/NullListener.cs
+++ b/src/ReactiveDomain.Testing/Specifications/NullListener.cs
@@ -36,6 +36,14 @@ public sealed class NullListener : IListener, ISubscriber {
 	/// <remarks>Ignored, as nothing here reports a position.</remarks>
 	public void SeedAllPosition(Position? position) { }
 
+	/// <inheritdoc cref="IListener.HoldDelivery"/>
+	/// <remarks>Holds nothing, as nothing is ever delivered.</remarks>
+	public IDisposable HoldDelivery() => new NoHold();
+
+	private sealed class NoHold : IDisposable {
+		public void Dispose() { }
+	}
+
 	/// <summary>
 	/// Gets the name of the stream.
 	/// </summary>


### PR DESCRIPTION
**What does this pull request do?**

Makes a read model's checkpoint mean what its docs claimed, and makes a snapshot restorable without losing or repeating an event.

- A checkpoint is recorded when an event is handed to the model's queue, not when it is received.
- `StreamCheckpoint.Version` is nullable, so a stream that has delivered nothing cannot checkpoint `0` — which resumed *after* event 0 and ate it.
- `CaptureConsistentState()` pairs state with checkpoints sampled at one cut. Capture refuses while a stream is still reading, and starting a stream refuses inside a capture window.
- `StreamCheckpoint.Compare` / `ReadModelState.Compare` order snapshots per stream, yielding `Equal` / `Before` / `After` / `Concurrent`.
- `Position` orders unsigned so `End` is not the minimum, and implements `IComparable<Position>`.
- `MockStreamStoreConnection.SubscribeToAllFrom` threw for every position but the start (a `master`-level bug, not separable from this stack — its semantics depend on the position stamping added in #277).
- `DirectApply` / `Publish` set `HasUnreplayableInput`; capture refuses rather than emit a snapshot that cannot be restored.
- CI logs `trx` and uploads it per-TFM.

**How does this pull request accomplish that goal?**

Every listener's delivery is held while checkpoints are sampled and a barrier is enqueued, so nothing can publish in between: everything sampled is already ahead of the barrier and nothing past it is. Reaching the barrier on the model's queue proves exactly the sampled events were applied. The hold spans two operations, not the wait.

`StreamListener` and `QueuedStreamListener` publish and record under one lock so no sample can catch a delivery between the two.

**Why is this pull request important?**

`GetCheckpoint()` ran ahead of applied state by the queue depth. Pairing it with model state in a snapshot resumed *past* the events still in flight, which were then never applied — reproduced here: checkpoint at version 2, zero events applied, three lost on restore.

**Link to any issues that this resolves**

Exact per-event checkpoints remain #211's remaining half; this establishes the cut instead. Subscription drop/retry is still #267.

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports
- [x] Any new code must be covered by at least one unit test
- [x] All public methods must be documented with XML comments

Fixes are mutation-tested: each is removed in turn and the test that covers it fails. Three are reasoned rather than demonstrated — the `_closing` flag, the redundant `StreamName` assignment, and the sentinel generation stamp — because their windows are a couple of statements wide.

Every positional assertion runs against a mock that stamps positions on every event; both wrappers only get them from `$all` reads. Worth one run with `LIVE_ES_CONNECTION` before anything depends on positions in production.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HY6dWaEdW9wMCKwe9rAwPK)_