### PR TITLE
0.17 follow-ups: ModelWentLive, barrier teardown pruning, SaveAndContinue, CI capacity floor

### DIFF
--- a/docs/0.17.0-migration.md
+++ b/docs/0.17.0-migration.md
@@ -1,8 +1,7 @@
 # 0.17.0 migration notes
 
-Draft for the release body. Two 0.17 changes alter behavior consumers may be relying on without
-knowing it; both were hit by an early adopter of `0.17.0-rc.1`. Everything else in 0.17 is
-additive.
+Two 0.17 changes alter behavior consumers may be relying on without knowing it. Everything else
+in 0.17 is additive.
 
 ## Command timeouts: the diagnostic thresholds no longer double as defaults (#270)
 

--- a/docs/0.17.0-migration.md
+++ b/docs/0.17.0-migration.md
@@ -1,8 +1,8 @@
 # 0.17.0 migration notes
 
 Draft for the release body. Two 0.17 changes alter behavior consumers may be relying on without
-knowing it; both were hit during PowerModels.Accounting's adoption of `0.17.0-rc.1`. Everything
-else in 0.17 is additive.
+knowing it; both were hit by an early adopter of `0.17.0-rc.1`. Everything else in 0.17 is
+additive.
 
 ## Command timeouts: the diagnostic thresholds no longer double as defaults (#270)
 

--- a/docs/0.17.0-migration.md
+++ b/docs/0.17.0-migration.md
@@ -1,0 +1,68 @@
+# 0.17.0 migration notes
+
+Draft for the release body. Two 0.17 changes alter behavior consumers may be relying on without
+knowing it; both were hit during PowerModels.Accounting's adoption of `0.17.0-rc.1`. Everything
+else in 0.17 is additive.
+
+## Command timeouts: the diagnostic thresholds no longer double as defaults (#270)
+
+Through 0.16, a send with no explicit timeout resolved its defaults from the *diagnostic*
+thresholds: `MultiQueuedPublisher.Execute` used `ackTimeout ?? slowMsgThreshold` and
+`responseTimeout ?? slowCmdThreshold`. A bus constructed with
+`new Dispatcher(name, slowCmdThreshold: TimeSpan.FromSeconds(5))` therefore had a 5-second
+default response timeout — without anyone having chosen one.
+
+In 0.17 the thresholds are diagnostics only (a slow command is logged, never failed), and an
+unbudgeted send falls to the hardcoded defaults: **100 ms ack / 500 ms response**. A consumer
+whose sends were living off the threshold conflation sees `CommandTimedOutException` on any
+command slower than 500 ms — under store latency this presents as widespread, deterministic
+failures.
+
+**Migration:** pass the new constructor parameters with the values the thresholds were silently
+providing:
+
+```csharp
+new Dispatcher(name,
+    slowMsgThreshold: TimeSpan.FromSeconds(5),   // diagnostic: log slow messages
+    slowCmdThreshold: TimeSpan.FromSeconds(5),   // diagnostic: log slow commands
+    defaultAckTimeout: TimeSpan.FromSeconds(5),      // timeout: fail unacked commands
+    defaultResponseTimeout: TimeSpan.FromSeconds(5)); // timeout: fail uncompleted commands
+```
+
+`CommandManager`, `MultiQueuedPublisher`, and `Dispatcher` all take the pair; both are also
+settable after construction (`AckTimeout` / `ResponseTimeout`), applying to commands registered
+from then on.
+
+## Test wait budgets: sized by capacity tier, not by `GITHUB_ACTIONS` (#276)
+
+Through 0.16, `TestTimeouts` keyed its budgets on the `GITHUB_ACTIONS` environment variable —
+CI got 5 s waits / 10 s command timeouts, everything else 500 ms. In 0.17 budgets come from
+`TestCapacityDetector`, which buckets the process by core count (under 4 cores Small: 5 s/10 s;
+4–7 Medium: 2 s/5 s; 8+ Large: 500 ms/500 ms), **floored at Small in a recognized CI
+environment** (`GITHUB_ACTIONS` or `CI` set to `true`/`1`) — a hosted runner's cores say nothing
+about noisy neighbours or suites whose waits price I/O rather than scheduling.
+
+What changes for a consumer:
+
+- **CI runners (any size):** Small-tier budgets — the same 5 s/10 s the 0.16 CI profile gave.
+- **Local machines with 4–7 cores:** budgets *widen* from 500 ms to 2 s/5 s.
+- **Local machines with 8+ cores:** 500 ms, as before.
+- **Containers and agent sandboxes with no CI variable:** budgets follow cores. A suite whose
+  waits are store-bound rather than scheduler-bound should pin the tier explicitly:
+  `REACTIVEDOMAIN_TEST_CAPACITY=Small`. The override wins over both cores and the CI floor, in
+  both directions, and `TestTimeouts.Budget` remains assignable per test project for full manual
+  control.
+
+`TestTimeouts.IsCi` remains and now means "the Small tier is in force"; the reason behind the
+detected tier is reported by `TestTimeouts.CapacityReason` and printed by
+`TestTimeouts.WriteCapacity(...)`, so a red run can state the budget it ran under.
+
+## Housekeeping noted during the RC
+
+- The release nuspecs' dependency floors and XML-doc references were corrected for the RC
+  (`6da468e`); the published `0.17.0-rc.1` packages carry the right floors.
+- The `.Debug` nuspec variants (`ReactiveDomain.Debug.nuspec`, `ReactiveDomain.Testing.Debug.nuspec`)
+  still declare an older dependency generation (EventStore.Client 21.x-era, net48/core-era floors)
+  and were not touched by the RC correction. If the debug-package flow is still in use, they need
+  the same sync before anyone packs from them; if not, deleting them removes the trap. Flagged for
+  a human call rather than changed here.

--- a/docs/0.17.0-migration.md
+++ b/docs/0.17.0-migration.md
@@ -56,13 +56,3 @@ What changes for a consumer:
 `TestTimeouts.IsCi` remains and now means "the Small tier is in force"; the reason behind the
 detected tier is reported by `TestTimeouts.CapacityReason` and printed by
 `TestTimeouts.WriteCapacity(...)`, so a red run can state the budget it ran under.
-
-## Housekeeping noted during the RC
-
-- The release nuspecs' dependency floors and XML-doc references were corrected for the RC
-  (`6da468e`); the published `0.17.0-rc.1` packages carry the right floors.
-- The `.Debug` nuspec variants (`ReactiveDomain.Debug.nuspec`, `ReactiveDomain.Testing.Debug.nuspec`)
-  still declare an older dependency generation (EventStore.Client 21.x-era, net48/core-era floors)
-  and were not touched by the RC correction. If the debug-package flow is still in use, they need
-  the same sync before anyone packs from them; if not, deleting them removes the trap. Flagged for
-  a human call rather than changed here.

--- a/src/ReactiveDomain.Foundation.Tests/when_capturing_a_consistent_snapshot.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_capturing_a_consistent_snapshot.cs
@@ -133,16 +133,17 @@ public sealed class when_capturing_a_consistent_snapshot : IDisposable {
 		// A bounded burst: the handler is slower than the writer, so captures meet a queue with events
 		// in it, but the queue still drains — an endless writer would outrun it and no cut would ever
 		// be reached, since a capture completes only when its marker does.
+		// The loop runs on queue depth, not the writer's lifetime: a fast writer can finish before the
+		// first capture while the slow handler still holds the deep queue the case needs.
 		var writer = Task.Run(() => Append(stream, 150));
 		var captures = 0;
-		while (!writer.IsCompleted) {
-			if (!AwaitQueueDepth(rm, writer)) { break; }
+		while (AwaitQueueDepth(rm, writer)) {
 			AssertSelfConsistent(await rm.CaptureConsistentState());
 			captures++;
 		}
 		await writer;
 		AssertSelfConsistent(await rm.CaptureConsistentState());
-		Assert.True(captures > 0, "no capture was taken while the writer was running");
+		Assert.True(captures > 0, "no capture met a non-empty queue");
 	}
 
 	[Fact]
@@ -193,8 +194,7 @@ public sealed class when_capturing_a_consistent_snapshot : IDisposable {
 
 		var writer = Task.Run(() => { for (var i = 0; i < 75; i++) { Append(first, 1); Append(second, 1); } });
 		var captures = 0;
-		while (!writer.IsCompleted) {
-			if (!AwaitQueueDepth(rm, writer)) { break; }
+		while (AwaitQueueDepth(rm, writer)) {
 			// Both streams at one cut: the state has to be the sum of the two prefixes, so a listener
 			// that kept delivering past the sample shows up here as a state ahead of its checkpoints.
 			AssertSelfConsistent(await rm.CaptureConsistentState());
@@ -202,7 +202,7 @@ public sealed class when_capturing_a_consistent_snapshot : IDisposable {
 		}
 		await writer;
 		AssertSelfConsistent(await rm.CaptureConsistentState());
-		Assert.True(captures > 0, "no capture was taken while the writer was running");
+		Assert.True(captures > 0, "no capture met a non-empty queue");
 	}
 
 	[Fact]

--- a/src/ReactiveDomain.Foundation.Tests/when_capturing_a_consistent_snapshot.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_capturing_a_consistent_snapshot.cs
@@ -128,22 +128,22 @@ public sealed class when_capturing_a_consistent_snapshot : IDisposable {
 		rm.Start(stream, null, true);
 		await rm.IsLive;
 
-		// Appending throughout, so the cut lands somewhere in the middle of delivery rather than at a
-		// quiet point chosen to suit it.
-		// A bounded burst: the handler is slower than the writer, so captures meet a queue with events
-		// in it, but the queue still drains — an endless writer would outrun it and no cut would ever
-		// be reached, since a capture completes only when its marker does.
-		// The loop runs on queue depth, not the writer's lifetime: a fast writer can finish before the
-		// first capture while the slow handler still holds the deep queue the case needs.
+		// The guaranteed cut: wedged, the burst piles into the queue, and the capture is requested
+		// against that provably non-empty queue — no race decides whether the case arises. Unwedging
+		// lets it drain with the writer still appending behind the marker, so the cut lands mid-delivery.
+		rm.Wedge();
 		var writer = Task.Run(() => Append(stream, 150));
-		var captures = 0;
+		AssertEx.IsOrBecomesTrue(() => rm.MessageCount > 0, TestTimeouts.ThrottleWaitFor);
+		var capturing = rm.CaptureConsistentState();
+		rm.Unwedge();
+		AssertSelfConsistent(await capturing);
+		// Opportunistic extra cuts while the burst drains — every one that meets a non-empty queue
+		// must also be self-consistent.
 		while (AwaitQueueDepth(rm, writer)) {
 			AssertSelfConsistent(await rm.CaptureConsistentState());
-			captures++;
 		}
 		await writer;
 		AssertSelfConsistent(await rm.CaptureConsistentState());
-		Assert.True(captures > 0, "no capture met a non-empty queue");
 	}
 
 	[Fact]
@@ -192,17 +192,20 @@ public sealed class when_capturing_a_consistent_snapshot : IDisposable {
 		rm.Start(second, null, true);
 		await rm.IsLive;
 
+		// Both streams at one cut: the state has to be the sum of the two prefixes, so a listener that
+		// kept delivering past the sample shows up as a state ahead of its checkpoints. The wedge makes
+		// the first cut guaranteed rather than raced — see the single-stream case above.
+		rm.Wedge();
 		var writer = Task.Run(() => { for (var i = 0; i < 75; i++) { Append(first, 1); Append(second, 1); } });
-		var captures = 0;
+		AssertEx.IsOrBecomesTrue(() => rm.MessageCount > 0, TestTimeouts.ThrottleWaitFor);
+		var capturing = rm.CaptureConsistentState();
+		rm.Unwedge();
+		AssertSelfConsistent(await capturing);
 		while (AwaitQueueDepth(rm, writer)) {
-			// Both streams at one cut: the state has to be the sum of the two prefixes, so a listener
-			// that kept delivering past the sample shows up here as a state ahead of its checkpoints.
 			AssertSelfConsistent(await rm.CaptureConsistentState());
-			captures++;
 		}
 		await writer;
 		AssertSelfConsistent(await rm.CaptureConsistentState());
-		Assert.True(captures > 0, "no capture met a non-empty queue");
 	}
 
 	[Fact]

--- a/src/ReactiveDomain.Foundation.Tests/when_using_catch_up_connection.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_catch_up_connection.cs
@@ -42,19 +42,59 @@ public sealed class when_using_catch_up_connection : IDisposable {
 	}
 
 	[Fact]
-	public void timeout_names_the_lagging_stream() {
+	public void timeout_names_the_busy_read_model() {
+		AppendEvents(1, 2);
+		using var gate = new ManualResetEventSlim(false);
+		using var rm = new SumReadModel(_catchUp, gate);
+		rm.StartAsync(_stream);
+		_catchUp.WaitForCatchUp(TestTimeouts.ThrottleWaitFor, rm);
+
+		// The gated value blocks the model's own queue thread, not delivery: the listener hands the
+		// event on and its checkpoint advances, so the deterministic laggard is the busy queue.
+		AppendEvents(1, GatedValue);
+		var ex = Assert.Throws<TimeoutException>(() =>
+			_catchUp.WaitForCatchUp(TimeSpan.FromMilliseconds(200), rm));
+		Assert.Contains($"queue {nameof(SumReadModel)}", ex.Message);
+
+		gate.Set();
+		_catchUp.WaitForCatchUp(TestTimeouts.ThrottleWaitFor, rm);
+		Assert.Equal(2 + GatedValue, rm.Sum);
+	}
+
+	[Fact]
+	public void disposed_listeners_do_not_pin_the_barrier() {
 		AppendEvents(1, 1);
-		var listener = _catchUp.GetListener("laggard");
+		var listener = _catchUp.GetListener("torn down");
 		listener.Start(_stream);
 		_catchUp.WaitForCatchUp(TestTimeouts.ThrottleWaitFor);
 
-		// a dead listener must read as a laggard, not as caught up
+		// A model deliberately torn down while the connection lives on (snapshot-restore and
+		// kill/resume flows) can never deliver again; the barrier must converge without it.
 		listener.Dispose();
 		AppendEvents(2, 1);
 
-		var ex = Assert.Throws<TimeoutException>(() => _catchUp.WaitForCatchUp(TimeSpan.FromMilliseconds(200)));
-		Assert.Contains(_stream, ex.Message);
-		Assert.Contains("delivered 0 of 2", ex.Message);
+		_catchUp.WaitForCatchUp(TestTimeouts.ThrottleWaitFor);
+	}
+
+	[Fact]
+	public void the_barrier_delivers_the_went_live_marker() {
+		AppendEvents(3, 1);
+		using var rm = new SumReadModel(_catchUp);
+		rm.StartAsync(_stream);
+
+		_catchUp.WaitForCatchUp(TestTimeouts.ThrottleWaitFor, rm);
+		Assert.True(rm.SawWentLive, "The barrier's queue drain includes the ModelWentLive it enqueues.");
+	}
+
+	[Fact]
+	public void signal_when_live_delivers_the_went_live_marker() {
+		AppendEvents(3, 1);
+		using var rm = new SumReadModel(_catchUp);
+		rm.StartAsync(_stream);
+		rm.SignalWhenLive();
+
+		AssertEx.IsOrBecomesTrue(() => rm.SawWentLive, TestTimeouts.ThrottleWaitFor);
+		Assert.Equal(3, rm.Sum); // the marker runs behind the history the arming waited for
 	}
 
 	[Fact]
@@ -75,19 +115,33 @@ public sealed class when_using_catch_up_connection : IDisposable {
 
 	public record CatchUpTestEvent(int Value) : Event;
 
+	private const int GatedValue = 999;
+
 	private sealed class SumReadModel :
 		ReadModelBase,
-		IHandle<CatchUpTestEvent> {
+		IHandle<CatchUpTestEvent>,
+		IHandle<ModelWentLive> {
+		private readonly ManualResetEventSlim? _gate;
 		public long Sum { get; private set; }
+		public bool SawWentLive { get; private set; }
 
-		public SumReadModel(IConfiguredConnection connection)
+		public SumReadModel(IConfiguredConnection connection, ManualResetEventSlim? gate = null)
 			: base(nameof(SumReadModel), connection) {
-			// ReSharper disable once RedundantTypeArgumentsOfMethod
+			_gate = gate;
+			// ReSharper disable RedundantTypeArgumentsOfMethod
 			EventStream.Subscribe<CatchUpTestEvent>(this);
+			EventStream.Subscribe<ModelWentLive>(this);
+			// ReSharper restore RedundantTypeArgumentsOfMethod
 		}
 
 		void IHandle<CatchUpTestEvent>.Handle(CatchUpTestEvent @event) {
+			if (@event.Value == GatedValue)
+				_gate?.Wait();
 			Sum += @event.Value;
+		}
+
+		void IHandle<ModelWentLive>.Handle(ModelWentLive _) {
+			SawWentLive = true;
 		}
 	}
 }

--- a/src/ReactiveDomain.Foundation.Tests/when_using_correlated_repository.cs
+++ b/src/ReactiveDomain.Foundation.Tests/when_using_correlated_repository.cs
@@ -9,11 +9,16 @@ namespace ReactiveDomain.Foundation.Tests;
 public sealed class when_using_correlated_repository {
 	private readonly CorrelatedStreamStoreRepository _correlatedRepo;
 	private readonly Guid _accountId = Guid.NewGuid();
+	private readonly MockStreamStoreConnection _mockStore;
+	private readonly JsonMessageSerializer _serializer = new();
+	private readonly string _streamName;
 
 	public when_using_correlated_repository() {
-		var mockStore = new MockStreamStoreConnection("testRepo");
-		mockStore.Connect();
-		var repo = new StreamStoreRepository(new PrefixedCamelCaseStreamNameBuilder(), mockStore, new JsonMessageSerializer());
+		_mockStore = new MockStreamStoreConnection("testRepo");
+		_mockStore.Connect();
+		var namer = new PrefixedCamelCaseStreamNameBuilder();
+		_streamName = namer.GenerateForAggregate(typeof(Account), _accountId);
+		var repo = new StreamStoreRepository(namer, _mockStore, _serializer);
 		_correlatedRepo = new CorrelatedStreamStoreRepository(repo);
 		var source = MessageBuilder.New(() => new CreateAccount(_accountId));
 		var account = new Account(_accountId, source);
@@ -153,6 +158,42 @@ public sealed class when_using_correlated_repository {
 		Assert.NotNull(retrievedAccount2);
 		Assert.Equal(_accountId, retrievedAccount2.Id);
 		Assert.Equal(101, retrievedAccount.Balance);
+	}
+
+	[Fact]
+	public void save_ends_the_unit_of_work() {
+		var source = MessageBuilder.New(() => new CreditAccount(_accountId, 50));
+		var account = _correlatedRepo.GetById<Account>(_accountId, source);
+		account.Credit(50);
+		_correlatedRepo.Save(account);
+
+		Assert.Throws<InvalidOperationException>(() => account.Credit(1));
+	}
+
+	[Fact]
+	public void save_and_continue_keeps_the_source_armed() {
+		var source = MessageBuilder.New(() => new CreditAccount(_accountId, 50));
+		var account = _correlatedRepo.GetById<Account>(_accountId, source);
+		account.Credit(50);
+		_correlatedRepo.SaveAndContinue(account);
+
+		// The held instance keeps raising in the same unit of work, and every persisted event —
+		// before and after the intermediate save — carries the one command's correlation and causation.
+		account.Credit(49);
+		_correlatedRepo.Save(account);
+
+		Assert.Equal(150, _correlatedRepo.GetById<Account>(_accountId, source).Balance);
+		var slice = _mockStore.ReadStreamForward(_streamName, 4, 2);
+		foreach (var recorded in slice.Events) {
+			var evt = Assert.IsAssignableFrom<ICorrelatedMessage>(_serializer.Deserialize(recorded));
+			Assert.Equal(source.MsgId, evt.CausationId);
+			Assert.Equal(source.CorrelationId, evt.CorrelationId);
+		}
+
+		// The final save cleared the source as usual, and a fresh retrieval re-arms it.
+		Assert.Throws<InvalidOperationException>(() => account.Credit(1));
+		var next = MessageBuilder.New(() => new CreditAccount(_accountId, 1));
+		_correlatedRepo.GetById<Account>(_accountId, next).Credit(1);
 	}
 
 	[Fact]

--- a/src/ReactiveDomain.Foundation/CatchUpConnection.cs
+++ b/src/ReactiveDomain.Foundation/CatchUpConnection.cs
@@ -80,6 +80,12 @@ public sealed class CatchUpConnection(IConfiguredConnection inner) : IConfigured
 			throw new TimeoutException("A read model faulted or was disposed before going live.", ex);
 		}
 
+		// Queryability includes the go-live cache flushes that ride ModelWentLive. An armed model's
+		// marker is a task-pool continuation off IsLive and can lose the race to the idle check
+		// below, so enqueue one here — behind the histories the wait just proved delivered, and
+		// idempotent by the marker's contract when the armed one also lands.
+		foreach (var rm in readModels) { rm.Handle(new ModelWentLive()); }
+
 		// What remains is the residue IsLive does not span: events committed after the read phase,
 		// and listeners started outside any read model. Those have no in-band completion signal, so
 		// this part stays a poll.
@@ -97,7 +103,14 @@ public sealed class CatchUpConnection(IConfiguredConnection inner) : IConfigured
 	private List<string> ListLaggards(ReadModelBase[] readModels) {
 		var laggards = new List<string>();
 		IListener[] tracked;
-		lock (_tracked) { tracked = _tracked.ToArray(); }
+		lock (_tracked) {
+			// A disposed listener can never deliver again; keeping it would pin the barrier below a
+			// moving stream tail whenever a model is deliberately torn down while the connection
+			// lives on — snapshot-restore and kill/resume flows do exactly that. A subscription that
+			// merely drops leaves its listener undisposed, so that failure still reads as a laggard.
+			_tracked.RemoveAll(static listener => listener.IsDisposed);
+			tracked = _tracked.ToArray();
+		}
 		foreach (var listener in tracked) {
 			// A checkpoint arrives with the stream name, so an unnamed listener has not started.
 			if (listener.Checkpoint is not { } checkpoint) { continue; }

--- a/src/ReactiveDomain.Foundation/Domain/AggregateRoot.cs
+++ b/src/ReactiveDomain.Foundation/Domain/AggregateRoot.cs
@@ -43,9 +43,18 @@ public abstract class AggregateRoot : EventDrivenStateMachine, ICorrelatedEventS
 				"Cannot take events without valid source.");
 		}
 	}
+
+	// One-shot: set by the repository's intermediate save immediately before the take it covers,
+	// so the source survives exactly that save and the safe-by-default clearing returns after.
+	private bool _continueSource;
+	internal void ContinueSourceThroughNextTake() => _continueSource = true;
+
 	protected override void TakeEventsCompleted() {
-		_correlationId = Guid.Empty;
-		_causationId = Guid.Empty;
+		if (!_continueSource) {
+			_correlationId = Guid.Empty;
+			_causationId = Guid.Empty;
+		}
+		_continueSource = false;
 		base.TakeEventsCompleted();
 	}
 	protected override void OnEventRaised(object @event) {

--- a/src/ReactiveDomain.Foundation/ICorrelatedRepository.cs
+++ b/src/ReactiveDomain.Foundation/ICorrelatedRepository.cs
@@ -9,6 +9,21 @@ public interface ICorrelatedRepository {
 	TAggregate GetById<TAggregate>(Guid id, ICorrelatedMessage source) where TAggregate : AggregateRoot, IEventSource;
 	TAggregate GetById<TAggregate>(Guid id, int version, ICorrelatedMessage source) where TAggregate : AggregateRoot, IEventSource;
 	void Save(IEventSource aggregate);
+
+	/// <summary>
+	/// Persists the recorded events and leaves the aggregate armed with the same source — the
+	/// intermediate save for a handler that writes durable state and keeps raising in one unit of work.
+	/// </summary>
+	/// <remarks>
+	/// <para><see cref="Save(IEventSource)"/> ends the unit of work: it clears the source, so a later
+	/// raise on the held instance throws. Use this instead for every write of a multi-write handler
+	/// except the last — the events of all of them carry the one command's correlation and causation.</para>
+	/// <para>A subsequent <c>GetById</c> re-arms the instance for its own source either way, so
+	/// cached-instance reuse across commands is unaffected.</para>
+	/// </remarks>
+	/// <param name="aggregate">The aggregate whose recorded events to persist.</param>
+	void SaveAndContinue(IEventSource aggregate);
+
 	void Delete(IEventSource aggregate);
 	void HardDelete(IEventSource aggregate);
 }

--- a/src/ReactiveDomain.Foundation/IListener.cs
+++ b/src/ReactiveDomain.Foundation/IListener.cs
@@ -40,6 +40,9 @@ public interface IListener : IDisposable {
 	/// </summary>
 	void SeedAllPosition(Position? position);
 
+	/// <summary>Whether this listener has been disposed; a disposed listener delivers nothing further.</summary>
+	bool IsDisposed { get; }
+
 	/// <summary>
 	/// Holds this listener's delivery, so that nothing is published to <see cref="EventStream"/> and
 	/// <see cref="Checkpoint"/> cannot move, until the returned handle is disposed.

--- a/src/ReactiveDomain.Foundation/ModelWentLive.cs
+++ b/src/ReactiveDomain.Foundation/ModelWentLive.cs
@@ -1,0 +1,48 @@
+using ReactiveDomain.Messaging;
+
+namespace ReactiveDomain.Foundation;
+
+/// <summary>
+/// The in-band signal that every source a read model started — own streams and relays alike — has
+/// handed over its history. Handlers flush catch-up caches and publish live state here.
+/// </summary>
+/// <remarks>
+/// Enqueued on the model's own queue when <see cref="ReadModelBase.IsLive"/> completes (see
+/// <see cref="ModelWentLiveArming.SignalWhenLive"/>), so the handler runs behind everything those
+/// histories delivered. Handling is idempotent by contract: the arming continuation and
+/// <see cref="CatchUpConnection.WaitForCatchUp"/> may each enqueue one. A test over a null
+/// connection applies it directly (<see cref="ReadModelBase.DirectApply"/>) to declare liveness at
+/// a chosen point.
+/// </remarks>
+public sealed record ModelWentLive : IMessage {
+	/// <inheritdoc cref="IMessage.MsgId"/>
+	public Guid MsgId { get; } = Guid.NewGuid();
+}
+
+/// <summary>Arms a read model to receive <see cref="ModelWentLive"/> when it goes live.</summary>
+public static class ModelWentLiveArming {
+	/// <summary>
+	/// Enqueues <see cref="ModelWentLive"/> onto <paramref name="model"/>'s queue once every started
+	/// source has handed over its history. Call at every composition site, after the model's last
+	/// <c>Start</c> call — a model whose site forgets this never flushes its catch-up caches.
+	/// </summary>
+	/// <remarks>
+	/// <para>Arm after the last <c>Start</c>: <see cref="ReadModelBase.IsLive"/> spans the streams
+	/// started so far, so a marker armed earlier fires ahead of the histories it is meant to trail.
+	/// Armed by the composition, not the model's constructor, so a test fixture over a null
+	/// connection keeps deterministic control: a null read drains instantly, and a
+	/// constructor-armed marker would race the fixture's own <see cref="ReadModelBase.DirectApply"/>
+	/// calls.</para>
+	/// <para>A continuation rather than an await because the flush must run on the model's queue
+	/// thread under its reader lock; the marker gets it there. A faulted source faults
+	/// <see cref="ReadModelBase.IsLive"/> and no marker is sent — the caches stay visibly unflushed
+	/// rather than flushing over a model missing history.</para>
+	/// </remarks>
+	/// <param name="model">The read model to arm; its composition site owns this call.</param>
+	public static void SignalWhenLive(this ReadModelBase model) =>
+		model.IsLive.ContinueWith(
+			_ => model.Handle(new ModelWentLive()),
+			CancellationToken.None,
+			TaskContinuationOptions.OnlyOnRanToCompletion,
+			TaskScheduler.Default);
+}

--- a/src/ReactiveDomain.Foundation/StreamStore/CorrelatedStreamStoreRepository.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/CorrelatedStreamStoreRepository.cs
@@ -66,6 +66,14 @@ public class CorrelatedStreamStoreRepository : ICorrelatedRepository, IDisposabl
 		}
 	}
 
+	/// <inheritdoc cref="ICorrelatedRepository.SaveAndContinue"/>
+	public void SaveAndContinue(IEventSource aggregate) {
+		// An uncorrelated event source has no source to preserve; the plain save is exactly equivalent.
+		if (aggregate is AggregateRoot root)
+			root.ContinueSourceThroughNextTake();
+		Save(aggregate);
+	}
+
 	/// <summary>
 	/// Soft delete the aggregate. Its stream can be re-created by appending new events.
 	/// </summary>

--- a/src/ReactiveDomain.Foundation/StreamStore/StreamListener.cs
+++ b/src/ReactiveDomain.Foundation/StreamStore/StreamListener.cs
@@ -337,7 +337,11 @@ public class StreamListener : IListener {
 
 	#region Implementation of IDisposable
 
-	private bool _disposed;
+	private volatile bool _disposed;
+
+	/// <inheritdoc cref="IListener.IsDisposed"/>
+	public bool IsDisposed => _disposed;
+
 	public void Dispose() {
 		Dispose(true);
 		GC.SuppressFinalize(this);

--- a/src/ReactiveDomain.Testing.Tests/TestCapacityDetectorTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/TestCapacityDetectorTests.cs
@@ -67,12 +67,41 @@ public sealed class TestCapacityDetectorTests {
 		Assert.Equal(TestCapacity.Small, TestCapacityDetector.Detect(2, Override(value)).Capacity);
 	}
 
-	/// <summary>Naming a CI system is what this replaced: a large runner is not small for being CI.</summary>
-	[Fact]
-	public void a_ci_variable_alone_does_not_shrink_the_bucket() {
-		var (capacity, _, _) = TestCapacityDetector.Detect(64, Env(("GITHUB_ACTIONS", "true"), ("CI", "true")));
+	/// <summary>The direction that must never regress: CI cannot silently drop to narrower budgets
+	/// for having cores — a hosted runner's cores say nothing about noisy neighbours or I/O-bound
+	/// waits. (Deliberate reversal, Chris 2026-08-07: the cores-only shape shipped in the RC and cost
+	/// a downstream suite exactly this way.)</summary>
+	[Theory]
+	[InlineData("GITHUB_ACTIONS", "true")]
+	[InlineData("GITHUB_ACTIONS", "TRUE")]
+	[InlineData("CI", "true")]
+	[InlineData("CI", "1")]
+	public void a_ci_environment_floors_the_bucket_at_small(string variable, string value) {
+		var (capacity, cores, reason) = TestCapacityDetector.Detect(64, Env((variable, value)));
 
-		Assert.Equal(TestCapacity.Large, capacity);
+		Assert.Equal(TestCapacity.Small, capacity);
+		Assert.Equal(64, cores);
+		Assert.Contains(variable, reason);
+		Assert.Contains(TestCapacityDetector.OverrideEnvironmentVariable, reason);
+	}
+
+	[Fact]
+	public void the_override_wins_over_the_ci_floor_in_both_directions() {
+		var ciAndOverride = Env(("GITHUB_ACTIONS", "true"),
+			(TestCapacityDetector.OverrideEnvironmentVariable, "Large"));
+
+		Assert.Equal(TestCapacity.Large, TestCapacityDetector.Detect(2, ciAndOverride).Capacity);
+		Assert.Equal(TestCapacity.Large, TestCapacityDetector.Detect(64, ciAndOverride).Capacity);
+	}
+
+	/// <summary>Only an affirmative value marks CI; a variable that exists but says no is not one.</summary>
+	[Theory]
+	[InlineData("false")]
+	[InlineData("0")]
+	[InlineData("")]
+	public void a_non_affirmative_ci_value_leaves_the_cores_in_charge(string value) {
+		Assert.Equal(TestCapacity.Large,
+			TestCapacityDetector.Detect(64, Env(("GITHUB_ACTIONS", value), ("CI", value))).Capacity);
 	}
 
 	[Fact]

--- a/src/ReactiveDomain.Testing.Tests/TestCapacityDetectorTests.cs
+++ b/src/ReactiveDomain.Testing.Tests/TestCapacityDetectorTests.cs
@@ -69,8 +69,7 @@ public sealed class TestCapacityDetectorTests {
 
 	/// <summary>The direction that must never regress: CI cannot silently drop to narrower budgets
 	/// for having cores — a hosted runner's cores say nothing about noisy neighbours or I/O-bound
-	/// waits. (Deliberate reversal, Chris 2026-08-07: the cores-only shape shipped in the RC and cost
-	/// a downstream suite exactly this way.)</summary>
+	/// waits.</summary>
 	[Theory]
 	[InlineData("GITHUB_ACTIONS", "true")]
 	[InlineData("GITHUB_ACTIONS", "TRUE")]

--- a/src/ReactiveDomain.Testing/Specifications/NullListener.cs
+++ b/src/ReactiveDomain.Testing/Specifications/NullListener.cs
@@ -57,10 +57,15 @@ public sealed class NullListener : IListener, ISubscriber {
 		Name = name;
 	}
 
+	/// <inheritdoc cref="IListener.IsDisposed"/>
+	public bool IsDisposed { get; private set; }
+
 	/// <summary>
 	/// Cleans up resources.
 	/// </summary>
-	public void Dispose() { }
+	public void Dispose() {
+		IsDisposed = true;
+	}
 
 	/// <summary>
 	/// Starts the listener at the requested checkpoint. Since the listener is not connected to anything,

--- a/src/ReactiveDomain.Testing/Specifications/NullRepository.cs
+++ b/src/ReactiveDomain.Testing/Specifications/NullRepository.cs
@@ -52,6 +52,12 @@ public class NullRepository : ICorrelatedRepository, IRepository {
 	/// <summary>
 	/// Does nothing. Required for implementation of <see cref="ICorrelatedRepository"/>.
 	/// </summary>
+	/// <param name="aggregate">This parameter is ignored.</param>
+	public void SaveAndContinue(IEventSource aggregate) { }
+
+	/// <summary>
+	/// Does nothing. Required for implementation of <see cref="ICorrelatedRepository"/>.
+	/// </summary>
 	/// <typeparam name="TAggregate">This type parameter is ignored.</typeparam>
 	/// <param name="id">This parameter is ignored.</param>
 	/// <param name="aggregate">Output parameter for the retrieved aggregate.</param>

--- a/src/ReactiveDomain.Testing/TestCapacityDetector.cs
+++ b/src/ReactiveDomain.Testing/TestCapacityDetector.cs
@@ -1,21 +1,32 @@
 namespace ReactiveDomain.Testing;
 
 /// <summary>
-/// Buckets a test process by the cores available to it, and reports what it decided on.
+/// Buckets a test process by the cores available to it, floored at <see cref="TestCapacity.Small"/>
+/// on a recognized CI environment, and reports what it decided on.
 /// </summary>
 /// <remarks>
-/// Cores are the signal because cores are the cause: a wait that expires early did so because the
-/// machine could not schedule the work in time. Naming CI providers answered that by proxy, and
-/// answered it wrong for everything off the list — a capped container, a self-hosted runner, an old
-/// laptop. <see cref="Environment.ProcessorCount"/> already reflects a container's CPU cap.
+/// <para>Cores are the primary signal because cores are the usual cause: a wait that expires early
+/// did so because the machine could not schedule the work in time.
+/// <see cref="Environment.ProcessorCount"/> already reflects a container's CPU cap.</para>
+/// <para>CI is the exception cores cannot see: a hosted runner's cores say nothing about noisy
+/// neighbours, cold caches, or suites whose waits price I/O rather than scheduling — so a
+/// recognized CI variable keeps the widest budgets regardless of core count, and
+/// <see cref="OverrideEnvironmentVariable"/> is the escape hatch in both directions.</para>
 /// </remarks>
 public static class TestCapacityDetector {
 	/// <summary>
-	/// Forces a bucket regardless of cores, for when the core count is not the whole story — a
+	/// Forces a bucket regardless of cores or CI, for when neither is the whole story — a
 	/// many-core machine running several test jobs at once has the cores but not the capacity.
 	/// Recognized values are the <see cref="TestCapacity"/> names, case-insensitively.
 	/// </summary>
 	public const string OverrideEnvironmentVariable = "REACTIVEDOMAIN_TEST_CAPACITY";
+
+	/// <summary>
+	/// The variables whose value <c>true</c> or <c>1</c> marks a CI environment: <c>GITHUB_ACTIONS</c>,
+	/// and the generic <c>CI</c> most providers set. A CI system off this list sets
+	/// <see cref="OverrideEnvironmentVariable"/> instead.
+	/// </summary>
+	public static readonly IReadOnlyList<string> CiEnvironmentVariables = ["GITHUB_ACTIONS", "CI"];
 
 	/// <summary>Default lower bound for <see cref="TestCapacity.Large"/>.</summary>
 	public const int LargeCores = 8;
@@ -51,6 +62,15 @@ public static class TestCapacityDetector {
 					return (capacity, cores, $"{OverrideEnvironmentVariable}={capacity} (explicit override)");
 			}
 			// Unrecognized: fall through to the cores rather than honour a default nobody asked for.
+		}
+
+		foreach (var variable in CiEnvironmentVariables) {
+			var value = getEnvironmentVariable(variable);
+			if (string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) || value == "1") {
+				return (TestCapacity.Small, cores,
+					$"{variable}={value}: CI floors the bucket at {TestCapacity.Small} over {cores} cores " +
+					$"({OverrideEnvironmentVariable} overrides)");
+			}
 		}
 
 		if (cores >= LargeCores)


### PR DESCRIPTION
**What does this pull request do?**

Four follow-ups for the 0.17 release line, each closing a gap an early adopter of `0.17.0-rc.1` hit:

1. **`ModelWentLive` + `SignalWhenLive`** (`ReactiveDomain.Foundation`) — the in-band signal that every source a read model started, own streams and relays alike, has handed over its history. Handlers flush catch-up caches and publish live state on it, instead of hand-counting live transitions per source.
2. **`CatchUpConnection` hardening** — the barrier enqueues the `ModelWentLive` marker per read model after its IsLive wait (so post-barrier queryability includes the go-live cache flushes), and prunes disposed listeners so a model deliberately torn down while the connection lives on (snapshot-restore, kill/resume flows) cannot pin the barrier below a moving stream tail forever. `IListener` gains `IsDisposed` to support the pruning. Note one deliberate semantics revision: an explicitly disposed listener no longer reads as a laggard — a *dropped* subscription leaves its listener undisposed and still does.
3. **`ICorrelatedRepository.SaveAndContinue`** — the intermediate save for multi-write handlers. `Save` ends the unit of work (the take clears the source), which forces a handler that records durable intermediate state and keeps raising — the write-ahead-plan shape — to re-fetch before every later write. `SaveAndContinue` persists exactly as `Save` does but carries the same source through the take, correlation and causation preserved verbatim; plain `Save` keeps its safe-by-default clearing.
4. **`TestCapacityDetector` CI floor** — a recognized CI environment floors the capacity bucket at Small, so a many-core runner no longer silently under-budgets store-bound waits. Plus the draft 0.17.0 migration notes (`docs/0.17.0-migration.md`) covering the two behavior changes consumers can hit unknowingly.

**How does this pull request accomplish that goal?**

- The marker is armed by `SignalWhenLive` as a continuation off `ReadModelBase.IsLive`, so it lands on the model's own queue behind everything those histories delivered; handling is idempotent by contract (the armed continuation and the barrier may each enqueue one). The docs carry the arming contract: arm after the model's last `Start`; a faulted source sends no marker.
- The barrier's pruning removes `IsDisposed` listeners inside the laggard scan, under the existing tracking lock; `StreamListener` implements the flag off its existing dispose state.
- `SaveAndContinue` sets a one-shot flag on `AggregateRoot` honored by `TakeEventsCompleted` — preserving the actual correlation/causation fields rather than resynthesizing a source, which would drift causation. `NullRepository` implements the new interface member as a no-op.

**Why is this pull request important?**

All three Foundation changes remove workarounds consumers otherwise hand-roll: per-source go-live counting, teardown-safe barriers, and the choice between a repeated re-fetch idiom or manually poking `Source` (which the correlated repository exists to make unnecessary). The capacity floor keeps CI test budgets honest on large runners.

**Link to any issues that this resolves**

Resolves #285. Also carries the evidence trail for #284 (closed as not planned — the measurement gate came back well under budget).

**Checklist**
- [x] All unit tests in the solution must pass on all versions of .NET that the solution supports — full suite green on net8.0 and net10.0 (891 × 2), `dotnet format --verify-no-changes` clean
- [x] Any new code must be covered by at least one unit test — marker delivery (armed and barrier-driven), disposed-listener pruning, busy-queue laggard timeout, `SaveAndContinue` source preservation and plain-`Save` clearing, capacity-floor pinning
- [x] All public methods must be documented with XML comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DckST6afDA3B2eduZ8BKck

---
_Generated by [Claude Code](https://claude.ai/code/session_01DckST6afDA3B2eduZ8BKck)_